### PR TITLE
Reveal HTML comments as visible styled blocks in markdown preview

### DIFF
--- a/markdown-viewer/app.js
+++ b/markdown-viewer/app.js
@@ -558,6 +558,9 @@ async function renderMarkdown(content, filename) {
         fileName.textContent = filename;
         markdownContent.innerHTML = htmlContent;
 
+        // Make HTML comments visible
+        revealHtmlComments(markdownContent);
+
         // Show content area, hide drop zone
         dropZone.style.display = 'none';
         contentArea.style.display = 'flex';
@@ -587,6 +590,33 @@ async function renderMarkdown(content, filename) {
         console.error('Error rendering markdown:', error);
         alert('Error rendering markdown content. Please check the file format.');
     }
+}
+
+// ===========================
+// HTML Comment Reveal
+// ===========================
+function revealHtmlComments(container) {
+    // Walk the DOM and replace comment nodes with visible styled blocks
+    const walker = document.createTreeWalker(
+        container,
+        NodeFilter.SHOW_COMMENT,
+        null
+    );
+
+    const commentNodes = [];
+    while (walker.nextNode()) {
+        commentNodes.push(walker.currentNode);
+    }
+
+    commentNodes.forEach((node) => {
+        const text = node.nodeValue.trim();
+        if (!text) return;
+
+        const block = document.createElement('div');
+        block.className = 'html-comment-block';
+        block.textContent = text;
+        node.parentNode.replaceChild(block, node);
+    });
 }
 
 // ===========================

--- a/markdown-viewer/styles.css
+++ b/markdown-viewer/styles.css
@@ -563,6 +563,17 @@ body {
     height: auto;
 }
 
+.markdown-content .html-comment-block {
+    background-color: var(--bg-secondary);
+    border-left: 3px solid var(--text-secondary);
+    padding: 0.75em 1em;
+    margin-bottom: 1em;
+    color: var(--text-secondary);
+    font-size: 0.9em;
+    white-space: pre-wrap;
+    border-radius: 0 4px 4px 0;
+}
+
 /* ===========================
    Raw Markdown View
    =========================== */


### PR DESCRIPTION
HTML comments (<!-- -->) are hidden by browsers, making documents with instructional content inside comments appear empty. This adds a post-render step that converts comment nodes into visible, styled blocks so all file content is readable in the preview.

https://claude.ai/code/session_012gGPAtG73yfPjmxD2W5x9j