### PR TITLE
Harden desktop: fix recent files, hot reload, silent startup failures

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, Menu, dialog, ipcMain, globalShortcut } = require('electron');
+const { app, BrowserWindow, Menu, dialog, ipcMain, globalShortcut, shell } = require('electron');
 const path = require('path');
 const fs = require('fs');
 const chokidar = require('chokidar');
@@ -8,24 +8,93 @@ const MAX_RECENT_FILES = 15;
 
 let mainWindow = null;
 let store = null;
+let logFilePath = null;
 
 // Queue files requested before the window is ready (e.g. Finder double-click on launch)
 let pendingFilePaths = [];
 
 // ===========================
-// Store (electron-store)
+// Logging
 // ===========================
-async function initStore() {
-  // electron-store v11+ is ESM-only, so we use dynamic import
-  const { default: Store } = await import('electron-store');
-  store = new Store({
-    name: 'specdown-state',
-    defaults: {
-      recentFiles: [],
-      windowBounds: { width: 1200, height: 800 },
-      session: { tabs: [] },
+// Writes to a user-accessible log file so silent failures in packaged builds
+// (ASAR + ESM dynamic imports, missing native bindings, etc.) are recoverable.
+function initLogFile() {
+  try {
+    const userData = app.getPath('userData');
+    if (!fs.existsSync(userData)) {
+      fs.mkdirSync(userData, { recursive: true });
+    }
+    logFilePath = path.join(userData, 'specdown-main.log');
+  } catch (_) {
+    // Can't establish a log file — fall back to console only.
+    logFilePath = null;
+  }
+}
+
+function logError(msg, err) {
+  const detail = err && err.stack ? err.stack : String(err || '');
+  const line = `[${new Date().toISOString()}] ${msg}: ${detail}\n`;
+  // eslint-disable-next-line no-console
+  console.error(line);
+  if (logFilePath) {
+    try {
+      fs.appendFileSync(logFilePath, line);
+    } catch (_) {
+      // Swallow — logging must never crash the app.
+    }
+  }
+}
+
+// ===========================
+// Store (simple JSON persistence)
+// ===========================
+// Replaces electron-store v11, which is ESM-only and has a history of
+// silently failing to load in packaged ASAR builds (breaking recent files
+// and session restore). A tiny synchronous JSON file in userData is simpler,
+// has no native deps, and is trivially debuggable.
+function initStore() {
+  const defaults = {
+    recentFiles: [],
+    windowBounds: { width: 1200, height: 800 },
+    session: { tabs: [] },
+    customCssPath: '',
+  };
+
+  let statePath;
+  try {
+    statePath = path.join(app.getPath('userData'), 'specdown-state.json');
+  } catch (err) {
+    logError('Failed to resolve userData path; persistence disabled', err);
+    store = null;
+    return;
+  }
+
+  let data = { ...defaults };
+  try {
+    if (fs.existsSync(statePath)) {
+      const raw = fs.readFileSync(statePath, 'utf8');
+      const parsed = JSON.parse(raw);
+      data = { ...defaults, ...parsed };
+    }
+  } catch (err) {
+    logError('Failed to load state file; starting with defaults', err);
+  }
+
+  const write = () => {
+    try {
+      fs.writeFileSync(statePath, JSON.stringify(data, null, 2));
+    } catch (err) {
+      logError('Failed to write state file', err);
+    }
+  };
+
+  store = {
+    get: (key, fallback) => (Object.prototype.hasOwnProperty.call(data, key) ? data[key] : fallback),
+    set: (key, value) => {
+      data[key] = value;
+      write();
     },
-  });
+  };
 }
 
 function getRecentFiles() {
@@ -33,6 +102,17 @@ function getRecentFiles() {
 }
 
 function addRecentFile(filePath) {
+  // Feed the native OS recent-documents list (macOS Dock, Windows jump list).
+  // This is independent of our own persistent store so it still works even if
+  // JSON persistence is broken.
+  if (typeof app.addRecentDocument === 'function') {
+    try {
+      app.addRecentDocument(filePath);
+    } catch (err) {
+      logError('app.addRecentDocument failed', err);
+    }
+  }
+
   if (!store) return;
   let recent = store.get('recentFiles', []);
   recent = recent.filter((p) => p !== filePath);
@@ -154,27 +234,56 @@ async function showOpenDialog() {
 // File Watching
 // ===========================
 
-// Map of filePath → chokidar FSWatcher
+// Map of filePath → chokidar FSWatcher.
+//
+// Why we watch the parent directory instead of the file itself:
+// Most modern editors (VSCode, vim, Sublime, JetBrains) save atomically —
+// they write a temp file and rename it over the target. Renaming changes
+// the inode, and chokidar's single-file watch follows the inode, so the
+// watcher goes dead after the first save. Watching the parent directory
+// with a basename filter sidesteps this entirely and is robust against
+// unlink → add sequences.
+//
+// We also don't capture `webContents` in the change closure anymore:
+// if the renderer is reloaded (View > Reload), the captured reference
+// becomes stale. Instead we look up `mainWindow.webContents` lazily.
 const watchers = new Map();
 
-function watchFile(filePath, webContents) {
+function watchFile(filePath, _webContents) {
   if (watchers.has(filePath)) return; // already watching
 
-  const watcher = chokidar.watch(filePath, {
+  const dir = path.dirname(filePath);
+  const basename = path.basename(filePath);
+
+  const watcher = chokidar.watch(dir, {
     persistent: true,
     ignoreInitial: true,
+    depth: 0, // Only the directory itself, not subdirs.
     awaitWriteFinish: { stabilityThreshold: 300, pollInterval: 100 },
   });
 
-  watcher.on('change', () => {
+  const handleEvent = (eventPath) => {
+    // chokidar may pass a full path or just a basename depending on platform.
+    const eventBase = eventPath ? path.basename(eventPath) : '';
+    if (eventBase && eventBase !== basename) return;
+
     try {
       const fileData = readMarkdownFile(filePath);
-      if (webContents && !webContents.isDestroyed()) {
-        webContents.send('file-changed', fileData);
+      const target = mainWindow && mainWindow.webContents;
+      if (target && !target.isDestroyed()) {
+        target.send('file-changed', fileData);
       }
     } catch (err) {
-      console.error('Failed to re-read watched file:', filePath, err);
+      logError(`Failed to re-read watched file: ${filePath}`, err);
     }
+  };
+
+  // 'change' covers in-place edits; 'add' covers the post-rename inode of an
+  // atomic-save, which chokidar sees as the "new" file appearing.
+  watcher.on('change', handleEvent);
+  watcher.on('add', handleEvent);
+  watcher.on('error', (err) => {
+    logError(`Watcher error for ${filePath}`, err);
   });
 
   watchers.set(filePath, watcher);
@@ -411,6 +520,41 @@ function buildMenu() {
         ]),
       ],
     },
+    // Help menu — diagnostics live here so issues are reportable.
+    {
+      label: 'Help',
+      submenu: [
+        {
+          label: 'Open Log File',
+          click: () => {
+            if (!logFilePath) {
+              dialog.showMessageBox({
+                type: 'info',
+                message: 'No log file has been created yet.',
+              });
+              return;
+            }
+            // Ensure the file exists so the OS doesn't refuse to open it.
+            try {
+              if (!fs.existsSync(logFilePath)) {
+                fs.writeFileSync(logFilePath, '');
+              }
+              shell.openPath(logFilePath);
+            } catch (err) {
+              logError('Failed to open log file', err);
+            }
+          },
+        },
+        {
+          label: 'Show Log File In Folder',
+          click: () => {
+            if (logFilePath && fs.existsSync(logFilePath)) {
+              shell.showItemInFolder(logFilePath);
+            }
+          },
+        },
+      ],
+    },
   ];
 
   const menu = Menu.buildFromTemplate(template);
@@ -424,28 +568,57 @@ function rebuildMenu() {
 // ===========================
 // App Lifecycle
 // ===========================
-app.whenReady().then(async () => {
-  await initStore();
-  buildMenu();
-  createWindow();
-
-  // Global shortcut: Cmd+Shift+M brings SpecDown to front and prompts open
-  globalShortcut.register('CommandOrControl+Shift+M', () => {
-    if (!mainWindow) {
-      createWindow();
-    } else {
-      if (mainWindow.isMinimized()) mainWindow.restore();
-      mainWindow.focus();
-      showOpenDialog();
-    }
-  });
-
-  app.on('activate', () => {
-    if (BrowserWindow.getAllWindows().length === 0) {
-      createWindow();
-    }
-  });
+// Catch-all: surface any unhandled error in the main process so silent
+// failures become visible (log + optional dialog once we have one).
+process.on('uncaughtException', (err) => {
+  logError('uncaughtException', err);
 });
+process.on('unhandledRejection', (reason) => {
+  logError('unhandledRejection', reason);
+});
+
+// IIFE instead of `app.whenReady().then(...)` so we can await, catch, and
+// surface startup errors. Previously a rejection anywhere in the startup
+// chain (e.g. electron-store ESM import failure in a packaged build) was
+// swallowed silently — which is exactly how recent files and session
+// restore "never worked" in shipped DMGs.
+(async () => {
+  try {
+    await app.whenReady();
+
+    initLogFile();
+    initStore();
+    buildMenu();
+    createWindow();
+
+    // Global shortcut: Cmd+Shift+M brings SpecDown to front and prompts open
+    globalShortcut.register('CommandOrControl+Shift+M', () => {
+      if (!mainWindow) {
+        createWindow();
+      } else {
+        if (mainWindow.isMinimized()) mainWindow.restore();
+        mainWindow.focus();
+        showOpenDialog();
+      }
+    });
+
+    app.on('activate', () => {
+      if (BrowserWindow.getAllWindows().length === 0) {
+        createWindow();
+      }
+    });
+  } catch (err) {
+    logError('Startup failed', err);
+    try {
+      dialog.showErrorBox(
+        'SpecDown failed to start',
+        String(err && err.message ? err.message : err)
+      );
+    } catch (_) {
+      // Dialog may not be available yet — the log line above is our fallback.
+    }
+  }
+})();
 
 app.on('will-quit', () => {
   globalShortcut.unregisterAll();

--- a/package.json
+++ b/package.json
@@ -62,6 +62,11 @@
       "markdown-viewer/**/*",
       "package.json"
     ],
+    "asarUnpack": [
+      "node_modules/chokidar/**",
+      "node_modules/fsevents/**",
+      "**/*.node"
+    ],
     "mac": {
       "target": "dmg",
       "category": "public.app-category.developer-tools"

--- a/tests/unit/desktop-main.test.js
+++ b/tests/unit/desktop-main.test.js
@@ -21,24 +21,42 @@ jest.mock('chokidar', () => ({
 jest.mock('electron', () => ({
   app: {
     name: 'Specdown Desktop',
+    // A thenable whose `then` never resolves — the IIFE in main.js awaits
+    // this, so its body stays suspended during tests and we can exercise
+    // the exported pure functions in isolation.
     whenReady: jest.fn(() => ({ then: jest.fn() })),
     on: jest.fn(),
     quit: jest.fn(),
+    getPath: jest.fn(() => '/tmp/specdown-test-userdata'),
+    addRecentDocument: jest.fn(),
   },
-  BrowserWindow: jest.fn(() => ({
-    loadFile: jest.fn(),
-    webContents: { on: jest.fn(), send: jest.fn() },
-    on: jest.fn(),
-  })),
+  BrowserWindow: Object.assign(
+    jest.fn(() => ({
+      loadFile: jest.fn(),
+      webContents: { on: jest.fn(), send: jest.fn() },
+      on: jest.fn(),
+    })),
+    { getAllWindows: jest.fn(() => []) }
+  ),
   Menu: {
     buildFromTemplate: jest.fn((template) => template),
     setApplicationMenu: jest.fn(),
   },
   dialog: {
     showOpenDialog: jest.fn(),
+    showErrorBox: jest.fn(),
+    showMessageBox: jest.fn(),
   },
   ipcMain: {
     on: jest.fn(),
+  },
+  globalShortcut: {
+    register: jest.fn(),
+    unregisterAll: jest.fn(),
+  },
+  shell: {
+    openPath: jest.fn(),
+    showItemInFolder: jest.fn(),
   },
 }));
 
@@ -156,6 +174,17 @@ describe('desktop/main.js', () => {
       expect(template.find(m => m.label === 'View')).toBeDefined();
       expect(template.find(m => m.label === 'Window')).toBeDefined();
     });
+
+    it('includes a Help menu with Open Log File', () => {
+      buildMenu();
+      const template = Menu.buildFromTemplate.mock.calls[0][0];
+      const helpMenu = template.find(m => m.label === 'Help');
+      expect(helpMenu).toBeDefined();
+
+      const openLog = helpMenu.submenu.find(item => item.label === 'Open Log File');
+      expect(openLog).toBeDefined();
+      expect(typeof openLog.click).toBe('function');
+    });
   });
 
   describe('IPC handlers', () => {
@@ -195,13 +224,16 @@ describe('desktop/main.js', () => {
     });
 
     describe('watchFile', () => {
-      it('creates a chokidar watcher for the given path', () => {
+      it('creates a chokidar watcher for the parent directory of the file', () => {
         const mockWebContents = { isDestroyed: jest.fn(() => false), send: jest.fn() };
         watchFile('/path/to/file.md', mockWebContents);
 
-        expect(chokidar.watch).toHaveBeenCalledWith('/path/to/file.md', expect.objectContaining({
+        // We watch the parent dir (not the file) so atomic renames don't
+        // orphan the watcher on the old inode.
+        expect(chokidar.watch).toHaveBeenCalledWith('/path/to', expect.objectContaining({
           persistent: true,
           ignoreInitial: true,
+          depth: 0,
         }));
         expect(watchers.has('/path/to/file.md')).toBe(true);
       });
@@ -215,24 +247,30 @@ describe('desktop/main.js', () => {
         expect(watchers.size).toBe(1);
       });
 
-      it('registers a change handler on the watcher', () => {
+      it('registers change, add, and error handlers on the watcher', () => {
         const mockWatcher = { on: jest.fn().mockReturnThis(), close: jest.fn() };
         chokidar.watch.mockReturnValue(mockWatcher);
         const mockWebContents = { isDestroyed: jest.fn(() => false), send: jest.fn() };
 
         watchFile('/path/to/file.md', mockWebContents);
 
-        expect(mockWatcher.on).toHaveBeenCalledWith('change', expect.any(Function));
+        // 'change' for in-place edits; 'add' catches atomic saves (where the
+        // editor replaces the file via rename and chokidar sees it as a new
+        // add event on the post-rename inode).
+        const registeredEvents = mockWatcher.on.mock.calls.map((call) => call[0]);
+        expect(registeredEvents).toContain('change');
+        expect(registeredEvents).toContain('add');
+        expect(registeredEvents).toContain('error');
       });
 
       it('can watch multiple different paths', () => {
         const mockWebContents = { isDestroyed: jest.fn(() => false), send: jest.fn() };
         watchFile('/path/to/a.md', mockWebContents);
-        watchFile('/path/to/b.md', mockWebContents);
+        watchFile('/other/dir/b.md', mockWebContents);
 
         expect(watchers.size).toBe(2);
         expect(watchers.has('/path/to/a.md')).toBe(true);
-        expect(watchers.has('/path/to/b.md')).toBe(true);
+        expect(watchers.has('/other/dir/b.md')).toBe(true);
       });
     });
 


### PR DESCRIPTION
## Summary

Three targeted fixes for long-standing "never worked in the packaged DMG" issues — recent files, hot reload (file watching), and silent startup failures — plus a diagnostics surface so future issues are reportable.

### 1. Recent files / session restore
- **Replaced `electron-store` v11** (ESM-only, silently fragile inside a packaged ASAR) with a ~30-line sync JSON store in `app.getPath('userData')`. Same `.get/.set` API, no native deps, trivially debuggable.
- Also calls `app.addRecentDocument(filePath)` so the native macOS Dock "Recent Items" integration works alongside our custom menu.

### 2. Hot reload (file watching)
- **Watch the parent directory** with `depth: 0` and basename filter instead of the file itself. Editors that save atomically (VSCode, vim, Sublime, JetBrains) replace files via rename, which changes the inode and kills chokidar's single-file watch after one save. Directory watching survives the rename.
- Added an `add` handler so the post-rename inode fires a reload too, plus an `error` handler for debuggability.
- Dropped the captured `webContents` closure — `mainWindow.webContents` is now read lazily so `View > Reload` doesn't orphan the listener.
- **`asarUnpack`** for `node_modules/chokidar/**`, `node_modules/fsevents/**`, and `**/*.node`. Native `.node` bindings cannot load from inside an ASAR archive, which is almost certainly why watching never worked in the shipped DMG.

### 3. Diagnostics / silent failures
- Log file at `userData/specdown-main.log` with an `initLogFile` / `logError` helper.
- `process.on('uncaughtException' / 'unhandledRejection')` handlers.
- Startup switched from `app.whenReady().then(...)` (which swallows rejections — exactly how `electron-store` failures disappeared) to a `try/catch` IIFE that surfaces errors via `dialog.showErrorBox`.
- New **Help menu** with `Open Log File` and `Show Log File In Folder`.

### What was intentionally left out
- **Code signing / notarization** — still the biggest "works locally, broken in DMG" lever, but needs Apple Developer credentials in CI secrets. Recommended as the next session.
- **Playwright end-to-end test** — bigger lift; worth a dedicated session.
- `electron-store` is still in `dependencies` (unused) to avoid churning the lockfile.

## Test plan

- [x] `npm test` — 279/279 passing, including new cases for parent-dir watching, `change`/`add`/`error` handler registration, and the new Help menu
- [ ] Smoke test on macOS: `npm run desktop`, open a file, edit + save in VSCode, verify the preview reloads (previously died after one save)
- [ ] Smoke test on macOS: open a file, quit, relaunch — verify `Open Recent` submenu shows the file
- [ ] Smoke test on macOS: open the DMG build (`npm run desktop:build`) and repeat the two checks above — this is the surface where everything was silently failing
- [ ] Verify `Help > Open Log File` opens `~/Library/Application Support/Specdown Desktop/specdown-main.log`
- [ ] Deliberately break something in startup (e.g. throw in `initStore`) and confirm a `dialog.showErrorBox` appears instead of a silent no-op

https://claude.ai/code/session_017m98bD1DT1BbYwJRaDxvug