### PR TITLE
Fix desktop GitHub Action failing due to missing package-lock.json

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -20,10 +20,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Build DMG
         run: npm run desktop:build


### PR DESCRIPTION
This fixes the DMG GitHub actions build failure