### PR TITLE
Fix version mismatch between main branch and GitHub Pages

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # Skip if the commit was made by this workflow (prevents infinite loop)
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    if: "!contains(github.event.head_commit.message, '[version bump]')"
 
     permissions:
       contents: write
@@ -34,7 +34,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Bump patch version
-        run: npm version patch -m "Bump version to %s [skip ci]"
+        run: npm version patch -m "Bump version to %s [version bump]"
 
       - name: Push version commit and tag
         run: git push --follow-tags origin main


### PR DESCRIPTION
Replace [skip ci] with [version bump] in the version-bump workflow commit message. [skip ci] is a GitHub-wide flag that suppresses all workflows, which prevented the deploy workflow from re-triggering after a version bump. The custom [version bump] tag only skips the version-bump workflow itself, allowing GitHub Pages to deploy the correct version.

https://claude.ai/code/session_01YG34CcmzZML8L2MKZJ5AMU