### PR TITLE
Complete session 1 docs: fix SPEC.md layout, add desktop dev instruct…

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,20 @@ All modern browsers with ES6+ support and FileReader API.
 ```
 specdown/
 ├── README.md                    # This file
-└── markdown-viewer/            # Application directory
-    ├── index.html              # Main application page
-    ├── styles.css              # Application styles and theming
-    ├── app.js                  # Core application logic
-    ├── logo.svg                # SpecDown logo (light theme)
-    ├── logo-dark.svg           # SpecDown logo (dark theme)
-    └── favicon.svg             # Browser tab icon
+├── SPEC.md                      # Full product spec
+├── markdown-viewer/             # Web app (shared with desktop)
+│   ├── index.html               # Main application page
+│   ├── styles.css               # Application styles and theming
+│   ├── app.js                   # Core application logic
+│   ├── logo.svg                 # SpecDown logo (light theme)
+│   ├── logo-dark.svg            # SpecDown logo (dark theme)
+│   ├── favicon.svg              # Browser tab icon
+│   └── vendor/                  # Vendored libraries
+├── desktop/                     # Electron shell
+│   ├── main.js                  # Main process
+│   └── preload.js               # IPC bridge stub
+├── tests/                       # Jest test suite
+└── package.json
 ```
 
 ### Technology Stack
@@ -204,11 +211,29 @@ Each Mermaid diagram is automatically enhanced with:
 
 ### Development
 
+#### Running the Desktop App
+
+```bash
+npm run desktop
+```
+
+Launches the Electron window loading the Specdown web app. Requires Node.js and dependencies installed (`npm install`).
+
+#### Running Tests
+
+```bash
+npm test
+```
+
+Runs the full Jest test suite (unit + integration). All tests must pass before committing.
+
 #### Modifying the App
 
-1. **Styling**: Edit `styles.css` for visual changes
-2. **Functionality**: Edit `app.js` for behavior changes
-3. **Structure**: Edit `index.html` for layout changes
+1. **Styling**: Edit `markdown-viewer/styles.css` for visual changes
+2. **Functionality**: Edit `markdown-viewer/app.js` for behavior changes
+3. **Structure**: Edit `markdown-viewer/index.html` for layout changes
+4. **Electron main process**: Edit `desktop/main.js`
+5. **IPC bridge**: Edit `desktop/preload.js`
 
 #### Adding Features
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -114,27 +114,28 @@ Everything the existing web version does must work identically in the desktop ve
 
 ### Same Repo, Shared Code
 
-The desktop version lives in the same repository as the web version. Desktop-specific code is isolated in a `desktop/` directory. The existing `index.html`, `app.js`, `styles.css`, and `vendor/` directory are shared between both versions. The web version's GitHub Pages deployment is completely unaffected.
+The desktop version lives in the same repository as the web version. Desktop-specific code is isolated in a `desktop/` directory. The existing web app (`markdown-viewer/index.html`, `app.js`, `styles.css`, and `vendor/`) is shared between both versions. The web version's GitHub Pages deployment is completely unaffected.
 
 ### Repo Layout
 
 ```
 specdown/
-├── index.html            ← shared (web + desktop frontend)
-├── app.js                ← shared (modified for tab management + IPC)
-├── styles.css            ← shared (extended for tab bar UI)
-├── vendor/               ← shared (Marked, Mermaid, Panzoom, Highlight.js)
-├── tests/                ← existing web tests + new desktop tests
-├── package.json          ← extended with Electron deps + scripts
-├── desktop/              ← NEW: Electron-specific
-│   ├── main.js           ←   Main process (window, menus, file system, persistence)
-│   ├── preload.js        ←   Secure IPC bridge
-│   └── icons/            ←   App icons
+├── markdown-viewer/       ← existing web app (shared with desktop)
+│   ├── index.html         ←   Main application page
+│   ├── app.js             ←   Core app logic (modified for tab management + IPC)
+│   ├── styles.css         ←   Styles (extended for tab bar UI)
+│   └── vendor/            ←   Marked, Mermaid, Panzoom, Highlight.js
+├── desktop/               ← Electron-specific
+│   ├── main.js            ←   Main process (window, menus, file system, persistence)
+│   ├── preload.js         ←   Secure IPC bridge
+│   └── icons/             ←   App icons
+├── tests/                 ← existing web tests + new desktop tests
+├── package.json           ← extended with Electron deps + scripts
 ├── brainstorm.md
 ├── SPEC.md
 └── .github/workflows/
-    ├── static.yml        ← existing: deploys web version to GitHub Pages
-    └── desktop.yml       ← NEW: builds .dmg, attaches to GitHub Releases
+    ├── static.yml         ← existing: deploys web version to GitHub Pages
+    └── desktop.yml        ← NEW: builds .dmg, attaches to GitHub Releases
 ```
 
 ### Process Architecture
@@ -268,5 +269,21 @@ Playwright for Electron for full-app tests:
 - Open Recent menu population
 
 ---
+
+## Implementation Status
+
+| Feature | Status |
+|---|---|
+| Electron shell (`desktop/main.js`, `desktop/preload.js`) | Implemented |
+| Dev loop (`npm run desktop`) | Implemented |
+| Existing Jest test suite passing | Verified |
+| Multi-file tabs | Pending |
+| Native file open (`Cmd+O`) | Pending |
+| File watching | Pending |
+| Persistent state | Pending |
+| Recent files & favorites | Pending |
+| Print & PDF export | Pending |
+| Native macOS menus | Pending |
+| DMG packaging (`electron-builder`) | Pending |
 
 *Last updated: 2026-02-21*


### PR DESCRIPTION
…ions to README

- Fix SPEC.md repo layout to reflect markdown-viewer/ directory structure (files don't live at repo root; they're in markdown-viewer/)
- Update SPEC.md architecture text to reference markdown-viewer/ paths
- Add Implementation Status table to SPEC.md showing Electron shell as done
- Add desktop app launch instructions to README (npm run desktop)
- Add npm test instructions to README Development section
- Update README file structure diagram to include desktop/ and tests/
- Update README Modifying section to reference markdown-viewer/ paths

Tasks 5–7 of TASKS.md complete. Task 4 (manual rendering verification) is assigned to the human developer and will be done on macOS.

https://claude.ai/code/session_01SbwBTq5EsPrbSWm7FEsvgR