### PR TITLE
Automate version syncing: single source of truth in package.json

### DIFF
--- a/markdown-viewer/app.js
+++ b/markdown-viewer/app.js
@@ -3,7 +3,7 @@
 // ===========================
 const VALID_EXTENSIONS = ['.md', '.markdown'];
 const FONT_FAMILY = '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif';
-const APP_VERSION = '0.025';
+const APP_VERSION = '0.0.25';
 const APP_VERSION_LABEL = 'alpha';
 const SOURCE_REPO = 'cbremer/markdown-viewer';
 const SOURCE_REPO_URL = 'https://github.com/' + SOURCE_REPO;
@@ -31,11 +31,22 @@ const fullscreenOverlay = document.getElementById('fullscreen-overlay');
 // Initialization
 // ===========================
 function init() {
+    setupVersionInfo();
     setupTheme();
     setupEventListeners();
     configureMermaid();
     configureMarked();
     checkForUpdates();
+}
+
+// ===========================
+// Version Info
+// ===========================
+function setupVersionInfo() {
+    var versionLabel = document.getElementById('version-label');
+    if (versionLabel) {
+        versionLabel.textContent = 'v' + APP_VERSION + ' (' + APP_VERSION_LABEL + ')';
+    }
 }
 
 // ===========================

--- a/markdown-viewer/index.html
+++ b/markdown-viewer/index.html
@@ -26,7 +26,7 @@
             <div class="header-left">
                 <h1>Markdown Diagram Viewer</h1>
                 <div class="version-info">
-                    <span id="version-label" class="version-label">v0.025 (alpha)</span>
+                    <span id="version-label" class="version-label"></span>
                     <span id="version-update" class="version-update" style="display: none;"></span>
                     <a id="source-link" class="source-link" href="https://github.com/cbremer/markdown-viewer" target="_blank" rel="noopener noreferrer">Source</a>
                 </div>

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test:unit": "jest tests/unit",
     "test:integration": "jest tests/integration",
     "test:verbose": "jest --verbose",
-    "test:ci": "jest --ci --coverage --maxWorkers=2"
+    "test:ci": "jest --ci --coverage --maxWorkers=2",
+    "version": "node scripts/sync-version.js && git add markdown-viewer/app.js"
   },
   "keywords": [
     "markdown",

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+/**
+ * Syncs the version from package.json into app.js (APP_VERSION constant).
+ *
+ * This runs automatically via the npm "version" lifecycle script, so
+ * bumping the version is a single command:
+ *
+ *   npm version 0.0.26
+ *   npm version patch
+ *   npm version minor
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const pkgPath = path.join(__dirname, '..', 'package.json');
+const appPath = path.join(__dirname, '..', 'markdown-viewer', 'app.js');
+
+const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+const version = pkg.version;
+
+let appCode = fs.readFileSync(appPath, 'utf8');
+
+const versionRegex = /^const APP_VERSION = '[^']*';/m;
+if (!versionRegex.test(appCode)) {
+    console.error('Could not find APP_VERSION constant in app.js');
+    process.exit(1);
+}
+
+appCode = appCode.replace(versionRegex, "const APP_VERSION = '" + version + "';");
+
+fs.writeFileSync(appPath, appCode, 'utf8');
+console.log('Synced version ' + version + ' into app.js');


### PR DESCRIPTION
- app.js now dynamically renders the version label on init via setupVersionInfo(), removing the hardcoded text from index.html
- Add scripts/sync-version.js to sync package.json version into the APP_VERSION constant in app.js
- Add npm "version" lifecycle hook so `npm version <ver>` automatically updates both package.json and app.js in one command

https://claude.ai/code/session_01AWr1AxShGRm36XC837x8Zd