### PR TITLE
docs: add "Not Built Yet" cross-project snapshot to docs/README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,3 +22,9 @@ YYYY-MM-DD-<type>-<detail>.md
 - `brainstorm` — pre-code exploration, problem framing, framework comparisons
 - `spec` — technical specification (version new files for major revisions, e.g. `spec-desktop-v2.md`)
 - `tasks` — session-level implementation checklists (one file per working session, numbered)
+
+## Not Built Yet (Current Cross-Project Snapshot)
+
+- **Desktop (`project-desktop`)**: No remaining features in the current Session 1–4 scope.
+- **URL opening (`project-url`)**: Inline reviewer comments (Google Docs-style) are still unimplemented and intentionally deferred from Session 01.
+- **iOS/iPad (`project-ios`)**: Still in brainstorming (no implementation yet); next major milestones are authoring `spec-ios-v1` and executing Session 01 setup tasks.


### PR DESCRIPTION
### Motivation
- Clarify the current implementation status across projects in `docs/README.md` so readers can see which features are implemented or intentionally deferred.

### Description
- Add a `Not Built Yet (Current Cross-Project Snapshot)` section to `docs/README.md` that notes the status of `project-desktop`, `project-url`, and `project-ios`.

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab978583a883248e958ce1c1507116)