### PR TITLE
Support GitHub Enterprise URLs and add credentials to fetch requests

### DIFF
--- a/markdown-viewer/app.js
+++ b/markdown-viewer/app.js
@@ -310,10 +310,23 @@ function handleFile(file) {
 // URL Loading
 // ===========================
 function normalizeMarkdownUrl(url) {
-    const githubBlobPattern = /^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/blob\/(.+)$/;
+    // Match GitHub-style blob URLs on any host (supports github.com and GitHub Enterprise)
+    // Pattern: https://<host>/<owner>/<repo>/blob/<ref>/<path>
+    const githubBlobPattern = /^(https?):\/\/([^/]+)\/([^/]+)\/([^/]+)\/blob\/(.+)$/;
     const match = url.match(githubBlobPattern);
     if (match) {
-        return 'https://raw.githubusercontent.com/' + match[1] + '/' + match[2] + '/' + match[3];
+        var protocol = match[1];
+        var host = match[2];
+        var owner = match[3];
+        var repo = match[4];
+        var rest = match[5];
+
+        // github.com uses a dedicated raw content host
+        if (host === 'github.com') {
+            return 'https://raw.githubusercontent.com/' + owner + '/' + repo + '/' + rest;
+        }
+        // GitHub Enterprise uses /raw/ instead of /blob/ on the same host
+        return protocol + '://' + host + '/' + owner + '/' + repo + '/raw/' + rest;
     }
     return url;
 }
@@ -355,7 +368,7 @@ async function handleUrl(url) {
     const filename = getFilenameFromUrl(url);
 
     try {
-        const response = await fetch(fetchUrl);
+        const response = await fetch(fetchUrl, { credentials: 'include' });
         if (!response.ok) {
             showUrlError('Failed to fetch URL: HTTP ' + response.status);
             return;

--- a/tests/unit/urlHandling.test.js
+++ b/tests/unit/urlHandling.test.js
@@ -47,6 +47,24 @@ describe('URL Handling', () => {
       const expected = 'https://raw.githubusercontent.com/user/repo/main/file.md';
       expect(normalizeMarkdownUrl(input)).toBe(expected);
     });
+
+    it('converts a GitHub Enterprise blob URL to a raw URL on the same host', () => {
+      const input = 'https://github.linkedin.com/linkedin-multiproduct/scout-docs/blob/master/docs/intro.md';
+      const expected = 'https://github.linkedin.com/linkedin-multiproduct/scout-docs/raw/master/docs/intro.md';
+      expect(normalizeMarkdownUrl(input)).toBe(expected);
+    });
+
+    it('preserves the protocol for GitHub Enterprise http URLs', () => {
+      const input = 'http://git.internal.company.com/team/project/blob/develop/README.md';
+      const expected = 'http://git.internal.company.com/team/project/raw/develop/README.md';
+      expect(normalizeMarkdownUrl(input)).toBe(expected);
+    });
+
+    it('converts a GitHub Enterprise blob URL with a deep path', () => {
+      const input = 'https://github.corp.net/org/repo/blob/feature/src/docs/spec.md';
+      const expected = 'https://github.corp.net/org/repo/raw/feature/src/docs/spec.md';
+      expect(normalizeMarkdownUrl(input)).toBe(expected);
+    });
   });
 
   // ===========================
@@ -107,7 +125,8 @@ describe('URL Handling', () => {
       await handleUrl('https://raw.githubusercontent.com/user/repo/main/README.md');
 
       expect(global.fetch).toHaveBeenCalledWith(
-        'https://raw.githubusercontent.com/user/repo/main/README.md'
+        'https://raw.githubusercontent.com/user/repo/main/README.md',
+        { credentials: 'include' }
       );
 
       // Content area should be visible (tab was created)
@@ -124,7 +143,22 @@ describe('URL Handling', () => {
       await handleUrl('https://github.com/user/repo/blob/main/spec.md');
 
       expect(global.fetch).toHaveBeenCalledWith(
-        'https://raw.githubusercontent.com/user/repo/main/spec.md'
+        'https://raw.githubusercontent.com/user/repo/main/spec.md',
+        { credentials: 'include' }
+      );
+    });
+
+    it('auto-converts a GitHub Enterprise blob URL and fetches with credentials', async () => {
+      global.fetch.mockImplementation(() => Promise.resolve({
+        ok: true,
+        text: () => Promise.resolve('# Enterprise Doc'),
+      }));
+
+      await handleUrl('https://github.linkedin.com/org/repo/blob/master/docs/intro.md');
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://github.linkedin.com/org/repo/raw/master/docs/intro.md',
+        { credentials: 'include' }
       );
     });
 


### PR DESCRIPTION
## Summary
This PR extends URL handling to support GitHub Enterprise instances in addition to github.com, and adds credential support to fetch requests for authenticated access.

## Key Changes
- **Enhanced URL normalization**: Updated `normalizeMarkdownUrl()` to support GitHub Enterprise blob URLs on custom hosts (e.g., `github.linkedin.com`, `git.internal.company.com`)
  - Regex pattern now captures protocol and host separately to handle any GitHub-style instance
  - github.com continues to use the dedicated `raw.githubusercontent.com` host
  - GitHub Enterprise instances use `/raw/` on the same host instead of `/blob/`
  - Preserves both HTTPS and HTTP protocols

- **Added credential support**: Updated `handleUrl()` to include `{ credentials: 'include' }` in fetch requests
  - Enables authentication for private repositories and enterprise instances
  - Allows cookies and credentials to be sent with cross-origin requests

## Implementation Details
- The regex pattern now captures 5 groups: `(protocol)://(host)/(owner)/(repo)/blob/(ref/path)`
- Host-specific logic determines the appropriate raw content URL format
- All existing tests updated to expect credentials parameter in fetch calls
- Added comprehensive test coverage for GitHub Enterprise URLs with various host formats and branch names

https://claude.ai/code/session_01W5NM1bM7rjbzmP92G3w6ai