### PR TITLE
Add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,3 +5,23 @@ When working with this repo, read and follow `CLAUDE.md` for:
 - Project overview and goals
 - Commands and scripts
 - Coding, testing, and documentation conventions
+
+## Cursor Cloud specific instructions
+
+### Services
+
+| Service | How to run | Notes |
+|---------|-----------|-------|
+| Web app | `cd markdown-viewer && python3 -m http.server 8000` | Static files; no build step needed |
+| Tests | `npm test` | Jest with jsdom; all 285 tests run in ~2s |
+| Desktop (Electron) | `npm run desktop` | Requires display server; not available headless |
+
+### Key notes
+
+- **No linter configured.** There is no ESLint/Prettier setup; skip lint steps.
+- **No lockfile.** The repo has no `package-lock.json`; `npm install` generates one fresh each time.
+- **Node.js >=22.12 required** (specified in `package.json` engines).
+- **Web app is pure static files** — serve `markdown-viewer/` with any HTTP server (e.g. `python3 -m http.server 8000`). No bundler or build step.
+- **Electron desktop app** cannot run in headless Cloud Agent environments (needs a display). Test the shared `markdown-viewer/` code via Jest or the static HTTP server instead.
+- **Coverage thresholds** are not enforced via config, but `npm run test:coverage` will show coverage percentages.
+- To test markdown rendering interactively, inject markdown via JS in the browser console (simulate drag-and-drop with `DragEvent` + `DataTransfer` on `#drop-zone`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` to help future cloud agents quickly understand how to run and test this project in headless environments.

### Changes

- Documents the three main services (web app, tests, Electron desktop) with run commands
- Notes key gotchas: no linter, no lockfile, Node >=22.12 requirement
- Adds tips for interactive testing (markdown injection via JS console)

### Evidence of working environment

[specdown_demo_loading_markdown.mp4](https://cursor.com/agents/bc-8621d154-2871-4fc2-a883-77ca5dcabdc7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fspecdown_demo_loading_markdown.mp4)

Demo of the web app loading markdown content with interactive Mermaid diagrams and syntax-highlighted code.

[SpecDown landing page](https://cursor.com/agents/bc-8621d154-2871-4fc2-a883-77ca5dcabdc7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fspecdown_landing_page.webp)
[Rendered markdown with Mermaid diagram](https://cursor.com/agents/bc-8621d154-2871-4fc2-a883-77ca5dcabdc7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fspecdown_rendered_markdown.webp)

All 285 tests pass:
```
Test Suites: 16 passed, 16 total
Tests:       285 passed, 285 total
```

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8621d154-2871-4fc2-a883-77ca5dcabdc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8621d154-2871-4fc2-a883-77ca5dcabdc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

