### PR TITLE
Automate DMG builds on version bump and improve release docs

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -5,9 +5,18 @@ on:
     tags:
       - 'v*'
   workflow_dispatch:
+  workflow_run:
+    workflows: ["Bump version on merge"]
+    types:
+      - completed
 
 jobs:
   build-dmg:
+    # Run on tag push, manual dispatch, or when version-bump succeeds
+    if: >
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
     runs-on: macos-latest
     permissions:
       contents: write
@@ -15,6 +24,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine release tag
+        id: get_tag
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          else
+            TAG=$(git describe --tags --abbrev=0)
+            echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -30,7 +51,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload DMG to GitHub Release
-        if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ steps.get_tag.outputs.tag }}
           files: dist/*.dmg

--- a/README.md
+++ b/README.md
@@ -223,6 +223,34 @@ Download the latest `.dmg` from [GitHub Releases](../../releases).
 2. Drag **Specdown Desktop** to your Applications folder
 3. Right-click > **Open** on first launch
 
+### Releasing
+
+The release pipeline is fully automated. Every merge to `main` triggers the following sequence:
+
+1. **Version Bump** -- The "Bump version on merge" workflow runs `npm version patch`, creating a new version commit and git tag (e.g., `v0.0.46`), then pushes both to `main`.
+2. **DMG Build** -- The "Build Desktop App" workflow detects the version bump, checks out the tagged code on a macOS runner, and runs `npm run desktop:build` to produce a `.dmg`.
+3. **GitHub Release** -- The DMG is uploaded to a GitHub Release matching the new tag. The release is created automatically if it does not already exist.
+4. **Web Deploy** -- Simultaneously, the "Deploy static content" workflow deploys the latest web app to GitHub Pages.
+
+#### Downloading the DMG
+
+Go to the repository's [Releases page](../../releases) and download the `.dmg` file from the latest release.
+
+#### Manually Triggering a Build
+
+If the automated build did not run (or you need to rebuild):
+
+1. Go to **Actions** > **Build Desktop App** in the repository.
+2. Click **Run workflow** and select the `main` branch.
+3. The workflow will build a DMG and attach it to the most recent tag's release.
+
+#### Building a DMG Locally (macOS only)
+
+```bash
+npm install
+npm run desktop:build    # produces a .dmg in dist/
+```
+
 ### Development
 
 #### Running the Desktop App from Source


### PR DESCRIPTION
## Summary
This PR enhances the release pipeline by automating DMG builds when versions are bumped, and adds comprehensive documentation for the release process.

## Key Changes

**Workflow Improvements:**
- Added `workflow_run` trigger to "Build Desktop App" workflow so it automatically runs after the "Bump version on merge" workflow completes
- Added conditional logic to run the build job on tag pushes, manual dispatch, or successful version bump completion
- Implemented dynamic tag detection that works for both direct tag pushes and workflow-triggered builds
- Removed the tag-only restriction from the DMG upload step, allowing uploads from any trigger type using the dynamically determined tag

**Documentation:**
- Added comprehensive "Releasing" section to README covering the full automated release pipeline
- Documented the 4-step release sequence: version bump → DMG build → GitHub release → web deploy
- Added instructions for manually downloading DMGs from the Releases page
- Added steps for manually triggering builds via GitHub Actions
- Added local build instructions for macOS developers

## Implementation Details
The workflow now uses `git describe --tags --abbrev=0` to determine the most recent tag when the build is triggered by the version bump workflow, ensuring the DMG is correctly associated with the new version even when not directly triggered by a tag push event.

https://claude.ai/code/session_01Tg3SzYJDJehmML9g1cuCHC