### PR TITLE
Fix diagram container cutting off bottom when zooming in

### DIFF
--- a/markdown-viewer/app.js
+++ b/markdown-viewer/app.js
@@ -373,7 +373,8 @@ function initializePanzoom(diagramId) {
         maxScale: 5,
         minScale: 0.5,
         step: 0.2,
-        cursor: 'grab'
+        cursor: 'grab',
+        contain: 'outside'
     });
     
     // Store instance for cleanup

--- a/markdown-viewer/styles.css
+++ b/markdown-viewer/styles.css
@@ -456,13 +456,11 @@ body {
 
 .diagram-wrapper {
     min-height: 400px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
     padding: 2rem;
     cursor: grab;
     overflow: hidden;
     position: relative;
+    text-align: center;
 }
 
 .diagram-wrapper:active {
@@ -472,6 +470,7 @@ body {
 .diagram-wrapper svg {
     max-width: 100%;
     height: auto;
+    display: inline-block;
 }
 
 /* ===========================


### PR DESCRIPTION
Two changes to fix the zoom/pan clipping issue:

1. Replace flex centering with text-align on .diagram-wrapper - flex centering with align-items:center interferes with Panzoom's transform origin calculations, causing incorrect pan bounds when zoomed in.

2. Add contain:'outside' to inline Panzoom config - this ensures the diagram can't be panned past its edges when zoomed, matching the fullscreen behavior and allowing proper access to all diagram areas.

https://claude.ai/code/session_016yV5NqeP8ZQEagXjMw9iV6