### PR TITLE
Fix fragile eval-based test helper and improve handleDragLeave robust…

### DIFF
--- a/markdown-viewer/app.js
+++ b/markdown-viewer/app.js
@@ -116,7 +116,7 @@ function handleDragOver(e) {
 function handleDragLeave(e) {
     e.preventDefault();
     e.stopPropagation();
-    if (e.target === dropZone) {
+    if (!dropZone.contains(e.relatedTarget)) {
         dropZone.classList.remove('drag-over');
     }
 }


### PR DESCRIPTION
…ness

Replace loadApp's direct eval with indirect eval (0, eval)() to execute app.js at global scope, eliminating the fragile "global.$1 = function" regex transformations. Now only converts let/const to var for global property exposure—function declarations naturally become global.

Fix handleDragLeave to use dropZone.contains(e.relatedTarget) instead of e.target === dropZone, which correctly handles drag events from child elements.

https://claude.ai/code/session_0197PQQUJNstH67dmRknFMVH