### PR TITLE
Rebrand to SpecDown: A Markdown Viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,4 @@
-# AI utils & tools
-Simple utilities and apps made by Chris Bremer using AI
-
----
-
-## Markdown Diagram Viewer
+# SpecDown
 
 A lightweight, browser-based markdown viewer with enhanced diagram navigation capabilities. Perfect for viewing documentation with complex Mermaid diagrams that need zooming, panning, and detailed exploration.
 
@@ -84,7 +79,10 @@ markdown_viewer/
 └── markdown-viewer/            # Application directory
     ├── index.html              # Main application page
     ├── styles.css              # Application styles and theming
-    └── app.js                  # Core application logic
+    ├── app.js                  # Core application logic
+    ├── logo.svg                # SpecDown logo (light theme)
+    ├── logo-dark.svg           # SpecDown logo (dark theme)
+    └── favicon.svg             # Browser tab icon
 ```
 
 ### Technology Stack
@@ -290,4 +288,4 @@ For issues or questions:
 
 ---
 
-**Happy Diagram Viewing! 📊**
+**Happy Diagram Viewing with SpecDown! 📊**

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SpecDown
+# SpecDown: A Markdown Viewer
 
 A lightweight, browser-based markdown viewer with enhanced diagram navigation capabilities. Perfect for viewing documentation with complex Mermaid diagrams that need zooming, panning, and detailed exploration.
 

--- a/markdown-viewer/app.js
+++ b/markdown-viewer/app.js
@@ -5,7 +5,7 @@ const VALID_EXTENSIONS = ['.md', '.markdown'];
 const FONT_FAMILY = '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif';
 const APP_VERSION = '0.0.27';
 const APP_VERSION_LABEL = 'alpha';
-const SOURCE_REPO = 'cbremer/markdown-viewer';
+const SOURCE_REPO = 'cbremer/specdown';
 const SOURCE_REPO_URL = 'https://github.com/' + SOURCE_REPO;
 
 // ===========================

--- a/markdown-viewer/favicon.svg
+++ b/markdown-viewer/favicon.svg
@@ -1,0 +1,31 @@
+<svg width="256" height="256" viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="SpecDown app icon">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#00A3BF"/>
+      <stop offset="1" stop-color="#FF7A4D"/>
+    </linearGradient>
+    <linearGradient id="c" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#FFD36A"/>
+      <stop offset="1" stop-color="#FF7A00"/>
+    </linearGradient>
+  </defs>
+
+  <rect x="16" y="16" width="224" height="224" rx="44" fill="#0B1220"/>
+  <circle cx="128" cy="128" r="88" fill="none" stroke="url(#g)" stroke-width="14" opacity="0.95"/>
+
+  <path d="M128 56
+           C84 56, 60 92, 60 126
+           C60 172, 92 202, 128 214
+           C164 202, 196 172, 196 126
+           C196 92, 172 56, 128 56 Z"
+        fill="#0F1724"/>
+
+  <path d="M92 132 Q106 122 120 132" fill="none" stroke="#00D5FF" stroke-width="10" stroke-linecap="round" opacity="0.9"/>
+  <path d="M136 132 Q150 122 164 132" fill="none" stroke="#00D5FF" stroke-width="10" stroke-linecap="round" opacity="0.9"/>
+
+  <g transform="translate(128,96)">
+    <path d="M0 -20 L20 0 L0 20 L-20 0 Z" fill="url(#c)"/>
+    <path d="M0 -20 L20 0 L0 20 L-20 0 Z" fill="none" stroke="#FFFFFF" stroke-width="2" opacity="0.35"/>
+    <circle cx="0" cy="0" r="7" fill="#FFFFFF" opacity="0.30"/>
+  </g>
+</svg>

--- a/markdown-viewer/index.html
+++ b/markdown-viewer/index.html
@@ -3,9 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Markdown Diagram Viewer</title>
+    <title>SpecDown: A Markdown Viewer</title>
+    <link rel="icon" type="image/svg+xml" href="favicon.svg">
     <link rel="stylesheet" href="styles.css">
-    
+
     <!-- Local Dependencies -->
     <script src="vendor/marked.min.js"></script>
     <script src="vendor/mermaid.min.js"></script>
@@ -24,11 +25,14 @@
         <!-- Header -->
         <header class="app-header">
             <div class="header-left">
-                <h1>Markdown Diagram Viewer</h1>
+                <a href="." class="logo-link" title="SpecDown: A Markdown Viewer">
+                    <img src="logo.svg" alt="SpecDown" class="header-logo header-logo-light">
+                    <img src="logo-dark.svg" alt="SpecDown" class="header-logo header-logo-dark">
+                </a>
                 <div class="version-info">
                     <span id="version-label" class="version-label"></span>
                     <span id="version-update" class="version-update" style="display: none;"></span>
-                    <a id="source-link" class="source-link" href="https://github.com/cbremer/markdown-viewer" target="_blank" rel="noopener noreferrer">Source</a>
+                    <a id="source-link" class="source-link" href="https://github.com/cbremer/specdown" target="_blank" rel="noopener noreferrer">Source</a>
                 </div>
             </div>
             <div class="header-controls">

--- a/markdown-viewer/index.html
+++ b/markdown-viewer/index.html
@@ -29,6 +29,7 @@
                     <img src="logo.svg" alt="SpecDown" class="header-logo header-logo-light">
                     <img src="logo-dark.svg" alt="SpecDown" class="header-logo header-logo-dark">
                 </a>
+                <h1 style="position:absolute;left:-10000px;top:auto;width:1px;height:1px;overflow:hidden;">SpecDown: A Markdown Viewer</h1>
                 <div class="version-info">
                     <span id="version-label" class="version-label"></span>
                     <span id="version-update" class="version-update" style="display: none;"></span>

--- a/markdown-viewer/logo-dark.svg
+++ b/markdown-viewer/logo-dark.svg
@@ -1,0 +1,53 @@
+<svg width="520" height="140" viewBox="0 0 520 140" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="SpecDown logo">
+  <defs>
+    <linearGradient id="sdG" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#00A3BF"/>
+      <stop offset="1" stop-color="#FF7A4D"/>
+    </linearGradient>
+    <linearGradient id="sdCore" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#FFD36A"/>
+      <stop offset="1" stop-color="#FF7A00"/>
+    </linearGradient>
+  </defs>
+
+  <!-- MARK -->
+  <g transform="translate(24,20)">
+    <!-- halo ring -->
+    <circle cx="50" cy="50" r="44" fill="none" stroke="url(#sdG)" stroke-width="6" opacity="0.9"/>
+
+    <!-- simplified "android face" shield -->
+    <path d="M50 10
+             C28 10, 16 28, 16 46
+             C16 70, 32 86, 50 92
+             C68 86, 84 70, 84 46
+             C84 28, 72 10, 50 10 Z"
+          fill="#0F1724" opacity="0.95"/>
+
+    <!-- cheek highlights -->
+    <path d="M28 44 C30 32, 38 24, 50 22" fill="none" stroke="#FFFFFF" stroke-width="3" opacity="0.12"/>
+    <path d="M72 44 C70 32, 62 24, 50 22" fill="none" stroke="#FFFFFF" stroke-width="3" opacity="0.12"/>
+
+    <!-- eyes -->
+    <path d="M34 50 Q40 46 46 50" fill="none" stroke="#00D5FF" stroke-width="4" stroke-linecap="round" opacity="0.9"/>
+    <path d="M54 50 Q60 46 66 50" fill="none" stroke="#00D5FF" stroke-width="4" stroke-linecap="round" opacity="0.9"/>
+
+    <!-- core (diamond) -->
+    <g transform="translate(50,34)">
+      <path d="M0 -10 L10 0 L0 10 L-10 0 Z" fill="url(#sdCore)"/>
+      <path d="M0 -10 L10 0 L0 10 L-10 0 Z" fill="none" stroke="#FFFFFF" stroke-width="1" opacity="0.35"/>
+      <circle cx="0" cy="0" r="3.5" fill="#FFFFFF" opacity="0.35"/>
+    </g>
+  </g>
+
+  <!-- WORDMARK -->
+  <g transform="translate(140,45)">
+    <text x="0" y="50"
+          font-family="Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial"
+          font-size="56" font-weight="800" letter-spacing="-0.02em"
+          fill="#FFFFFF">Spec</text>
+    <text x="138" y="50"
+          font-family="Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial"
+          font-size="56" font-weight="800" letter-spacing="-0.02em"
+          fill="url(#sdG)">Down</text>
+  </g>
+</svg>

--- a/markdown-viewer/logo.svg
+++ b/markdown-viewer/logo.svg
@@ -1,0 +1,53 @@
+<svg width="520" height="140" viewBox="0 0 520 140" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="SpecDown logo">
+  <defs>
+    <linearGradient id="sdG" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#00A3BF"/>
+      <stop offset="1" stop-color="#FF7A4D"/>
+    </linearGradient>
+    <linearGradient id="sdCore" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#FFD36A"/>
+      <stop offset="1" stop-color="#FF7A00"/>
+    </linearGradient>
+  </defs>
+
+  <!-- MARK -->
+  <g transform="translate(24,20)">
+    <!-- halo ring -->
+    <circle cx="50" cy="50" r="44" fill="none" stroke="url(#sdG)" stroke-width="6" opacity="0.9"/>
+
+    <!-- simplified "android face" shield -->
+    <path d="M50 10
+             C28 10, 16 28, 16 46
+             C16 70, 32 86, 50 92
+             C68 86, 84 70, 84 46
+             C84 28, 72 10, 50 10 Z"
+          fill="#0F1724" opacity="0.95"/>
+
+    <!-- cheek highlights -->
+    <path d="M28 44 C30 32, 38 24, 50 22" fill="none" stroke="#FFFFFF" stroke-width="3" opacity="0.12"/>
+    <path d="M72 44 C70 32, 62 24, 50 22" fill="none" stroke="#FFFFFF" stroke-width="3" opacity="0.12"/>
+
+    <!-- eyes -->
+    <path d="M34 50 Q40 46 46 50" fill="none" stroke="#00D5FF" stroke-width="4" stroke-linecap="round" opacity="0.9"/>
+    <path d="M54 50 Q60 46 66 50" fill="none" stroke="#00D5FF" stroke-width="4" stroke-linecap="round" opacity="0.9"/>
+
+    <!-- core (diamond) -->
+    <g transform="translate(50,34)">
+      <path d="M0 -10 L10 0 L0 10 L-10 0 Z" fill="url(#sdCore)"/>
+      <path d="M0 -10 L10 0 L0 10 L-10 0 Z" fill="none" stroke="#FFFFFF" stroke-width="1" opacity="0.35"/>
+      <circle cx="0" cy="0" r="3.5" fill="#FFFFFF" opacity="0.35"/>
+    </g>
+  </g>
+
+  <!-- WORDMARK -->
+  <g transform="translate(140,45)">
+    <text x="0" y="50"
+          font-family="Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial"
+          font-size="56" font-weight="800" letter-spacing="-0.02em"
+          fill="#0F1724">Spec</text>
+    <text x="138" y="50"
+          font-family="Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial"
+          font-size="56" font-weight="800" letter-spacing="-0.02em"
+          fill="url(#sdG)">Down</text>
+  </g>
+</svg>

--- a/markdown-viewer/styles.css
+++ b/markdown-viewer/styles.css
@@ -68,9 +68,32 @@ body {
 
 .header-left {
     display: flex;
-    align-items: baseline;
+    align-items: center;
     gap: 1rem;
     flex-wrap: wrap;
+}
+
+.logo-link {
+    display: flex;
+    align-items: center;
+    text-decoration: none;
+}
+
+.header-logo {
+    height: 40px;
+    width: auto;
+}
+
+.header-logo-dark {
+    display: none;
+}
+
+[data-theme="dark"] .header-logo-light {
+    display: none;
+}
+
+[data-theme="dark"] .header-logo-dark {
+    display: block;
 }
 
 .app-header h1 {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "markdown-diagram-viewer",
+  "name": "specdown",
   "version": "0.0.27",
-  "description": "A lightweight, browser-based markdown viewer with enhanced diagram navigation capabilities",
+  "description": "SpecDown: A lightweight, browser-based markdown viewer with enhanced diagram navigation capabilities",
   "main": "markdown-viewer/app.js",
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
- Add SpecDown logo SVG with light and dark theme variants
- Add SVG favicon for browser tab branding
- Replace header h1 with logo image
- Update page title, source repo links, and package name

https://claude.ai/code/session_0171yoYQqsFdZguKN1AVm9y3