### PR TITLE
Set up DMG packaging and GitHub Releases distribution (TASKS.md #4)

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -1,0 +1,37 @@
+name: Build Desktop App
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  build-dmg:
+    runs-on: macos-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build DMG
+        run: npm run desktop:build
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload DMG to GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*.dmg

--- a/README.md
+++ b/README.md
@@ -209,11 +209,23 @@ Each Mermaid diagram is automatically enhanced with:
 - Reset view if performance degrades
 - Simplify diagram if rendering is slow
 
+### Desktop App (macOS)
+
+#### Download
+
+Download the latest `.dmg` from [GitHub Releases](../../releases).
+
+> **Note:** The app is unsigned. On first launch, right-click the app and select **Open** to bypass Gatekeeper. Alternatively, run `xattr -cr /Applications/Specdown\ Desktop.app` after installing.
+
+#### Install
+
+1. Open the downloaded `.dmg`
+2. Drag **Specdown Desktop** to your Applications folder
+3. Right-click > **Open** on first launch
+
 ### Development
 
-#### Running the Desktop App
-
-The desktop version runs as an Electron app from source. A downloadable `.dmg` is not yet available — that's coming in a future release via GitHub Releases.
+#### Running the Desktop App from Source
 
 **First-time setup:**
 ```bash
@@ -224,6 +236,11 @@ npm install               # install Electron and all dependencies
 **Launch the app:**
 ```bash
 npm run desktop           # opens the Specdown Desktop window
+```
+
+**Build the DMG locally (macOS only):**
+```bash
+npm run desktop:build     # produces a .dmg in dist/
 ```
 
 Requires Node.js (v18+) installed on your machine.

--- a/SPEC.md
+++ b/SPEC.md
@@ -284,6 +284,6 @@ Playwright for Electron for full-app tests:
 | Recent files & favorites | Pending |
 | Print & PDF export | Pending |
 | Native macOS menus | Pending |
-| DMG packaging (`electron-builder`) | Pending |
+| DMG packaging (`electron-builder`) | Configured (awaiting macOS build) |
 
 *Last updated: 2026-02-21*

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "desktop/main.js",
   "scripts": {
     "desktop": "electron .",
-    "desktop:build": "echo 'Packaging not yet configured'",
+    "desktop:build": "electron-builder --mac dmg",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
@@ -55,6 +55,25 @@
     "setupFilesAfterEnv": [
       "<rootDir>/tests/setup.js"
     ]
+  },
+  "build": {
+    "appId": "com.specdown.desktop",
+    "productName": "Specdown Desktop",
+    "directories": {
+      "output": "dist"
+    },
+    "files": [
+      "desktop/**/*",
+      "markdown-viewer/**/*",
+      "package.json"
+    ],
+    "mac": {
+      "target": "dmg",
+      "category": "public.app-category.developer-tools"
+    },
+    "dmg": {
+      "title": "Specdown Desktop"
+    }
   },
   "dependencies": {
     "@highlightjs/cdn-assets": "^11.9.0",


### PR DESCRIPTION
Configure electron-builder for macOS DMG builds, add GitHub Actions
workflow to build and publish .dmg on tag push, and document download
instructions in README.

https://claude.ai/code/session_01DJrQ4JTKg56J6JFesmpUX9