### PR TITLE
Restructure desktop app tasks: add DMG packaging and GitHub Releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,11 +213,20 @@ Each Mermaid diagram is automatically enhanced with:
 
 #### Running the Desktop App
 
+The desktop version runs as an Electron app from source. A downloadable `.dmg` is not yet available — that's coming in a future release via GitHub Releases.
+
+**First-time setup:**
 ```bash
-npm run desktop
+cd specdown               # navigate into the project directory
+npm install               # install Electron and all dependencies
 ```
 
-Launches the Electron window loading the Specdown web app. Requires Node.js and dependencies installed (`npm install`).
+**Launch the app:**
+```bash
+npm run desktop           # opens the Specdown Desktop window
+```
+
+Requires Node.js (v18+) installed on your machine.
 
 #### Running Tests
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -42,7 +42,18 @@ Get the existing Specdown web app running inside an Electron window with a worki
 
 ### 4. Verify the web app renders correctly in Electron
 **Who:** Human developer (on a Mac)
-- Run `npm run desktop`
+
+**Prerequisites — run these first:**
+```bash
+cd specdown              # navigate into the project directory
+npm install              # install Electron and all dependencies
+```
+
+**Then launch the app:**
+```bash
+npm run desktop          # opens the Electron window
+```
+
 - Manual verification checklist:
   - [ ] Window opens with "Specdown Desktop" title
   - [ ] Drop zone / file picker UI appears

--- a/TASKS.md
+++ b/TASKS.md
@@ -99,6 +99,30 @@ npm run desktop          # opens the Electron window
 - Update SPEC.md "Current Spec" timestamp
 - Note in SPEC.md which features are now implemented (Electron shell, dev loop) vs. pending
 
+### 8. Set up DMG packaging and GitHub Releases distribution
+**Who:** AI coding agent
+- Configure `electron-builder` in `package.json` for macOS DMG packaging:
+  - App name: "Specdown Desktop"
+  - Bundle ID (e.g. `com.specdown.desktop`)
+  - Set `markdown-viewer/` and `desktop/` as included files
+  - Target: `dmg` for macOS
+  - No code signing or notarization (internal use — users bypass Gatekeeper via right-click > Open)
+- Add npm script: `"desktop:build"` — currently a no-op placeholder, wire it to `electron-builder`
+- Create `.github/workflows/desktop.yml` GitHub Actions workflow:
+  - Trigger: tag push (e.g. `v*-desktop`) or manual `workflow_dispatch`
+  - Runs on `macos-latest`
+  - Steps: checkout, `npm install`, `npm run desktop:build`, upload `.dmg` to GitHub Release
+  - Attach the built `.dmg` as a release asset
+- Update README with download instructions:
+  - "Download the latest `.dmg` from [GitHub Releases](link)"
+  - Note: unsigned app — right-click > Open on first launch
+- Verify the workflow file is valid YAML and references correct paths
+
+**Definition of done for this task:**
+- `npm run desktop:build` produces a `.dmg` file locally (requires macOS)
+- `.github/workflows/desktop.yml` exists and is valid
+- README documents how to download and install the desktop app
+
 ---
 
 ## Definition of Done

--- a/TASKS.md
+++ b/TASKS.md
@@ -40,22 +40,38 @@ Get the existing Specdown web app running inside an Electron window with a worki
 - For now, it just exists so the main process can reference it and the architecture is in place
 - Wire it into `BrowserWindow` webPreferences
 
-### 4. Verify the web app renders correctly in Electron
+### 4. Set up DMG packaging and GitHub Releases distribution
+**Who:** AI coding agent
+- Configure `electron-builder` in `package.json` for macOS DMG packaging:
+  - App name: "Specdown Desktop"
+  - Bundle ID (e.g. `com.specdown.desktop`)
+  - Set `markdown-viewer/` and `desktop/` as included files
+  - Target: `dmg` for macOS
+  - No code signing or notarization (internal use — users bypass Gatekeeper via right-click > Open)
+- Wire the `"desktop:build"` npm script to `electron-builder` (currently a no-op placeholder)
+- Create `.github/workflows/desktop.yml` GitHub Actions workflow:
+  - Trigger: tag push (e.g. `v*`) or manual `workflow_dispatch`
+  - Runs on `macos-latest`
+  - Steps: checkout, `npm install`, `npm run desktop:build`, upload `.dmg` to GitHub Release
+  - Attach the built `.dmg` as a release asset
+- Update README with download instructions:
+  - "Download the latest `.dmg` from GitHub Releases"
+  - Note: unsigned app — right-click > Open on first launch
+- Verify the workflow file is valid YAML and references correct paths
+
+**Definition of done:**
+- `npm run desktop:build` produces a `.dmg` file (requires macOS runner)
+- `.github/workflows/desktop.yml` exists and is valid
+- README documents how to download and install the desktop app
+
+### 5. Verify the desktop app works on macOS
 **Who:** Human developer (on a Mac)
