### PR TITLE
Switch from marked.setOptions+Renderer to marked.use() for code highl…

### DIFF
--- a/markdown-viewer/app.js
+++ b/markdown-viewer/app.js
@@ -163,26 +163,25 @@ function handleFile(file) {
 // ===========================
 function configureMarked() {
     // Configure marked with custom renderer for syntax highlighting
-    // Note: marked v11 removed the top-level `highlight` option;
-    // use a custom renderer with positional args (v11 API) instead.
-    const renderer = new marked.Renderer();
-    renderer.code = function(code, lang) {
-        if (lang && hljs.getLanguage(lang)) {
-            try {
-                const highlighted = hljs.highlight(code, { language: lang }).value;
-                return `<pre><code class="hljs language-${lang}">${highlighted}</code></pre>`;
-            } catch (err) {
-                console.error('Highlight error:', err);
-            }
-        }
-        const escaped = code.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-        return `<pre><code class="language-${lang || ''}">${escaped}</code></pre>`;
-    };
-
-    marked.setOptions({
+    // Use marked.use() which properly integrates overrides without
+    // replacing the entire renderer instance.
+    marked.use({
         breaks: true,
         gfm: true,
-        renderer: renderer
+        renderer: {
+            code(code, lang) {
+                if (lang && hljs.getLanguage(lang)) {
+                    try {
+                        const highlighted = hljs.highlight(code, { language: lang }).value;
+                        return `<pre><code class="hljs language-${lang}">${highlighted}</code></pre>`;
+                    } catch (err) {
+                        console.error('Highlight error:', err);
+                    }
+                }
+                const escaped = code.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+                return `<pre><code class="language-${lang || ''}">${escaped}</code></pre>`;
+            }
+        }
     });
 }
 

--- a/tests/integration/markdown.test.js
+++ b/tests/integration/markdown.test.js
@@ -18,22 +18,22 @@ describe('Markdown Rendering', () => {
     it('should configure marked with GFM enabled', () => {
       configureMarked();
 
-      expect(marked.setOptions).toHaveBeenCalled();
-      const config = marked.setOptions.mock.calls[0][0];
+      expect(marked.use).toHaveBeenCalled();
+      const config = marked.use.mock.calls[0][0];
       expect(config.gfm).toBe(true);
     });
 
     it('should enable line breaks', () => {
       configureMarked();
 
-      const config = marked.setOptions.mock.calls[0][0];
+      const config = marked.use.mock.calls[0][0];
       expect(config.breaks).toBe(true);
     });
 
     it('should configure a custom renderer for syntax highlighting', () => {
       configureMarked();
 
-      const config = marked.setOptions.mock.calls[0][0];
+      const config = marked.use.mock.calls[0][0];
       expect(config.renderer).toBeDefined();
       expect(typeof config.renderer.code).toBe('function');
     });
@@ -133,7 +133,7 @@ describe('Markdown Rendering', () => {
     it('should highlight code blocks via renderer.code', () => {
       configureMarked();
 
-      const config = marked.setOptions.mock.calls[0][0];
+      const config = marked.use.mock.calls[0][0];
       const codeRenderer = config.renderer.code;
 
       codeRenderer('console.log("test")', 'javascript');
@@ -146,7 +146,7 @@ describe('Markdown Rendering', () => {
     it('should handle highlight errors gracefully', () => {
       configureMarked();
 
-      const config = marked.setOptions.mock.calls[0][0];
+      const config = marked.use.mock.calls[0][0];
       const codeRenderer = config.renderer.code;
 
       hljs.highlight.mockImplementation(() => {
@@ -163,7 +163,7 @@ describe('Markdown Rendering', () => {
     it('should return escaped code for unknown languages', () => {
       configureMarked();
 
-      const config = marked.setOptions.mock.calls[0][0];
+      const config = marked.use.mock.calls[0][0];
       const codeRenderer = config.renderer.code;
 
       // Mock getLanguage to return undefined for unknown language


### PR DESCRIPTION
…ighting

Replace `new marked.Renderer()` + `marked.setOptions({ renderer })` with `marked.use({ renderer: { code() {...} } })` which is the recommended marked v11 API. The `use()` method properly integrates renderer overrides into the existing parser pipeline rather than replacing the entire renderer instance, avoiding potential wiring issues between the renderer and parser internals.

https://claude.ai/code/session_01TPgAHySfL2wgHJ7HntaW6i