### PR TITLE
Add actions:write permission for deploy workflow trigger

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -18,6 +18,7 @@ jobs:
 
     permissions:
       contents: write
+      actions: write
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The gh workflow run command requires actions:write permission on the GITHUB_TOKEN to dispatch workflow_dispatch events.

https://claude.ai/code/session_01YG34CcmzZML8L2MKZJ5AMU