### PR TITLE
Fix stale references after repo rename to specdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ All modern browsers with ES6+ support and FileReader API.
 ### File Structure
 
 ```
-markdown_viewer/
+specdown/
 ├── README.md                    # This file
 └── markdown-viewer/            # Application directory
     ├── index.html              # Main application page
@@ -101,15 +101,7 @@ markdown_viewer/
 
 ### Example Files
 
-Try the viewer with these example files:
-
-```bash
-# From the workspace
-/Users/cbremer/Documents/code/li-productivity-agents/docs/LIPA_SYSTEM_DIAGRAM.md
-/Users/cbremer/Documents/code/guide/GUIDE_SYSTEM_DIAGRAM.md
-```
-
-These files contain complex system architecture diagrams that showcase the interactive features.
+Try the viewer with any `.md` file containing Mermaid diagrams to explore the interactive features.
 
 ### Features in Detail
 
@@ -266,7 +258,7 @@ This project uses open-source libraries:
 
 ### Acknowledgments
 
-Built for viewing LinkedIn internal documentation with complex system diagrams. Optimized for exploring architecture diagrams like those in LIPA and GUIDE system documentation.
+Built for viewing documentation with complex system architecture diagrams.
 
 ### Version History
 

--- a/TEST_COVERAGE_ANALYSIS.md
+++ b/TEST_COVERAGE_ANALYSIS.md
@@ -1,4 +1,4 @@
-# Test Coverage Analysis - Markdown Diagram Viewer
+# Test Coverage Analysis - SpecDown
 
 **Date**: 2026-01-24
 **Branch**: claude/analyze-test-coverage-WOZaG
@@ -577,7 +577,7 @@ Need to mock CDN dependencies:
 ## Proposed Test File Structure
 
 ```
-markdown_viewer/
+specdown/
 ├── markdown-viewer/
 │   ├── index.html
 │   ├── app.js


### PR DESCRIPTION
- Update root directory name from markdown_viewer to specdown in README and TEST_COVERAGE_ANALYSIS file structures
- Update TEST_COVERAGE_ANALYSIS title to use SpecDown branding
- Remove hardcoded local filesystem paths to internal docs from README
- Remove LinkedIn-specific references from README acknowledgments

https://claude.ai/code/session_017iFwzrp6RCy6BM3bVdjNRZ