### PR TITLE
Fix deploy workflow to run after version bump completes

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,9 +1,11 @@
 name: Deploy static content
 
 on:
-  push:
-    branches: ["main"]
   workflow_dispatch:
+  workflow_run:
+    workflows: ["Bump version on merge"]
+    types:
+      - completed
 
 permissions:
   contents: read
@@ -16,6 +18,7 @@ concurrency:
 
 jobs:
   deploy:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -18,7 +18,6 @@ jobs:
 
     permissions:
       contents: write
-      actions: write
 
     steps:
       - uses: actions/checkout@v4
@@ -39,8 +38,3 @@ jobs:
 
       - name: Push version commit and tag
         run: git push --follow-tags origin main
-
-      - name: Trigger deploy workflow
-        run: gh workflow run "Deploy static content" --ref main
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The deploy workflow was triggering on every push to main, which meant it deployed the pre-bump version. Now it only deploys after the version bump workflow completes successfully, ensuring the site always shows the correct version number.

https://claude.ai/code/session_01YG34CcmzZML8L2MKZJ5AMU