-
-**Prerequisites — run these first:**
-```bash
-cd specdown              # navigate into the project directory
-npm install              # install Electron and all dependencies
-```
-
-**Then launch the app:**
-```bash
-npm run desktop          # opens the Electron window
-```
-
+- **Prerequisite:** Task 4 must be complete — a `.dmg` must be available from GitHub Releases
+- Download the `.dmg` from the GitHub Releases page
+- Open the `.dmg` and drag Specdown Desktop to Applications
+- First launch: right-click > Open to bypass Gatekeeper (unsigned app)
 - Manual verification checklist:
-  - [ ] Window opens with "Specdown Desktop" title
+  - [ ] App launches and window opens with "Specdown Desktop" title
   - [ ] Drop zone / file picker UI appears
   - [ ] Drag-and-drop a `.md` file — renders correctly
   - [ ] Mermaid diagrams render with zoom/pan/fullscreen controls
@@ -64,13 +80,13 @@ npm run desktop          # opens the Electron window
   - [ ] Syntax highlighting works in code blocks
 - Report any rendering differences vs. the browser version
 
-### 5. Verify existing tests still pass
+### 6. Verify existing tests still pass
 **Who:** AI coding agent
 - Run `npm test` — all existing Jest tests must pass
 - Run `npm run test:coverage` — coverage thresholds must still be met
 - No test modifications should be needed (Electron deps shouldn't affect jsdom tests)
 
-### 6. Fix SPEC.md repo layout
+### 7. Fix SPEC.md repo layout
 **Who:** AI coding agent
 - The SPEC.md currently shows `index.html`, `app.js`, `styles.css` at the repo root, but they actually live in `markdown-viewer/`
 - Update the repo layout diagram and any references to match reality:
@@ -91,7 +107,7 @@ npm run desktop          # opens the Electron window
   ```
 - Also update any architecture text that says "shared `index.html`, `app.js`, `styles.css`" to reference `markdown-viewer/` paths
 
-### 7. Update SPEC.md and README based on session results
+### 8. Update SPEC.md and README based on session results
 **Who:** AI coding agent
 - Add a "Development" section to README with:
   - `npm run desktop` — how to launch the desktop app
@@ -99,38 +115,16 @@ npm run desktop          # opens the Electron window
 - Update SPEC.md "Current Spec" timestamp
 - Note in SPEC.md which features are now implemented (Electron shell, dev loop) vs. pending
 
-### 8. Set up DMG packaging and GitHub Releases distribution
-**Who:** AI coding agent
-- Configure `electron-builder` in `package.json` for macOS DMG packaging:
-  - App name: "Specdown Desktop"
-  - Bundle ID (e.g. `com.specdown.desktop`)
-  - Set `markdown-viewer/` and `desktop/` as included files
-  - Target: `dmg` for macOS
-  - No code signing or notarization (internal use — users bypass Gatekeeper via right-click > Open)
-- Add npm script: `"desktop:build"` — currently a no-op placeholder, wire it to `electron-builder`
-- Create `.github/workflows/desktop.yml` GitHub Actions workflow:
-  - Trigger: tag push (e.g. `v*-desktop`) or manual `workflow_dispatch`
-  - Runs on `macos-latest`
-  - Steps: checkout, `npm install`, `npm run desktop:build`, upload `.dmg` to GitHub Release
-  - Attach the built `.dmg` as a release asset
-- Update README with download instructions:
-  - "Download the latest `.dmg` from [GitHub Releases](link)"
-  - Note: unsigned app — right-click > Open on first launch
-- Verify the workflow file is valid YAML and references correct paths
-
-**Definition of done for this task:**
-- `npm run desktop:build` produces a `.dmg` file locally (requires macOS)
-- `.github/workflows/desktop.yml` exists and is valid
-- README documents how to download and install the desktop app
-
 ---
 
 ## Definition of Done
-- `npm run desktop` launches an Electron window showing the Specdown UI
-- All existing `npm test` tests pass with no modifications
 - `desktop/main.js` and `desktop/preload.js` exist
+- `npm run desktop:build` produces a `.dmg` via `electron-builder`
+- `.github/workflows/desktop.yml` publishes the `.dmg` to GitHub Releases
+- Human developer can download the `.dmg`, install, and launch Specdown Desktop
+- All existing `npm test` tests pass with no modifications
 - SPEC.md repo layout matches the actual directory structure
-- README has instructions for running the desktop app
+- README has instructions for both downloading the app and running from source
 
 ## What This Unblocks
 - Session 2 can build on a working Electron shell to add native file open (`Cmd+O`), IPC bridge, and basic menus
@@ -139,6 +133,6 @@ npm run desktop          # opens the Electron window
 ---
 
 ## Notes
-- **Important:** This session does NOT require macOS. The Electron app can be scaffolded and tests verified on any platform. Task 4 (manual rendering verification) is the only Mac-specific step and is assigned to the human developer.
+- **Important:** Development happens in Claude Code cloud (Linux, no GUI). The AI agent handles tasks 1–4, 6–8. Task 5 (manual verification) requires a human on macOS with the `.dmg` from GitHub Releases.
 - The AI agent should not modify `markdown-viewer/app.js`, `styles.css`, or `index.html` in this session. The goal is to wrap the existing code, not change it.
 - If Electron's content security policy blocks loading vendored libraries from local files, the main process may need to configure appropriate CSP headers. Flag this if it happens rather than making sweeping changes.


### PR DESCRIPTION
## Summary
This PR restructures the desktop app development roadmap to introduce a formal packaging and distribution workflow. The key change is inserting a new Task 4 (DMG packaging and GitHub Releases) before manual verification, and renumbering subsequent tasks accordingly. The README is also updated to reflect that a downloadable `.dmg` will be available in the future via GitHub Releases, while documenting the current source-based launch method.

## Key Changes

- **Task restructuring in TASKS.md:**
  - New Task 4: "Set up DMG packaging and GitHub Releases distribution" — configures `electron-builder` for macOS DMG creation and adds a GitHub Actions workflow to automate release builds
  - Renamed Task 4 → Task 5: "Verify the desktop app works on macOS" — now depends on Task 4 and requires downloading the `.dmg` from GitHub Releases instead of running from source
  - Renumbered Tasks 5–7 → Tasks 6–8 accordingly
  - Updated task assignments: Task 4 is AI-driven (packaging setup), Task 5 is human-driven (manual macOS verification)

- **Definition of Done updates:**
  - Added explicit requirements for `.dmg` production and GitHub Releases publishing
  - Clarified that human verification uses the released `.dmg`, not source builds
  - Reordered items to emphasize the distribution workflow

- **README.md updates:**
  - Added "First-time setup" section with `npm install` instructions
  - Clarified that the downloadable `.dmg` is not yet available (future release)
  - Updated launch instructions to reference `npm run desktop` for source-based development
  - Added Node.js version requirement (v18+)

- **Notes section clarification:**
  - Updated to reflect that development happens in Claude Code cloud (Linux, no GUI)
  - Clarified task distribution: AI handles tasks 1–4 and 6–8; human handles Task 5 (macOS verification)

## Notable Details

- The new Task 4 includes specific `electron-builder` configuration requirements (app name, bundle ID, DMG target) and GitHub Actions workflow setup (tag-based triggers, macOS runner, release asset upload)
- Task 5 now includes a prerequisite check and explicit Gatekeeper bypass instructions (right-click > Open) for unsigned apps
- The README now distinguishes between future distribution (via `.dmg` from GitHub Releases) and current development (from source)

https://claude.ai/code/session_01TfGd541LEQoJkRqXTSrrp1