### PR TITLE
Trigger deploy workflow after version bump

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -38,3 +38,8 @@ jobs:
 
       - name: Push version commit and tag
         run: git push --follow-tags origin main
+
+      - name: Trigger deploy workflow
+        run: gh workflow run "Deploy static content" --ref main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
GITHUB_TOKEN pushes don't trigger other workflows, so the deploy workflow never ran after a version bump. Fix by explicitly triggering the deploy workflow via gh workflow dispatch after pushing the bump commit. This ensures GitHub Pages always has the latest version.

https://claude.ai/code/session_01YG34CcmzZML8L2MKZJ5AMU