### PR TITLE
Add preview/raw markdown view toggle functionality

### DIFF
--- a/markdown-viewer/index.html
+++ b/markdown-viewer/index.html
@@ -68,9 +68,15 @@
                     <span class="file-icon">📄</span>
                     <span id="file-name" class="file-name"></span>
                 </div>
-                <button id="load-new-file" class="load-new-button" title="Load another file">
-                    Load New File
-                </button>
+                <div class="content-header-actions">
+                    <button id="view-toggle" class="view-toggle-button" title="Toggle between preview and raw markdown">
+                        <span class="view-toggle-icon">&lt;/&gt;</span>
+                        <span class="view-toggle-label">Raw</span>
+                    </button>
+                    <button id="load-new-file" class="load-new-button" title="Load another file">
+                        Load New File
+                    </button>
+                </div>
             </div>
             <div id="markdown-content" class="markdown-content"></div>
         </div>

--- a/markdown-viewer/styles.css
+++ b/markdown-viewer/styles.css
@@ -286,6 +286,44 @@ body {
     color: var(--text-primary);
 }
 
+.content-header-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.view-toggle-button {
+    background-color: var(--bg-tertiary);
+    color: var(--text-primary);
+    border: 1px solid var(--border-color);
+    padding: 0.5rem 1rem;
+    border-radius: 6px;
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: var(--transition);
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+}
+
+.view-toggle-button:hover {
+    background-color: var(--accent-color);
+    color: white;
+    border-color: var(--accent-color);
+}
+
+.view-toggle-button.active {
+    background-color: var(--accent-color);
+    color: white;
+    border-color: var(--accent-color);
+}
+
+.view-toggle-icon {
+    font-family: 'Courier New', Courier, monospace;
+    font-weight: 700;
+    font-size: 0.85rem;
+}
+
 .load-new-button {
     background-color: var(--bg-tertiary);
     color: var(--text-primary);
@@ -407,6 +445,31 @@ body {
 .markdown-content img {
     max-width: 100%;
     height: auto;
+}
+
+/* ===========================
+   Raw Markdown View
+   =========================== */
+.raw-markdown {
+    background-color: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    padding: 1.5em;
+    margin: 0;
+    overflow-x: auto;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    font-family: 'Courier New', Courier, monospace;
+    font-size: 0.9em;
+    line-height: 1.7;
+    color: var(--text-primary);
+}
+
+.raw-markdown code {
+    background-color: transparent;
+    padding: 0;
+    font-family: inherit;
+    font-size: inherit;
 }
 
 /* ===========================

--- a/tests/unit/viewToggle.test.js
+++ b/tests/unit/viewToggle.test.js
@@ -1,0 +1,121 @@
+/**
+ * Unit tests for view toggle (preview/raw markdown) functionality
+ */
+
+const { loadHTML, loadApp } = require('../helpers/loadApp');
+require('../mocks/marked');
+require('../mocks/mermaid');
+require('../mocks/panzoom');
+require('../mocks/highlightjs');
+
+describe('View Toggle', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    loadHTML(document);
+    loadApp(document);
+  });
+
+  describe('initial state', () => {
+    it('should default to preview mode', () => {
+      expect(currentViewMode).toBe('preview');
+    });
+
+    it('should have empty raw markdown initially', () => {
+      expect(currentRawMarkdown).toBe('');
+    });
+
+    it('should render toggle button with Raw label', () => {
+      const label = document.querySelector('.view-toggle-label');
+      expect(label.textContent).toBe('Raw');
+    });
+
+    it('should not have active class on toggle button initially', () => {
+      const btn = document.getElementById('view-toggle');
+      expect(btn.classList.contains('active')).toBe(false);
+    });
+  });
+
+  describe('toggleViewMode', () => {
+    it('should do nothing when no markdown is loaded', () => {
+      currentRawMarkdown = '';
+      toggleViewMode();
+      expect(currentViewMode).toBe('preview');
+    });
+
+    it('should switch to raw mode and display escaped markdown', async () => {
+      const mdContent = '# Hello\n\nSome **bold** text with <html> tags';
+      await renderMarkdown(mdContent, 'test.md');
+
+      toggleViewMode();
+
+      expect(currentViewMode).toBe('raw');
+      const pre = document.querySelector('.raw-markdown');
+      expect(pre).not.toBeNull();
+      // HTML should be escaped
+      expect(pre.innerHTML).toContain('&lt;html&gt;');
+      expect(pre.innerHTML).toContain('# Hello');
+    });
+
+    it('should add active class to button in raw mode', async () => {
+      await renderMarkdown('# Test', 'test.md');
+      toggleViewMode();
+
+      const btn = document.getElementById('view-toggle');
+      expect(btn.classList.contains('active')).toBe(true);
+    });
+
+    it('should show Preview label in raw mode', async () => {
+      await renderMarkdown('# Test', 'test.md');
+      toggleViewMode();
+
+      const label = document.querySelector('.view-toggle-label');
+      expect(label.textContent).toBe('Preview');
+    });
+
+    it('should switch back to preview mode', async () => {
+      await renderMarkdown('# Test', 'test.md');
+      toggleViewMode(); // -> raw
+      toggleViewMode(); // -> preview
+
+      expect(currentViewMode).toBe('preview');
+      const btn = document.getElementById('view-toggle');
+      expect(btn.classList.contains('active')).toBe(false);
+    });
+
+    it('should show Raw label after switching back to preview', async () => {
+      await renderMarkdown('# Test', 'test.md');
+      toggleViewMode(); // -> raw
+      toggleViewMode(); // -> preview
+
+      const label = document.querySelector('.view-toggle-label');
+      expect(label.textContent).toBe('Raw');
+    });
+  });
+
+  describe('renderMarkdown stores raw content', () => {
+    it('should store the raw markdown content', async () => {
+      const md = '# Title\n\nParagraph';
+      await renderMarkdown(md, 'doc.md');
+      expect(currentRawMarkdown).toBe(md);
+    });
+
+    it('should reset view mode to preview on new render', async () => {
+      await renderMarkdown('# First', 'first.md');
+      toggleViewMode(); // -> raw
+      await renderMarkdown('# Second', 'second.md');
+      expect(currentViewMode).toBe('preview');
+    });
+  });
+
+  describe('showDropZone resets state', () => {
+    it('should clear raw markdown and reset view mode', async () => {
+      await renderMarkdown('# Test', 'test.md');
+      toggleViewMode();
+
+      showDropZone();
+
+      expect(currentRawMarkdown).toBe('');
+      expect(currentViewMode).toBe('preview');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
This PR adds a view toggle feature that allows users to switch between preview mode (rendered HTML) and raw markdown mode, displaying the unprocessed markdown source code.

## Key Changes
- **New state variables** in `app.js`:
  - `currentRawMarkdown`: stores the raw markdown content
  - `currentViewMode`: tracks whether viewing 'preview' or 'raw' mode

- **Toggle functionality** (`toggleViewMode()`):
  - Switches between preview and raw markdown views
  - In raw mode, displays escaped HTML in a `<pre>` block to prevent rendering
  - Cleans up panzoom instances when switching modes
  - Re-renders preview when switching back from raw mode

- **UI updates**:
  - Added view toggle button in the content header with icon and label
  - Button shows `</>` icon and "Raw" label in preview mode
  - Button shows `▶` icon and "Preview" label in raw mode
  - Active state styling applied when in raw mode
  - Grouped toggle and "Load New File" buttons in a flex container

- **State management**:
  - Raw markdown is stored when `renderMarkdown()` is called
  - View mode resets to preview when new files are loaded
  - State is cleared when returning to drop zone

- **Styling** (`styles.css`):
  - New `.view-toggle-button` with hover and active states
  - New `.raw-markdown` styles for displaying raw content with proper formatting
  - New `.content-header-actions` flex container for header buttons

- **Tests** (`viewToggle.test.js`):
  - Comprehensive unit tests covering initial state, toggle behavior, HTML escaping, and state management
  - Tests verify button styling, label updates, and integration with other functions

## Implementation Details
- HTML special characters (`<`, `>`, `&`) are properly escaped in raw mode to prevent unintended rendering
- Panzoom instances are cleaned up before switching to raw mode to avoid memory leaks
- The toggle button is disabled (returns early) when no markdown is loaded
- View mode automatically resets to preview when new markdown is rendered

https://claude.ai/code/session_01MWoQV4nVhpwkKLzKv5Upqy