### PR TITLE
Desktop: reference-counted file watching, native open handling, and tests

### DIFF
--- a/markdown-viewer/app.js
+++ b/markdown-viewer/app.js
@@ -21,6 +21,7 @@ let tabs = [];         // Array of { id, filename, filePath, rawMarkdown, viewMo
 let activeTabId = null;
 let nextTabId = 0;
 const MAX_TABS = 10;
+const watchRefCounts = new Map(); // filePath -> number of watching tabs
 
 // Desktop detection
 const isDesktop = !!(typeof window !== 'undefined' && window.specdown && window.specdown.isDesktop);
@@ -213,10 +214,19 @@ function updateViewToggleButton() {
 // Event Listeners
 // ===========================
 function setupEventListeners() {
+    function requestNativeOpenIfDesktop() {
+        if (isDesktop && window.specdown && window.specdown.requestFileOpen) {
+            window.specdown.requestFileOpen();
+            return true;
+        }
+        return false;
+    }
+
     // Browse button - stopPropagation prevents the dropZone click handler
     // from calling fileInput.click() a second time (button is inside drop-zone-content)
     browseButton.addEventListener('click', (e) => {
         e.stopPropagation();
+        if (requestNativeOpenIfDesktop()) return;
         fileInput.click();
     });
 
@@ -227,6 +237,7 @@ function setupEventListeners() {
     dropZone.addEventListener('click', (e) => {
         if (e.target.closest && e.target.closest('.url-section')) return;
         if (e.target === dropZone || e.target.closest('.drop-zone-content')) {
+            if (requestNativeOpenIfDesktop()) return;
             fileInput.click();
         }
     });
@@ -400,7 +411,7 @@ function handleFile(file) {
     const reader = new FileReader();
     reader.onload = (e) => {
         const content = e.target.result;
-        createTab(file.name, content);
+        createTab(file.name, content, file.path || null);
     };
     reader.onerror = () => {
         alert('Error reading file. Please try again.');
@@ -1209,6 +1220,10 @@ function renderTabBar() {
     const newTabBtn = tabBar.querySelector('.tab-new');
     if (newTabBtn) {
         newTabBtn.addEventListener('click', () => {
+            if (isDesktop && window.specdown && window.specdown.requestFileOpen) {
+                window.specdown.requestFileOpen();
+                return;
+            }
             fileInput.click();
         });
     }
@@ -1231,10 +1246,14 @@ function createTab(filename, content, filePath) {
         rawMarkdown: content,
         viewMode: 'preview',
         scrollTop: 0,
-        watching: false
+        watching: !!(isDesktop && filePath)
     };
     tabs.push(tab);
     activeTabId = id;
+
+    if (tab.watching) {
+        startWatchingFilePath(tab.filePath);
+    }
 
     renderTabBar();
     if (isDesktop) {
@@ -1284,7 +1303,7 @@ async function closeTab(id) {
 
     // Stop watching before removing the tab
     if (isDesktop && closedTab.watching && closedTab.filePath) {
-        window.specdown.unwatchFile(closedTab.filePath);
+        stopWatchingFilePath(closedTab.filePath);
     }
 
     if (wasActive) {
@@ -1351,6 +1370,30 @@ function updateWatchToggle() {
     }
 }
 
+function startWatchingFilePath(filePath) {
+    if (!isDesktop || !filePath || !window.specdown || !window.specdown.watchFile) return;
+
+    const currentCount = watchRefCounts.get(filePath) || 0;
+    watchRefCounts.set(filePath, currentCount + 1);
+
+    if (currentCount === 0) {
+        window.specdown.watchFile(filePath);
+    }
+}
+
+function stopWatchingFilePath(filePath) {
+    if (!isDesktop || !filePath || !window.specdown || !window.specdown.unwatchFile) return;
+
+    const currentCount = watchRefCounts.get(filePath) || 0;
+    if (currentCount <= 1) {
+        watchRefCounts.delete(filePath);
+        window.specdown.unwatchFile(filePath);
+        return;
+    }
+
+    watchRefCounts.set(filePath, currentCount - 1);
+}
+
 function toggleWatching() {
     if (!isDesktop) return;
     const tab = activeTabId !== null ? tabs.find(t => t.id === activeTabId) : null;
@@ -1359,9 +1402,9 @@ function toggleWatching() {
     tab.watching = !tab.watching;
 
     if (tab.watching) {
-        window.specdown.watchFile(tab.filePath);
+        startWatchingFilePath(tab.filePath);
     } else {
-        window.specdown.unwatchFile(tab.filePath);
+        stopWatchingFilePath(tab.filePath);
     }
 
     renderTabBar();

--- a/tests/unit/desktopRenderer.test.js
+++ b/tests/unit/desktopRenderer.test.js
@@ -1,0 +1,66 @@
+/**
+ * Unit tests for desktop-only renderer behavior in app.js
+ */
+
+const { loadHTML, loadApp } = require('../helpers/loadApp');
+require('../mocks/marked');
+require('../mocks/mermaid');
+require('../mocks/panzoom');
+require('../mocks/highlightjs');
+
+describe('Desktop renderer integration', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    window.specdown = {
+      isDesktop: true,
+      requestFileOpen: jest.fn(),
+      watchFile: jest.fn(),
+      unwatchFile: jest.fn(),
+      onFileOpened: jest.fn(),
+      onCloseTab: jest.fn(),
+      onFileChanged: jest.fn(),
+      onTriggerPrint: jest.fn(),
+      onTriggerSearch: jest.fn(),
+      onApplyCustomCss: jest.fn(),
+      saveSession: jest.fn(),
+    };
+
+    loadHTML(document);
+    loadApp(document);
+  });
+
+  afterEach(() => {
+    delete window.specdown;
+  });
+
+  it('uses native dialog on desktop when clicking Browse', () => {
+    const browseButton = document.getElementById('browse-button');
+    const fileInput = document.getElementById('file-input');
+    fileInput.click = jest.fn();
+
+    browseButton.dispatchEvent(new Event('click', { bubbles: true }));
+
+    expect(window.specdown.requestFileOpen).toHaveBeenCalledTimes(1);
+    expect(fileInput.click).not.toHaveBeenCalled();
+  });
+
+  it('auto-enables file watching for desktop file tabs and reference-counts duplicate paths', async () => {
+    createTab('one.md', '# One', '/tmp/one.md');
+    expect(window.specdown.watchFile).toHaveBeenCalledTimes(1);
+    expect(window.specdown.watchFile).toHaveBeenCalledWith('/tmp/one.md');
+
+    // Same file opened in another tab should not register a duplicate main-process watcher
+    createTab('one.md', '# One again', '/tmp/one.md');
+    expect(window.specdown.watchFile).toHaveBeenCalledTimes(1);
+
+    const firstTabId = tabs[0].id;
+    const secondTabId = tabs[1].id;
+
+    await closeTab(firstTabId);
+    expect(window.specdown.unwatchFile).not.toHaveBeenCalled();
+
+    await closeTab(secondTabId);
+    expect(window.specdown.unwatchFile).toHaveBeenCalledTimes(1);
+    expect(window.specdown.unwatchFile).toHaveBeenCalledWith('/tmp/one.md');
+  });
+});


### PR DESCRIPTION
### Motivation
- Improve desktop behavior to avoid duplicate native file watchers when the same file is opened in multiple tabs. 
- Use the native open dialog on desktop builds for a more integrated UX instead of always triggering the DOM file picker. 
- Add unit tests to verify desktop IPC interactions and watcher reference counting. 

### Description
- Introduce `watchRefCounts` `Map` and helper functions `startWatchingFilePath` and `stopWatchingFilePath` to reference-count calls to `window.specdown.watchFile`/`unwatchFile`. 
- Auto-enable watching for tabs created from local file paths by setting `watching` when `isDesktop` and `filePath` are present and call `startWatchingFilePath` on creation. 
- Replace direct `window.specdown.watchFile`/`unwatchFile` calls with the new helpers in `toggleWatching` and when closing tabs to ensure proper bookkeeping. 
- Integrate native open invocation by adding `requestNativeOpenIfDesktop` and using it for the `Browse` button, drop-zone click, and new-tab button to call `window.specdown.requestFileOpen` on desktop. 

### Testing
- Added `tests/unit/desktopRenderer.test.js` which mocks `window.specdown` and asserts that the native open is used and that watch/unwatch are reference-counted; the test suite ran and passed. 
- Ran the unit tests via Jest for the new desktop tests and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf9ba3dd108324a4e7943f3275d4e6)