### PR TITLE
Follow-up to #73: atomic state writes, watcher dedup, openPath handling

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -80,11 +80,23 @@ function initStore() {
     logError('Failed to load state file; starting with defaults', err);
   }
 
+  // Atomic write: write to a sibling temp file, then rename over the target.
+  // Rename is atomic on POSIX + NTFS, so a crash/kill mid-write can never
+  // leave `specdown-state.json` truncated — the worst case is a leftover
+  // `.tmp` file that gets overwritten on the next successful write.
   const write = () => {
+    const tempPath = `${statePath}.tmp`;
     try {
-      fs.writeFileSync(statePath, JSON.stringify(data, null, 2));
+      fs.writeFileSync(tempPath, JSON.stringify(data, null, 2));
+      fs.renameSync(tempPath, statePath);
     } catch (err) {
       logError('Failed to write state file', err);
+      // Best-effort cleanup of the temp file so it doesn't accumulate.
+      try {
+        if (fs.existsSync(tempPath)) fs.unlinkSync(tempPath);
+      } catch (_) {
+        // Swallow — we've already logged the real failure.
+      }
     }
   };
 
@@ -234,8 +246,6 @@ async function showOpenDialog() {
 // File Watching
 // ===========================
 
-// Map of filePath → chokidar FSWatcher.
-//
 // Why we watch the parent directory instead of the file itself:
 // Most modern editors (VSCode, vim, Sublime, JetBrains) save atomically —
 // they write a temp file and rename it over the target. Renaming changes
@@ -244,10 +254,18 @@ async function showOpenDialog() {
 // with a basename filter sidesteps this entirely and is robust against
 // unlink → add sequences.
 //
-// We also don't capture `webContents` in the change closure anymore:
-// if the renderer is reloaded (View > Reload), the captured reference
-// becomes stale. Instead we look up `mainWindow.webContents` lazily.
-const watchers = new Map();
+// Why we share one chokidar watcher per directory across files:
+// Opening several tabs from the same folder shouldn't create redundant
+// OS-level watches. `dirWatchers` holds one watcher per directory; each
+// entry maintains a `files` map (basename → full filePath) so incoming
+// events can be routed to the right tab. The exported `watchers` map
+// stays keyed by filePath for external API compatibility.
+//
+// We also don't capture `webContents` in the event closure anymore: if
+// the renderer is reloaded (View > Reload), a captured reference becomes
+// stale. Instead we look up `mainWindow.webContents` lazily at event time.
+const watchers = new Map();          // filePath → { dir }
+const dirWatchers = new Map();       // dir → { watcher, files: Map<basename, filePath> }
 
 function watchFile(filePath, _webContents) {
   if (watchers.has(filePath)) return; // already watching
@@ -255,45 +273,67 @@ function watchFile(filePath, _webContents) {
   const dir = path.dirname(filePath);
   const basename = path.basename(filePath);
 
-  const watcher = chokidar.watch(dir, {
-    persistent: true,
-    ignoreInitial: true,
-    depth: 0, // Only the directory itself, not subdirs.
-    awaitWriteFinish: { stabilityThreshold: 300, pollInterval: 100 },
-  });
+  let dirEntry = dirWatchers.get(dir);
+  if (!dirEntry) {
+    const files = new Map();
 
-  const handleEvent = (eventPath) => {
-    // chokidar may pass a full path or just a basename depending on platform.
-    const eventBase = eventPath ? path.basename(eventPath) : '';
-    if (eventBase && eventBase !== basename) return;
+    const handleEvent = (eventPath) => {
+      // chokidar may pass a full path or just a basename depending on platform.
+      const eventBase = eventPath ? path.basename(eventPath) : '';
+      const target = files.get(eventBase);
+      if (!target) return;
 
-    try {
-      const fileData = readMarkdownFile(filePath);
-      const target = mainWindow && mainWindow.webContents;
-      if (target && !target.isDestroyed()) {
-        target.send('file-changed', fileData);
+      try {
+        const fileData = readMarkdownFile(target);
+        const wc = mainWindow && mainWindow.webContents;
+        if (wc && !wc.isDestroyed()) {
+          wc.send('file-changed', fileData);
+        }
+      } catch (err) {
+        logError(`Failed to re-read watched file: ${target}`, err);
       }
-    } catch (err) {
-      logError(`Failed to re-read watched file: ${filePath}`, err);
-    }
-  };
+    };
 
-  // 'change' covers in-place edits; 'add' covers the post-rename inode of an
-  // atomic-save, which chokidar sees as the "new" file appearing.
-  watcher.on('change', handleEvent);
-  watcher.on('add', handleEvent);
-  watcher.on('error', (err) => {
-    logError(`Watcher error for ${filePath}`, err);
-  });
+    const watcher = chokidar.watch(dir, {
+      persistent: true,
+      ignoreInitial: true,
+      depth: 0, // Only the directory itself, not subdirs.
+      awaitWriteFinish: { stabilityThreshold: 300, pollInterval: 100 },
+    });
 
-  watchers.set(filePath, watcher);
+    // 'change' covers in-place edits; 'add' covers the post-rename inode
+    // of an atomic-save, which chokidar sees as a "new" file appearing.
+    watcher.on('change', handleEvent);
+    watcher.on('add', handleEvent);
+    watcher.on('error', (err) => {
+      logError(`Watcher error for ${dir}`, err);
+    });
+
+    dirEntry = { watcher, files };
+    dirWatchers.set(dir, dirEntry);
+  }
+
+  dirEntry.files.set(basename, filePath);
+  watchers.set(filePath, { dir });
 }
 
 function unwatchFile(filePath) {
-  const watcher = watchers.get(filePath);
-  if (watcher) {
-    watcher.close();
-    watchers.delete(filePath);
+  const entry = watchers.get(filePath);
+  if (!entry) return;
+
+  watchers.delete(filePath);
+
+  const dirEntry = dirWatchers.get(entry.dir);
+  if (!dirEntry) return;
+
+  dirEntry.files.delete(path.basename(filePath));
+  if (dirEntry.files.size === 0) {
+    try {
+      dirEntry.watcher.close();
+    } catch (err) {
+      logError(`Failed to close watcher for ${entry.dir}`, err);
+    }
+    dirWatchers.delete(entry.dir);
   }
 }
 
@@ -539,7 +579,17 @@ function buildMenu() {
               if (!fs.existsSync(logFilePath)) {
                 fs.writeFileSync(logFilePath, '');
               }
-              shell.openPath(logFilePath);
+              // shell.openPath returns Promise<string>: '' on success, an
+              // error message string on failure. Both arms need handling.
+              shell.openPath(logFilePath)
+                .then((result) => {
+                  if (result) {
+                    logError('Failed to open log file', new Error(result));
+                  }
+                })
+                .catch((err) => {
+                  logError('Failed to open log file', err);
+                });
             } catch (err) {
               logError('Failed to open log file', err);
             }

--- a/tests/unit/desktop-main.test.js
+++ b/tests/unit/desktop-main.test.js
@@ -218,8 +218,10 @@ describe('desktop/main.js', () => {
     });
 
     afterEach(() => {
-      // Clean up any watchers created during tests
-      watchers.forEach((watcher) => watcher.close());
+      // Route cleanup through unwatchFile so the internal dirWatchers
+      // map also gets cleared between tests (entries in `watchers` are
+      // metadata, not chokidar watchers).
+      [...watchers.keys()].forEach((filePath) => unwatchFile(filePath));
       watchers.clear();
     });
 
@@ -272,6 +274,17 @@ describe('desktop/main.js', () => {
         expect(watchers.has('/path/to/a.md')).toBe(true);
         expect(watchers.has('/other/dir/b.md')).toBe(true);
       });
+
+      it('reuses a single chokidar watcher for files in the same directory', () => {
+        const mockWebContents = { isDestroyed: jest.fn(() => false), send: jest.fn() };
+        watchFile('/shared/dir/a.md', mockWebContents);
+        watchFile('/shared/dir/b.md', mockWebContents);
+
+        // One OS-level watch on the parent dir serves both files.
+        expect(chokidar.watch).toHaveBeenCalledTimes(1);
+        expect(chokidar.watch).toHaveBeenCalledWith('/shared/dir', expect.any(Object));
+        expect(watchers.size).toBe(2);
+      });
     });
 
     describe('unwatchFile', () => {
@@ -287,6 +300,25 @@ describe('desktop/main.js', () => {
 
         expect(mockWatcher.close).toHaveBeenCalledTimes(1);
         expect(watchers.has('/path/to/file.md')).toBe(false);
+      });
+
+      it('keeps the shared dir watcher alive while other files in it are watched', () => {
+        const mockWatcher = { on: jest.fn().mockReturnThis(), close: jest.fn() };
+        chokidar.watch.mockReturnValue(mockWatcher);
+        const mockWebContents = { isDestroyed: jest.fn(() => false), send: jest.fn() };
+
+        watchFile('/shared/dir/a.md', mockWebContents);
+        watchFile('/shared/dir/b.md', mockWebContents);
+
+        unwatchFile('/shared/dir/a.md');
+        // One file in /shared/dir is still being watched, so the underlying
+        // chokidar watcher must stay open.
+        expect(mockWatcher.close).not.toHaveBeenCalled();
+        expect(watchers.has('/shared/dir/b.md')).toBe(true);
+
+        unwatchFile('/shared/dir/b.md');
+        // Last file gone → watcher closes.
+        expect(mockWatcher.close).toHaveBeenCalledTimes(1);
       });
 
       it('does nothing if the path is not being watched', () => {


### PR DESCRIPTION
Follow-up to cbremer/specdown#73 addressing the three Copilot review comments that landed after the merge.

## Summary

### 1. Atomic writes for `specdown-state.json`
Previously `fs.writeFileSync` wrote directly to the target file — a crash or kill mid-write could leave the preferences file truncated and silently lose recent files / session state. Now writes go to a sibling `.tmp` file and are then `renameSync`-ed over the target. Rename is atomic on POSIX + NTFS, so the worst-case is a stray `.tmp` file that gets cleaned up on the next write.

### 2. Deduplicate chokidar watchers by directory
Opening multiple tabs from the same folder was creating redundant OS-level watches — each file got its own chokidar watcher on the same parent directory. New internal `dirWatchers` map shares one watcher per directory, with a `files` map (basename → full filePath) for event routing. Refcount is implicit in `files.size`: when the last file in a directory is unwatched, the shared watcher closes.

### 3. Handle `shell.openPath` return value
`shell.openPath` returns `Promise<string>` — empty string means success, a non-empty string is the error message. The result was being ignored, so a failed `Help > Open Log File` would silently no-op. Now both branches route through `logError`.

## Test plan

- [x] `npm test` — 281/281 passing (up from 279)
  - New: `reuses a single chokidar watcher for files in the same directory`
  - New: `keeps the shared dir watcher alive while other files in it are watched`
  - Fixed: `afterEach` cleanup now routes through `unwatchFile` since `watchers` map entries are metadata, not chokidar watcher handles
- [ ] Manual: open two markdown files from the same folder, edit + save one, verify only that tab reloads
- [ ] Manual: open two markdown files from the same folder, close one tab, verify the other still hot-reloads
- [ ] Manual: kill the app while a state write is in flight (e.g. during rapid session changes) and verify `specdown-state.json` is still parseable on next launch

https://claude.ai/code/session_017m98bD1DT1BbYwJRaDxvug