### PR TITLE
Add brainstorm doc for Specdown Desktop (Mac app)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,272 @@
+# Current Spec
+
+## Product Overview
+
+- **Name:** Specdown Desktop
+- **What it is:** A macOS desktop application for viewing markdown files with interactive Mermaid diagram support. Wraps the existing Specdown web viewer (vanilla JS) in an Electron shell, adding native desktop capabilities.
+- **Who it's for:** Developers and technical users who write and review markdown documentation with embedded Mermaid diagrams, and want a dedicated local viewer without running a web server.
+- **Problem it solves:** The web version requires serving from a local web server, only handles one file at a time, loses state on reload, and can't integrate with the native file system (Finder, file associations, etc.).
+- **Fidelity:** Personal tool / alpha — private internal project, not distributed publicly.
+
+---
+
+## Form Factor & Platform
+
+- Desktop app for macOS (Tahoe or later)
+- Single-window, tabbed interface
+- Direct download distribution via `.dmg` from GitHub Releases
+- No code signing or notarization — internal use only (users bypass Gatekeeper via right-click > Open or `xattr -cr`)
+
+---
+
+## Technology Stack
+
+- **Framework:** Electron (Chromium + Node.js)
+- **Frontend:** Existing vanilla JavaScript, HTML, CSS (shared with web version)
+- **Libraries (carried over from web version):**
+  - Marked.js 11.1.1 — markdown parsing and rendering
+  - Mermaid.js 10.6.1 — diagram rendering
+  - Panzoom 4.5.1 — interactive zoom/pan for diagrams
+  - Highlight.js 11.9.0 — code syntax highlighting
+- **New packages for desktop:**
+  - `electron` — application runtime
+  - `electron-forge` or `electron-builder` — packaging and DMG creation
+  - `electron-store` — persistent JSON storage for app state
+  - `chokidar` — file system watching
+- **No cloud services** — entirely local, no backend, no accounts
+
+---
+
+## Features
+
+### Core Features (1:1 parity with web version)
+
+Everything the existing web version does must work identically in the desktop version:
+
+- GitHub Flavored Markdown rendering via Marked.js
+- Interactive Mermaid diagrams with zoom, pan, reset, and fullscreen
+- Syntax-highlighted code blocks (JavaScript, Python, Java, Bash, JSON, YAML)
+- Light/dark theme toggle (persistent)
+- Raw markdown / rendered preview toggle
+- Drag-and-drop file loading
+- Clean, minimal UI
+
+### New Desktop Features
+
+#### Multi-File Tabs
+- Tabbed interface within a single window, maximum 10 tabs
+- Each tab maintains independent state: file path, raw markdown content, scroll position, view mode (raw/preview), and panzoom instance states for diagrams
+- Tab bar displays filenames; tabs are individually closeable
+- Switching tabs preserves and restores per-tab state
+- Drag-and-drop multiple files at once to open them in separate tabs
+- Only the active tab's diagrams need to be fully rendered (lazy rendering for performance)
+
+#### Native File Open
+- `Cmd+O` opens a native macOS file dialog filtered to `.md` / `.markdown` files
+- Register as a file handler for `.md` files — double-click a markdown file in Finder to open it in Specdown Desktop
+- Drag files from Finder onto the Dock icon to open them
+- Appear in the macOS "Open With" context menu for markdown files
+
+#### File Watching (Opt-In)
+- Per-file toggle to auto-reload content when the file changes on disk
+- Useful when editing markdown in another application and previewing in Specdown Desktop
+- Implemented via `chokidar` in the main process, with change notifications sent to the renderer via IPC
+- Watching is off by default; user enables it per tab
+
+#### Persistent State
+- Remembers the following across sessions via `electron-store`:
+  - Open file paths and tab order
+  - Last active tab
+  - Scroll position per file
+  - View mode per file (raw/preview)
+  - Window size and position
+  - Theme preference (light/dark)
+  - Recent files list
+  - Favorited files
+- State is saved on meaningful changes (tab switch, close, theme change) and on app quit
+
+#### Recent Files & Favorites
+- Track recently opened files (accessible via File > Open Recent menu and within the app)
+- Users can star/favorite specific files for quick access
+- Favorites persist across sessions
+- Full sidebar grouping / workspaces deferred to a later iteration
+
+#### Print & PDF Export
+- Print the rendered markdown view via Electron's native print dialog
+- Export to PDF via `webContents.printToPDF()`
+- Accessible via `Cmd+P` and File > Print / Export to PDF menu items
+
+#### Keyboard Shortcuts
+- `Cmd+O` — Open file
+- `Cmd+W` — Close current tab
+- `Cmd+1` through `Cmd+9` — Switch to tab by position
+- `Cmd+P` — Print / Export to PDF
+
+#### Native macOS Menus
+- **File:** Open, Open Recent, Close Tab, Print, Export to PDF
+- **View:** Toggle Theme, Toggle Raw/Preview
+- **Window:** standard macOS window management
+- **Help:** About Specdown Desktop
+
+---
+
+## Architecture
+
+### Same Repo, Shared Code
+
+The desktop version lives in the same repository as the web version. Desktop-specific code is isolated in a `desktop/` directory. The existing `index.html`, `app.js`, `styles.css`, and `vendor/` directory are shared between both versions. The web version's GitHub Pages deployment is completely unaffected.
+
+### Repo Layout
+
+```
+specdown/
+├── index.html            ← shared (web + desktop frontend)
+├── app.js                ← shared (modified for tab management + IPC)
+├── styles.css            ← shared (extended for tab bar UI)
+├── vendor/               ← shared (Marked, Mermaid, Panzoom, Highlight.js)
+├── tests/                ← existing web tests + new desktop tests
+├── package.json          ← extended with Electron deps + scripts
+├── desktop/              ← NEW: Electron-specific
+│   ├── main.js           ←   Main process (window, menus, file system, persistence)
+│   ├── preload.js        ←   Secure IPC bridge
+│   └── icons/            ←   App icons
+├── brainstorm.md
+├── SPEC.md
+└── .github/workflows/
+    ├── static.yml        ← existing: deploys web version to GitHub Pages
+    └── desktop.yml       ← NEW: builds .dmg, attaches to GitHub Releases
+```
+
+### Process Architecture
+
+```
+┌──────────────────────────────────────────────────┐
+│                Electron Shell                     │
+│                                                   │
+│  ┌────────────────────────────────────────────┐  │
+│  │          Renderer Process                  │  │
+│  │          (Web Frontend)                    │  │
+│  │                                            │  │
+│  │  ┌─────────────┐  ┌───────────────────┐   │  │
+│  │  │  Tab Bar    │  │  Content Area     │   │  │
+│  │  │             │  │                   │   │  │
+│  │  │  file1.md   │  │  [Rendered MD]    │   │  │
+│  │  │  file2.md   │  │  [Diagrams]      │   │  │
+│  │  │  file3.md   │  │  [Code blocks]   │   │  │
+│  │  └─────────────┘  └───────────────────┘   │  │
+│  │                                            │  │
+│  │  Shared: Marked + Mermaid + Panzoom +     │  │
+│  │  Highlight.js + tab management logic       │  │
+│  └──────────────┬─────────────────────────────┘  │
+│                 │  IPC (via preload.js)           │
+│  ┌──────────────▼─────────────────────────────┐  │
+│  │          Main Process                      │  │
+│  │          (Node.js)                         │  │
+│  │                                            │  │
+│  │  - File system read (fs)                  │  │
+│  │  - File watching (chokidar)               │  │
+│  │  - Persistent storage (electron-store)    │  │
+│  │  - Native menus & dialogs                 │  │
+│  │  - Window management                      │  │
+│  │  - Print / PDF export                     │  │
+│  │  - File type associations                 │  │
+│  └────────────────────────────────────────────┘  │
+└──────────────────────────────────────────────────┘
+```
+
+### IPC Contract
+
+**Main process → Renderer:**
+- Deliver file content when a file is opened (via menu, dialog, Finder, or drag)
+- Notify when a watched file changes on disk
+- Trigger actions from menu items (toggle theme, toggle view mode, print)
+
+**Renderer → Main process:**
+- Request to open a file (triggers native dialog)
+- Save app state (open tabs, scroll positions, view modes, etc.)
+- Toggle file watching on/off for a specific file path
+- Request print or PDF export
+
+### Deployment
+
+| | Web Version | Desktop Version |
+|---|---|---|
+| **What ships** | Static files (HTML/JS/CSS) | Bundled `.app` inside `.dmg` |
+| **Deployed via** | GitHub Pages (`static.yml`) | GitHub Releases (`desktop.yml`) |
+| **Triggered by** | Push to main | Tag push or manual workflow dispatch |
+| **Users access via** | `cbremer.github.io/specdown` | Download `.dmg` from GitHub Releases |
+
+### Versioning
+
+Web and desktop share a single version number from `package.json`. Can split to independent versioning later if release cadences diverge.
+
+---
+
+## Design Principles
+
+1. **Viewer, not editor** — Specdown Desktop shows markdown. It does not edit it.
+2. **Local only** — No accounts, no cloud sync, no sharing features. Files live on the user's disk.
+3. **Minimal preferences** — Theme toggle and that's about it. No deep settings panels.
+4. **Fast startup** — Should feel faster to open than a browser tab.
+5. **Web version unaffected** — Desktop additions must not break the existing GitHub Pages deployment or web functionality.
+
+---
+
+## Scope Boundaries
+
+### In Scope
+- All features listed above
+- Existing Jest test suite continues passing
+- New tests for Electron main process and IPC
+- DMG packaging via GitHub Actions
+- Shared versioning with web version
+
+### Out of Scope (Deferred)
+- Markdown editing
+- Sidebar file grouping / workspaces
+- Mac App Store distribution
+- Code signing / notarization
+- Cross-platform support (Windows, Linux)
+- Accessibility (VoiceOver, keyboard-only navigation)
+- Auto-update mechanism
+- Cloud sync or collaboration
+
+---
+
+## Testing Strategy
+
+### Shared Rendering Logic
+Existing Jest test suite (unit + integration) continues covering markdown rendering, Mermaid diagram processing, theme toggling, and view mode switching. These tests validate the shared web frontend that both versions use.
+
+### Electron Main Process
+Unit tests for file operations, state persistence, and menu construction using Jest with mocked Electron APIs. Covers:
+- File reading and validation
+- `electron-store` read/write operations
+- File watcher setup and teardown
+- Menu template generation
+- IPC message handling
+
+### IPC Integration
+Tests verifying the main ↔ renderer communication pipeline:
+- File open request → content delivered → rendered in tab
+- State save request → persisted to store → restored on relaunch
+- File watch toggle → watcher started/stopped → change notification delivered
+
+### End-to-End
+Playwright for Electron for full-app tests:
+- Open a file via dialog, verify it renders correctly
+- Open multiple files, switch between tabs, verify state preservation
+- Close and reopen the app, verify state restoration
+- Print / export to PDF
+- Theme and view mode toggling
+
+### Manual Test Checklist
+- Finder file association (double-click `.md` file opens in Specdown Desktop)
+- Drag file from Finder onto Dock icon
+- Gatekeeper bypass on first launch
+- DMG install and uninstall (drag to Applications / drag to Trash)
+- Open Recent menu population
+
+---
+
+*Last updated: 2026-02-21*

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,109 @@
+# Session 1 Tasks: Electron Shell + Dev Loop
+
+## Current State
+- Working web app in `markdown-viewer/` (app.js, index.html, styles.css, vendor/)
+- Existing Jest test suite (unit + integration) in `tests/`
+- No desktop code exists — no Electron, no `desktop/` directory
+- Development progression: **Environment setup** — proving Electron works with the existing code
+
+## Goal
+Get the existing Specdown web app running inside an Electron window with a working dev loop (`npm run desktop` to launch, `npm test` still passes). No new features yet — just prove the shell works.
+
+---
+
+## Tasks
+
+### 1. Install Electron and tooling
+**Who:** AI coding agent
+- `npm install --save-dev electron`
+- `npm install --save-dev electron-builder` (for future DMG packaging)
+- `npm install electron-store` (will need soon for persistence)
+- Add npm scripts to `package.json`:
+  - `"desktop"` — launches the Electron app in dev mode
+  - `"desktop:build"` — placeholder for future packaging (can be a no-op for now)
+- Verify `npm test` still passes after dependency changes
+
+### 2. Create `desktop/main.js` — minimal Electron main process
+**Who:** AI coding agent
+- Create `desktop/` directory
+- Write `main.js` with:
+  - `BrowserWindow` that loads `markdown-viewer/index.html`
+  - Sensible default window size (1200x800)
+  - Window title: "Specdown Desktop"
+  - Basic app lifecycle (ready, window-all-closed, activate)
+  - DevTools disabled by default (can enable with flag later)
+- Keep it minimal — no menus, no IPC, no persistence yet
+
+### 3. Create `desktop/preload.js` — empty bridge
+**Who:** AI coding agent
+- Create a stub `preload.js` that will later expose IPC APIs to the renderer
+- For now, it just exists so the main process can reference it and the architecture is in place
+- Wire it into `BrowserWindow` webPreferences
+
+### 4. Verify the web app renders correctly in Electron
+**Who:** Human developer (on a Mac)
+- Run `npm run desktop`
+- Manual verification checklist:
+  - [ ] Window opens with "Specdown Desktop" title
+  - [ ] Drop zone / file picker UI appears
+  - [ ] Drag-and-drop a `.md` file — renders correctly
+  - [ ] Mermaid diagrams render with zoom/pan/fullscreen controls
+  - [ ] Light/dark theme toggle works
+  - [ ] Raw/preview toggle works
+  - [ ] Syntax highlighting works in code blocks
+- Report any rendering differences vs. the browser version
+
+### 5. Verify existing tests still pass
+**Who:** AI coding agent
+- Run `npm test` — all existing Jest tests must pass
+- Run `npm run test:coverage` — coverage thresholds must still be met
+- No test modifications should be needed (Electron deps shouldn't affect jsdom tests)
+
+### 6. Fix SPEC.md repo layout
+**Who:** AI coding agent
+- The SPEC.md currently shows `index.html`, `app.js`, `styles.css` at the repo root, but they actually live in `markdown-viewer/`
+- Update the repo layout diagram and any references to match reality:
+  ```
+  specdown/
+  ├── markdown-viewer/       ← existing web app
+  │   ├── index.html
+  │   ├── app.js
+  │   ├── styles.css
+  │   └── vendor/
+  ├── desktop/               ← NEW: Electron-specific
+  │   ├── main.js
+  │   ├── preload.js
+  │   └── icons/
+  ├── tests/
+  ├── package.json
+  └── ...
+  ```
+- Also update any architecture text that says "shared `index.html`, `app.js`, `styles.css`" to reference `markdown-viewer/` paths
+
+### 7. Update SPEC.md and README based on session results
+**Who:** AI coding agent
+- Add a "Development" section to README with:
+  - `npm run desktop` — how to launch the desktop app
+  - `npm test` — how to run tests (already documented, just confirm)
+- Update SPEC.md "Current Spec" timestamp
+- Note in SPEC.md which features are now implemented (Electron shell, dev loop) vs. pending
+
+---
+
+## Definition of Done
+- `npm run desktop` launches an Electron window showing the Specdown UI
+- All existing `npm test` tests pass with no modifications
+- `desktop/main.js` and `desktop/preload.js` exist
+- SPEC.md repo layout matches the actual directory structure
+- README has instructions for running the desktop app
+
+## What This Unblocks
+- Session 2 can build on a working Electron shell to add native file open (`Cmd+O`), IPC bridge, and basic menus
+- Human developer can start manually testing with real markdown files on macOS
+
+---
+
+## Notes
+- **Important:** This session does NOT require macOS. The Electron app can be scaffolded and tests verified on any platform. Task 4 (manual rendering verification) is the only Mac-specific step and is assigned to the human developer.
+- The AI agent should not modify `markdown-viewer/app.js`, `styles.css`, or `index.html` in this session. The goal is to wrap the existing code, not change it.
+- If Electron's content security policy blocks loading vendored libraries from local files, the main process may need to configure appropriate CSP headers. Flag this if it happens rather than making sweeping changes.

--- a/brainstorm.md
+++ b/brainstorm.md
@@ -1,0 +1,372 @@
+# Specdown Desktop — Brainstorm
+
+> Planning document. No code yet — just thinking things through.
+
+---
+
+## Where We Are Today
+
+Specdown (v0.0.39) is a browser-based markdown viewer built with vanilla JavaScript. No framework, no build step, no backend. You open it in a browser, drop in a `.md` file, and it renders:
+
+- **GitHub Flavored Markdown** via Marked.js
+- **Interactive Mermaid diagrams** with zoom, pan, reset, and fullscreen (via Panzoom)
+- **Syntax-highlighted code blocks** via Highlight.js
+- **Light/dark theme toggle** persisted in localStorage
+- **Raw/preview toggle** to see the source markdown
+
+The entire app is ~1,500 lines across `app.js`, `styles.css`, and `index.html`, plus four vendored libraries (Marked, Mermaid, Panzoom, Highlight.js). It's simple and focused.
+
+### What works well
+- Zero setup — no install, no build, no dependencies to manage at runtime
+- Clean rendering of markdown + diagrams
+- Mermaid interactivity (zoom/pan/fullscreen) is a differentiator
+- Light enough to understand and modify in an afternoon
+
+### Current limitations
+- **Single file at a time** — loading a new file replaces the old one
+- **No persistence** — the loaded markdown is lost on reload (only theme is saved)
+- **Requires a web server** — even locally, you need `python3 -m http.server` or similar
+- **No native file system access** — relies on drag-and-drop / file picker, can't watch files or open from Finder
+- **Browser tab overhead** — competes with everything else in the browser
+
+---
+
+## Why a Desktop App?
+
+The goal isn't to rebuild Specdown as something bigger. It's to make it **easier to use locally** while adding a few things that only make sense outside a browser tab.
+
+**Core motivation:**
+- Double-click a `.md` file in Finder and have it open in Specdown
+- Keep multiple files open at once
+- Remember what you were working on between sessions
+- Feel like a real tool, not a webpage
+
+**Non-goals:**
+- Editing markdown (this is a viewer, not an editor)
+- Cloud sync or collaboration
+- Cross-platform from day one (start with Mac, expand later if it makes sense)
+
+---
+
+## Framework Options
+
+Three realistic paths for wrapping a web-based UI in a Mac desktop app. Each lets us reuse the existing HTML/CSS/JS with varying degrees of native integration.
+
+### Option A: Tauri
+
+| | |
+|---|---|
+| **What it is** | Rust-based framework that wraps your web frontend in the system's native WebView (WKWebView on Mac) |
+| **Binary size** | ~5–10 MB |
+| **Backend language** | Rust |
+| **Frontend** | Any web tech — our existing vanilla JS/HTML/CSS drops right in |
+| **Native APIs** | File system, dialogs, menus, tray, notifications, auto-update |
+| **Maturity** | v2 is stable, growing ecosystem |
+
+**Pros:**
+- Tiny footprint — doesn't bundle a browser engine
+- Strong file system APIs (read, write, watch files)
+- Native Mac menus and dialogs out of the box
+- Good security model (explicit API permissions)
+- Active development and community
+
+**Cons:**
+- Rust backend has a learning curve if you're not already writing Rust
+- WebView rendering can have subtle differences from Chromium (but WKWebView on Mac is solid)
+- Smaller plugin/extension ecosystem than Electron
+
+**Best for:** Keeping things lightweight and native-feeling while reusing all existing web code.
+
+---
+
+### Option B: Electron
+
+| | |
+|---|---|
+| **What it is** | Bundles Chromium + Node.js to run web apps as desktop apps |
+| **Binary size** | ~150–200 MB |
+| **Backend language** | JavaScript / Node.js |
+| **Frontend** | Any web tech — same as above |
+| **Native APIs** | Full Node.js access plus Electron APIs for windows, menus, dialogs, tray, etc. |
+| **Maturity** | Battle-tested (VS Code, Slack, Discord, Notion) |
+
+**Pros:**
+- Everything is JavaScript — no new language to learn
+- Chromium rendering guarantees pixel-perfect consistency with current browser behavior
+- Massive ecosystem, tons of documentation and examples
+- Electron Forge / Electron Builder make packaging straightforward
+- Node.js gives full file system access, child processes, etc.
+
+**Cons:**
+- Large binary size for what is fundamentally a simple viewer
+- Higher memory footprint (~100+ MB baseline)
+- Chromium updates can introduce breaking changes
+- Feels like overkill for an app this focused
+
+**Best for:** Fastest path to a working desktop app if we prioritize developer velocity and don't mind the size.
+
+---
+
+### Option C: Swift + WKWebView
+
+| | |
+|---|---|
+| **What it is** | A native macOS app (SwiftUI or AppKit) that embeds WKWebView to render the web frontend |
+| **Binary size** | ~2–5 MB |
+| **Backend language** | Swift |
+| **Frontend** | Our existing web code loaded into WKWebView, with Swift ↔ JS bridging |
+| **Native APIs** | Full macOS SDK — menus, windows, file system, Spotlight, Quick Look, etc. |
+| **Maturity** | As mature as macOS itself |
+
+**Pros:**
+- Smallest possible footprint
+- Best native Mac integration (Dock, menu bar, Spotlight, file associations, universal binary)
+- Can distribute via Mac App Store or direct download with notarization
+- No extra runtime — uses the system WebView
+- SwiftUI makes basic window/tab management surprisingly simple
+
+**Cons:**
+- Mac-only (no path to Windows/Linux without a separate codebase or switching frameworks)
+- Requires Swift/Xcode knowledge
+- JS ↔ Swift bridge (`WKScriptMessageHandler`) adds complexity for native features
+- More manual work for auto-updates (Sparkle framework or roll your own)
+
+**Best for:** The most "Mac-native" result with the smallest binary, if we're committed to Mac-only.
+
+---
+
+### Framework Comparison
+
+| Criteria | Tauri | Electron | Swift + WKWebView |
+|---|---|---|---|
+| Binary size | ~5–10 MB | ~150–200 MB | ~2–5 MB |
+| Memory usage | Low | High | Lowest |
+| Reuse existing JS | Yes, directly | Yes, directly | Yes, via WKWebView |
+| File system access | Rust APIs | Node.js APIs | Swift APIs |
+| Native menus/dialogs | Yes | Yes | Yes (best) |
+| Auto-update | Built-in | Built-in | Manual (Sparkle) |
+| Learning curve | Rust (moderate) | JS (low) | Swift (moderate) |
+| Cross-platform later | Yes (Win/Linux) | Yes (Win/Linux) | No |
+| Mac App Store | Possible | Possible | Easiest |
+| Community/ecosystem | Growing | Largest | Apple ecosystem |
+
+---
+
+## Features to Carry Over (1:1 Parity)
+
+Everything the web version does today should work identically in the desktop version:
+
+- [ ] Markdown rendering (GFM via Marked.js)
+- [ ] Mermaid diagram rendering with interactive zoom/pan/reset/fullscreen
+- [ ] Syntax highlighting for code blocks
+- [ ] Light/dark theme toggle
+- [ ] Raw/preview mode toggle
+- [ ] Drag-and-drop file loading
+- [ ] Clean, minimal UI
+
+---
+
+## New Features for Desktop
+
+### 1. Multi-File Support
+
+Open multiple markdown files at once instead of one-at-a-time.
+
+**How it could work:**
+- **Tabbed interface** — each file gets a tab, like a browser or code editor
+- Tabs show filename, can be closed individually
+- Switching tabs preserves scroll position and view mode (raw/preview) per file
+- Drag-and-drop multiple files at once to open them all
+- Open from Finder via file association (double-click `.md` → opens in Specdown)
+
+**State per tab:**
+- File path
+- Raw markdown content
+- Scroll position
+- View mode (raw/preview)
+- Panzoom instance states for diagrams
+
+**Open questions:**
+- Limit on number of open tabs? Or just let it grow?
+- Tab overflow behavior — scrollable tab bar? Dropdown?
+
+---
+
+### 2. File Grouping / Workspaces
+
+Group related files together for quick access.
+
+**Possible approaches:**
+
+**A. Simple sidebar with groups**
+```
+┌──────────┬─────────────────────────────────┐
+│ Groups   │                                 │
+│          │   [Rendered Markdown Content]   │
+│ ▼ Project│                                 │
+│   spec.md│                                 │
+│   api.md │                                 │
+│   arch.md│                                 │
+│          │                                 │
+│ ▼ Notes  │                                 │
+│   todo.md│                                 │
+│   ideas  │                                 │
+│          │                                 │
+│ [+ Group]│                                 │
+└──────────┴─────────────────────────────────┘
+```
+
+- User creates named groups
+- Drag files into groups
+- Click a file to open it in a tab
+- Groups persist between sessions
+
+**B. Workspace files**
+- A `.specdown-workspace` file (JSON) that lists file paths and groups
+- Open a workspace to restore all files and groups
+- Can share workspace files with collaborators
+
+**C. Recent files + favorites**
+- Simpler: just track recently opened files and let users star/favorite specific ones
+- No explicit grouping, but still gives quick access
+
+**Recommendation:** Start with **C (recent + favorites)** as the MVP, evolve toward **A (sidebar groups)** if it proves useful. B is nice but adds complexity early.
+
+---
+
+### 3. Persistent Storage
+
+Today, only the theme preference survives a page reload. The desktop version should remember more.
+
+**What to persist:**
+- Open files (paths + tab order)
+- Last active tab
+- Scroll positions per file
+- View mode per file (raw/preview)
+- Window size and position
+- Theme preference
+- Recent files list
+- File groups / favorites
+- Sidebar collapsed/expanded state
+
+**Storage options by framework:**
+
+| Data | Tauri | Electron | Swift |
+|---|---|---|---|
+| App preferences | `tauri-plugin-store` (JSON) | `electron-store` (JSON) | `UserDefaults` |
+| File references | Store file paths | Store file paths | Bookmarks (sandbox-safe) |
+| Window state | Tauri window APIs | `electron-window-state` | `NSWindow` restoration |
+
+**Key consideration:** If distributing via Mac App Store (sandboxed), file access requires security-scoped bookmarks to re-open files across sessions. Tauri and Electron handle this differently than native Swift.
+
+---
+
+### 4. Native File System Integration
+
+Things that are only possible (or much better) as a desktop app:
+
+- **Open from Finder** — register as a handler for `.md` files
+- **File watching** — auto-reload when the file changes on disk (useful when editing in another app)
+- **Open with...** — appear in the macOS "Open With" menu for markdown files
+- **Recents menu** — integrate with macOS File > Open Recent
+- **Drag from Finder** — drag a file from Finder directly onto the app or its Dock icon
+
+---
+
+## Architecture Sketch
+
+Regardless of framework choice, the architecture follows a similar pattern:
+
+```
+┌─────────────────────────────────────────────┐
+│              Desktop Shell                   │
+│  (Tauri / Electron / Swift)                 │
+│                                              │
+│  ┌─────────────────────────────────────┐    │
+│  │           Web Frontend              │    │
+│  │                                     │    │
+│  │  ┌──────────┐  ┌────────────────┐  │    │
+│  │  │ Tab Bar  │  │ Content Area   │  │    │
+│  │  │          │  │                │  │    │
+│  │  │ file1.md │  │ [Rendered MD]  │  │    │
+│  │  │ file2.md │  │ [Diagrams]    │  │    │
+│  │  │ file3.md │  │ [Code blocks] │  │    │
+│  │  └──────────┘  └────────────────┘  │    │
+│  │                                     │    │
+│  │  Existing: Marked + Mermaid +      │    │
+│  │  Panzoom + Highlight.js            │    │
+│  └──────────┬──────────────────────────┘    │
+│             │ Bridge (IPC / JS Bridge)      │
+│  ┌──────────▼──────────────────────────┐    │
+│  │        Native Backend               │    │
+│  │                                     │    │
+│  │  - File system read/watch          │    │
+│  │  - Window management               │    │
+│  │  - Persistent storage              │    │
+│  │  - Native menus & dialogs          │    │
+│  │  - File associations               │    │
+│  └─────────────────────────────────────┘    │
+└─────────────────────────────────────────────┘
+```
+
+**What stays in the web layer:**
+- All markdown/Mermaid rendering (the hard-won diagram interactivity)
+- Theme management (CSS variables still work great)
+- View toggle logic
+- UI layout and styling
+
+**What moves to the native layer:**
+- File reading (replace FileReader API with native FS access)
+- File watching (new)
+- Persistent state management
+- Window/tab lifecycle
+- Menu bar integration
+- File type associations
+
+**Bridge responsibilities (IPC):**
+- `native → web`: "Here's the content of file X", "File X changed on disk", "User clicked Open Recent > file.md"
+- `web → native`: "User wants to open a file", "Save this state", "What files are in group Y?"
+
+---
+
+## What Stays Simple
+
+A few guiding principles to avoid scope creep:
+
+1. **Viewer, not editor** — Specdown shows markdown. It doesn't edit it. Opening the file in your editor of choice stays one click away.
+2. **No project management** — Groups/workspaces are for quick access, not for managing a project. No git integration, no task tracking, no build systems.
+3. **Local only** — No accounts, no cloud sync, no sharing features. Files live on your disk.
+4. **Minimal preferences** — Theme (light/dark) and maybe font size. No deep settings panels.
+5. **Fast startup** — Should open faster than a browser tab, not slower.
+
+---
+
+## Open Questions
+
+- **Which framework?** Need to weigh binary size, dev velocity, and whether cross-platform matters soon.
+- **Tab model or window model?** Multiple tabs in one window (like a browser) or separate windows per file (like Preview.app)? Or both?
+- **File watching scope** — Watch all open files? Only the active tab? Configurable?
+- **How to handle large files?** The web version loads everything into memory. Is there a practical size limit we should handle?
+- **Distribution** — Mac App Store, direct download (.dmg), Homebrew cask, or all three?
+- **Auto-updates** — Important for direct distribution. Less important for App Store.
+- **Keyboard shortcuts** — What's the minimal set? `Cmd+O` (open), `Cmd+W` (close tab), `Cmd+T` (new tab?), `Cmd+1-9` (switch tabs)?
+- **Should the app name change?** "Specdown" vs "Specdown Desktop" vs something else?
+
+---
+
+## Possible MVP Scope
+
+If we were to build a first version, the smallest useful thing might be:
+
+1. Pick a framework (probably Tauri or Electron for speed)
+2. Wrap existing web code as-is in a desktop window
+3. Add native file open dialog (`Cmd+O`)
+4. Add tabbed interface for multiple open files
+5. Persist open tabs + theme between sessions
+6. Register as a `.md` file handler on macOS
+
+That gets us from "web page you have to serve" to "real Mac app that opens markdown files" with minimal new code. Everything else (grouping, file watching, sidebar) can come later.
+
+---
+
+*Last updated: 2026-02-20*


### PR DESCRIPTION
Captures initial thinking on building a native Mac desktop version:
framework options (Tauri, Electron, Swift+WebKit), multi-file tabs,
file grouping, persistent storage, and architecture sketch. Planning
only — no code changes.

https://claude.ai/code/session_01LoJGbXs6YK4EXnevQ8Jwzy