### PR TITLE
Make watched-file auto-reload visible (scroll preserve + pulse + tab dot)

### DIFF
--- a/markdown-viewer/app.js
+++ b/markdown-viewer/app.js
@@ -1189,9 +1189,14 @@ function renderTabBar() {
     let html = '';
     for (const tab of tabs) {
         const isActive = tab.id === activeTabId;
-        html += `<div class="tab${isActive ? ' tab-active' : ''}" data-tab-id="${tab.id}">`;
+        const hasChanges = !!tab.hasUnseenChanges;
+        const classes = ['tab'];
+        if (isActive) classes.push('tab-active');
+        if (hasChanges) classes.push('tab-has-changes');
+        html += `<div class="${classes.join(' ')}" data-tab-id="${tab.id}">`;
         if (tab.watching) {
-            html += `<span class="tab-watching-dot" title="Watching for changes"></span>`;
+            const dotTitle = hasChanges ? 'File changed on disk' : 'Watching for changes';
+            html += `<span class="tab-watching-dot" title="${dotTitle}"></span>`;
         }
         html += `<span class="tab-filename">${escapeHtml(tab.filename)}</span>`;
         html += `<button class="tab-close" data-close-id="${tab.id}" title="Close tab">×</button>`;
@@ -1246,7 +1251,8 @@ function createTab(filename, content, filePath) {
         rawMarkdown: content,
         viewMode: 'preview',
         scrollTop: 0,
-        watching: !!(isDesktop && filePath)
+        watching: !!(isDesktop && filePath),
+        hasUnseenChanges: false
     };
     tabs.push(tab);
     activeTabId = id;
@@ -1270,6 +1276,9 @@ async function switchTab(id) {
     activeTabId = id;
     const tab = tabs.find(t => t.id === id);
     if (!tab) return;
+
+    // Clear the "unseen changes" flag now that the user is looking at it.
+    tab.hasUnseenChanges = false;
 
     renderTabBar();
     if (isDesktop) updateWatchToggle();
@@ -1370,6 +1379,29 @@ function updateWatchToggle() {
     }
 }
 
+// Briefly animate the watch toggle to signal that an auto-reload just
+// happened. Without this, the reload is invisible if the user happens
+// not to be looking at the content area when the disk write lands.
+let watchTogglePulseTimer = null;
+function pulseWatchToggle() {
+    if (!watchToggle) return;
+    watchToggle.classList.remove('reloaded');
+    // Force reflow so re-adding the class restarts the animation even
+    // when multiple reloads happen in quick succession.
+    // eslint-disable-next-line no-unused-expressions
+    void watchToggle.offsetWidth;
+    watchToggle.classList.add('reloaded');
+    watchToggle.title = 'Reloaded from disk';
+
+    if (watchTogglePulseTimer) clearTimeout(watchTogglePulseTimer);
+    watchTogglePulseTimer = setTimeout(() => {
+        watchToggle.classList.remove('reloaded');
+        // Restore the state-appropriate tooltip.
+        updateWatchToggle();
+        watchTogglePulseTimer = null;
+    }, 1200);
+}
+
 function startWatchingFilePath(filePath) {
     if (!isDesktop || !filePath || !window.specdown || !window.specdown.watchFile) return;
 
@@ -1425,7 +1457,7 @@ function setupDesktopIPC() {
     });
 
     // Listen for file-changed events (watched file updated on disk)
-    window.specdown.onFileChanged(function(fileData) {
+    window.specdown.onFileChanged(async function(fileData) {
         const tab = tabs.find(t => t.filePath === fileData.filePath);
         if (!tab) return;
 
@@ -1433,6 +1465,10 @@ function setupDesktopIPC() {
         tab.filename = fileData.filename;
 
         if (tab.id === activeTabId) {
+            // Preserve scroll position across the re-render so an
+            // auto-reload doesn't yank the user back to the top.
+            const savedScrollTop = markdownContent.scrollTop;
+
             if (tab.viewMode === 'raw') {
                 currentRawMarkdown = fileData.content;
                 const escaped = fileData.content
@@ -1440,9 +1476,20 @@ function setupDesktopIPC() {
                     .replace(/</g, '&lt;')
                     .replace(/>/g, '&gt;');
                 markdownContent.innerHTML = `<pre class="raw-markdown"><code>${escaped}</code></pre>`;
+                markdownContent.scrollTop = savedScrollTop;
             } else {
-                renderMarkdown(fileData.content, fileData.filename);
+                await renderMarkdown(fileData.content, fileData.filename);
+                markdownContent.scrollTop = savedScrollTop;
             }
+
+            // Visual feedback that an auto-reload happened — otherwise
+            // the user has no way to tell the content just changed.
+            pulseWatchToggle();
+        } else {
+            // Background tab: flag it so the user sees that something
+            // changed when they come back to it.
+            tab.hasUnseenChanges = true;
+            renderTabBar();
         }
     });
 

--- a/markdown-viewer/styles.css
+++ b/markdown-viewer/styles.css
@@ -397,6 +397,20 @@ body {
 .watch-toggle-icon {
     font-size: 1rem;
     line-height: 1;
+    display: inline-block;
+}
+
+/* Reload feedback: briefly spin + scale the watch icon so the user
+   sees that an auto-reload just happened. The JS strips the class
+   after ~1.2s. */
+@keyframes watch-toggle-pulse {
+    0%   { transform: rotate(0deg)   scale(1);    opacity: 1; }
+    40%  { transform: rotate(180deg) scale(1.25); opacity: 0.75; }
+    100% { transform: rotate(360deg) scale(1);    opacity: 1; }
+}
+
+.watch-toggle-button.reloaded .watch-toggle-icon {
+    animation: watch-toggle-pulse 900ms ease-out;
 }
 
 .tab-watching-dot {
@@ -406,6 +420,19 @@ body {
     background-color: #27ae60;
     border-radius: 50%;
     flex-shrink: 0;
+    transition: background-color 0.2s ease;
+}
+
+/* Background tab whose file changed on disk since the user last looked
+   at it. Amber dot + subtle pulse draws the eye without being noisy. */
+.tab.tab-has-changes .tab-watching-dot {
+    background-color: #f59e0b;
+    animation: tab-changed-pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes tab-changed-pulse {
+    0%, 100% { opacity: 1;   transform: scale(1);    }
+    50%      { opacity: 0.45; transform: scale(1.35); }
 }
 
 .view-toggle-button {

--- a/tests/unit/desktopRenderer.test.js
+++ b/tests/unit/desktopRenderer.test.js
@@ -63,4 +63,36 @@ describe('Desktop renderer integration', () => {
     expect(window.specdown.unwatchFile).toHaveBeenCalledTimes(1);
     expect(window.specdown.unwatchFile).toHaveBeenCalledWith('/tmp/one.md');
   });
+
+  it('flags background tabs whose watched file changed on disk, clearing on focus', async () => {
+    // Register the onFileChanged callback that app.js wired up during init.
+    const fileChangedCallback = window.specdown.onFileChanged.mock.calls[0][0];
+    expect(typeof fileChangedCallback).toBe('function');
+
+    createTab('a.md', '# A', '/tmp/a.md');
+    createTab('b.md', '# B', '/tmp/b.md');
+
+    // Tab b is now active; deliver a file-changed event for tab a.
+    const backgroundTab = tabs.find(t => t.filePath === '/tmp/a.md');
+    const activeTab = tabs.find(t => t.filePath === '/tmp/b.md');
+    expect(activeTabId).toBe(activeTab.id);
+
+    await fileChangedCallback({
+      filename: 'a.md',
+      filePath: '/tmp/a.md',
+      content: '# A (updated)',
+    });
+
+    // Background tab should be flagged and its DOM element should carry
+    // the change indicator class so the user sees something changed.
+    expect(backgroundTab.hasUnseenChanges).toBe(true);
+    const backgroundEl = document.querySelector(`.tab[data-tab-id="${backgroundTab.id}"]`);
+    expect(backgroundEl.classList.contains('tab-has-changes')).toBe(true);
+
+    // Switching to the background tab should clear the flag.
+    await switchTab(backgroundTab.id);
+    expect(backgroundTab.hasUnseenChanges).toBe(false);
+    const refreshedEl = document.querySelector(`.tab[data-tab-id="${backgroundTab.id}"]`);
+    expect(refreshedEl.classList.contains('tab-has-changes')).toBe(false);
+  });
 });


### PR DESCRIPTION
Third and final follow-up to cbremer/specdown#73 / cbremer/specdown#74. After those PRs, auto-reload on watched files actually *works* — but it works silently. This PR makes the reload visible.

## The problem

After #73/#74, when a watched file changes on disk:
- **Active tab**: content is swapped in-place and `renderMarkdown` scrolls to top, yanking the viewport away from wherever the user was reading.
- **Background tab**: content updates silently in memory with no indicator at all. User comes back and has no idea anything changed.
- **Watch toggle button**: static "watching / not watching" — no signal that a reload happened.

Net effect: the watching feature ships, but most users won't realize it's doing anything.

## Changes

All renderer-side (`markdown-viewer/`), no main-process changes.

### 1. Preserve scroll position across auto-reload
`onFileChanged` now saves `markdownContent.scrollTop` before the async `renderMarkdown` and restores it after. Rapid saves during reading no longer jump the viewport to the top.

### 2. Pulse the watch toggle on active-tab reload
New `pulseWatchToggle()` helper adds a `.reloaded` class for 1.2s, triggering a 900ms rotate+scale CSS animation on the icon and flipping the tooltip to "Reloaded from disk". A forced reflow restarts the animation if reloads overlap.

### 3. Mark background tabs with unseen changes
New `tab.hasUnseenChanges` flag, set when a background tab's file changes, cleared on `switchTab`. The tab-bar dot turns amber (`#f59e0b`) and pulses via `@keyframes tab-changed-pulse`. Follows the standard editor pattern (VSCode, Sublime, etc.).

## Test plan

- [x] `npm test` — 282/282 passing (added 1 new test: background-tab flag set + cleared on focus)
- [ ] Manual: open a file, scroll halfway, edit+save in external editor → viewport stays, watch icon briefly spins
- [ ] Manual: open two files, edit+save the inactive one → inactive tab shows amber pulsing dot; clicking it clears the dot
- [ ] Manual: rapid-fire saves → pulse animation restarts cleanly each time

## Caveats

- Pulse and scroll preservation can't be tested in Jest (jsdom has no layout/animation). Manual smoke test required.
- Branch was merged with `origin/main` to pick up version bumps from v0.0.67 / v0.0.68; diff should still be clean (one feature commit + one merge commit).

https://claude.ai/code/session_017m98bD1DT1BbYwJRaDxvug