### PR TITLE
Clean up desktop deps and add watch polling escape hatch

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install dependencies
         run: npm install
@@ -84,7 +84,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install dependencies
         run: npm install
@@ -128,7 +128,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/setup-node@v4
         if: github.event_name == 'push'
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Configure git
         if: github.event_name == 'push'

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -33,9 +33,22 @@ function initLogFile() {
 
 function logError(msg, err) {
   const detail = err && err.stack ? err.stack : String(err || '');
-  const line = `[${new Date().toISOString()}] ${msg}: ${detail}\n`;
+  const line = `[${new Date().toISOString()}] ERROR ${msg}: ${detail}\n`;
   // eslint-disable-next-line no-console
   console.error(line);
+  if (logFilePath) {
+    try {
+      fs.appendFileSync(logFilePath, line);
+    } catch (_) {
+      // Swallow — logging must never crash the app.
+    }
+  }
+}
+
+function logInfo(msg) {
+  const line = `[${new Date().toISOString()}] INFO  ${msg}\n`;
+  // eslint-disable-next-line no-console
+  console.log(line);
   if (logFilePath) {
     try {
       fs.appendFileSync(logFilePath, line);
@@ -294,11 +307,23 @@ function watchFile(filePath, _webContents) {
       }
     };
 
+    // Escape hatch for users on filesystems where fs.watch is unreliable:
+    // network mounts (SMB/NFS/Dropbox/iCloud Drive), VM shared folders,
+    // certain fuse filesystems. Setting SPECDOWN_WATCH_POLLING=1 forces
+    // chokidar into polling mode at a 500ms interval. CPU cost is small
+    // for a handful of files and it works everywhere.
+    const usePolling = process.env.SPECDOWN_WATCH_POLLING === '1';
+    if (usePolling) {
+      logInfo(`Chokidar polling mode enabled for ${dir} (SPECDOWN_WATCH_POLLING=1)`);
+    }
+
     const watcher = chokidar.watch(dir, {
       persistent: true,
       ignoreInitial: true,
       depth: 0, // Only the directory itself, not subdirs.
       awaitWriteFinish: { stabilityThreshold: 300, pollInterval: 100 },
+      usePolling,
+      interval: usePolling ? 500 : undefined,
     });
 
     // 'change' covers in-place edits; 'add' covers the post-rename inode

--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0"
   },
+  "engines": {
+    "node": ">=22.12"
+  },
   "jest": {
     "testEnvironment": "jsdom",
     "coverageDirectory": "coverage",
@@ -64,7 +67,6 @@
     ],
     "asarUnpack": [
       "node_modules/chokidar/**",
-      "node_modules/fsevents/**",
       "**/*.node"
     ],
     "mac": {
@@ -91,7 +93,6 @@
     "@highlightjs/cdn-assets": "^11.9.0",
     "@panzoom/panzoom": "^4.5.1",
     "chokidar": "^5.0.0",
-    "electron-store": "^11.0.2",
     "marked": "^11.1.1",
     "mermaid": "^10.6.1"
   }

--- a/tests/unit/desktop-main.test.js
+++ b/tests/unit/desktop-main.test.js
@@ -285,6 +285,53 @@ describe('desktop/main.js', () => {
         expect(chokidar.watch).toHaveBeenCalledWith('/shared/dir', expect.any(Object));
         expect(watchers.size).toBe(2);
       });
+
+      describe('SPECDOWN_WATCH_POLLING env var', () => {
+        const originalEnv = process.env.SPECDOWN_WATCH_POLLING;
+
+        afterEach(() => {
+          if (originalEnv === undefined) {
+            delete process.env.SPECDOWN_WATCH_POLLING;
+          } else {
+            process.env.SPECDOWN_WATCH_POLLING = originalEnv;
+          }
+        });
+
+        it('enables chokidar polling when SPECDOWN_WATCH_POLLING=1', () => {
+          process.env.SPECDOWN_WATCH_POLLING = '1';
+          const mockWebContents = { isDestroyed: jest.fn(() => false), send: jest.fn() };
+
+          watchFile('/path/to/file.md', mockWebContents);
+
+          expect(chokidar.watch).toHaveBeenCalledWith('/path/to', expect.objectContaining({
+            usePolling: true,
+            interval: 500,
+          }));
+        });
+
+        it('does not enable polling when the env var is unset', () => {
+          delete process.env.SPECDOWN_WATCH_POLLING;
+          const mockWebContents = { isDestroyed: jest.fn(() => false), send: jest.fn() };
+
+          watchFile('/path/to/file.md', mockWebContents);
+
+          const options = chokidar.watch.mock.calls[0][1];
+          expect(options.usePolling).toBe(false);
+          expect(options.interval).toBeUndefined();
+        });
+
+        it('does not enable polling for other truthy values', () => {
+          // Only the exact string '1' flips the switch — prevents accidental
+          // activation via e.g. `SPECDOWN_WATCH_POLLING=true`.
+          process.env.SPECDOWN_WATCH_POLLING = 'true';
+          const mockWebContents = { isDestroyed: jest.fn(() => false), send: jest.fn() };
+
+          watchFile('/path/to/file.md', mockWebContents);
+
+          const options = chokidar.watch.mock.calls[0][1];
+          expect(options.usePolling).toBe(false);
+        });
+      });
     });
 
     describe('unwatchFile', () => {


### PR DESCRIPTION
## Summary

Follow-up cleanup after the PR #73 / PR #74 desktop hardening work. Removes dead deps/config and adds a watch-mode escape hatch.

- **Remove `electron-store`** — PR #73 replaced it with a sync JSON store, but the dependency was still listed in `package.json` and bundled into the app. Dropped from `dependencies`.
- **Remove dead `node_modules/fsevents/**` from `asarUnpack`** — chokidar 5 went pure-JS and no longer depends on fsevents, so this entry was unpacking nothing.
- **Add `engines.node` = `>=22.12`** — documents the Node version required for chokidar 5's ESM-via-`require()` support (which is how we load it from CommonJS `main.js`).
- **Add `logInfo()` helper** — `logError()` was doing double-duty for non-error events; split into a dedicated info logger with `INFO ` prefix.
- **Add `SPECDOWN_WATCH_POLLING=1` env var** — flips chokidar into polling mode at a 500ms interval. Intended for users on network mounts (SMB/NFS/Dropbox/iCloud Drive), VM shared folders, or fuse filesystems where `fs.watch` is unreliable. Off by default; CPU cost is negligible for a handful of files when enabled.

## Test plan

- [x] `npm test` — 281 tests passing
- [ ] Manual: launch desktop app, open a file, confirm reload still works without the env var
- [ ] Manual: launch with `SPECDOWN_WATCH_POLLING=1`, confirm log line appears in log file and reload still works
- [ ] Manual: confirm nothing broken by `electron-store` removal (session restore on next launch)

https://claude.ai/code/session_017m98bD1DT1BbYwJRaDxvug