### PR TITLE
Fix file picker requiring double selection due to event bubbling

### DIFF
--- a/markdown-viewer/app.js
+++ b/markdown-viewer/app.js
@@ -105,8 +105,12 @@ function updateThemeIcon() {
 // Event Listeners
 // ===========================
 function setupEventListeners() {
-    // Browse button
-    browseButton.addEventListener('click', () => fileInput.click());
+    // Browse button - stopPropagation prevents the dropZone click handler
+    // from calling fileInput.click() a second time (button is inside drop-zone-content)
+    browseButton.addEventListener('click', (e) => {
+        e.stopPropagation();
+        fileInput.click();
+    });
     
     // File input change
     fileInput.addEventListener('change', handleFileSelect);

--- a/tests/unit/fileHandling.test.js
+++ b/tests/unit/fileHandling.test.js
@@ -188,6 +188,23 @@ describe('File Handling', () => {
     });
   });
 
+  describe('browse button click', () => {
+    it('should stop propagation to prevent double fileInput.click()', () => {
+      const browseButton = document.getElementById('browse-button');
+      const fileInput = document.getElementById('file-input');
+
+      const clickSpy = jest.fn();
+      fileInput.click = clickSpy;
+
+      // Simulate a click event on the browse button
+      const event = new Event('click', { bubbles: true });
+      browseButton.dispatchEvent(event);
+
+      // fileInput.click() should be called exactly once, not twice
+      expect(clickSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('handleDrop', () => {
     it('should extract file from drag event', () => {
       const file = new File(['# Test'], 'test.md', { type: 'text/markdown' });


### PR DESCRIPTION
The browse button is nested inside .drop-zone-content, so clicking it
triggered fileInput.click() twice: once from the button handler and
once from the drop zone click handler (via event bubbling). The second
call interferes with the already-open file dialog, causing files to
not load or require two selections. Fixed by adding stopPropagation()
to the browse button click handler.

https://claude.ai/code/session_013szPicE7B63ZVzYCv18Vmm