### PR TITLE
Add defensive guards in code renderer to prevent runtime crashes

### DIFF
--- a/markdown-viewer/app.js
+++ b/markdown-viewer/app.js
@@ -170,7 +170,9 @@ function configureMarked() {
         gfm: true,
         renderer: {
             code(code, lang) {
-                if (lang && hljs.getLanguage(lang)) {
+                // Guard against non-string code or missing hljs
+                if (typeof code !== 'string') return false;
+                if (lang && typeof hljs !== 'undefined' && hljs.getLanguage(lang)) {
                     try {
                         const highlighted = hljs.highlight(code, { language: lang }).value;
                         return `<pre><code class="hljs language-${lang}">${highlighted}</code></pre>`;


### PR DESCRIPTION
- Guard against code parameter being non-string (return false to fall back to default renderer)
- Guard against hljs being undefined with typeof check, preventing ReferenceError if highlight.js CDN fails to load

The original code never invoked hljs during marked.parse() (the highlight option was silently ignored in v11), but the custom renderer calls hljs.getLanguage() which throws if hljs isn't loaded.

https://claude.ai/code/session_01TPgAHySfL2wgHJ7HntaW6i