### PR TITLE
Add enterprise auth warning note to URL opener

### DIFF
--- a/markdown-viewer/index.html
+++ b/markdown-viewer/index.html
@@ -65,6 +65,7 @@
                         <button id="open-url-btn">Open</button>
                     </div>
                     <p id="url-error" class="url-error" style="display: none;"></p>
+                    <p class="url-note">Note: Some enterprise GitHub instances may require authentication and won't load here.</p>
                 </div>
             </div>
             <div class="drop-zone-overlay">

--- a/markdown-viewer/styles.css
+++ b/markdown-viewer/styles.css
@@ -294,6 +294,14 @@ body {
     max-width: 420px;
 }
 
+.url-note {
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+    text-align: center;
+    margin-top: 0.25rem;
+    opacity: 0.75;
+}
+
 .drop-zone-overlay {
     display: none;
     position: absolute;


### PR DESCRIPTION
Some enterprise GitHub instances require authentication that
prevents cross-origin fetches from working. This adds a subtle
note below the URL input to set expectations.

https://claude.ai/code/session_01AryBAK92S9xpg5cD2YeZtT