### PR TITLE
Trigger downstream workflows with --ref main instead of tag

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -106,9 +106,9 @@ jobs:
       - name: Trigger desktop build
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh workflow run desktop.yml --ref "${{ steps.tag.outputs.tag }}"
+        run: gh workflow run desktop.yml --ref main
 
       - name: Trigger static deploy
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh workflow run static.yml --ref "${{ steps.tag.outputs.tag }}"
+        run: gh workflow run static.yml --ref main


### PR DESCRIPTION
The github-pages environment has deployment branch restrictions that only allow deployments from main, not from tags. Using --ref v0.0.59 caused the static deploy to fail with "Tag is not allowed to deploy to github-pages". The desktop build also works correctly with --ref main since its get_tag step uses git describe --tags to find the latest tag.

https://claude.ai/code/session_01JqW3shoqZC6oKhnNAdwWBU