### PR TITLE
Add zoom percentage slider, keyboard shortcuts, and touch-friendly controls for Mermaid diagrams; add navigation recommendations doc

### DIFF
--- a/docs/2026-05-25-mermaid-navigation-recommendations.md
+++ b/docs/2026-05-25-mermaid-navigation-recommendations.md
@@ -1,0 +1,101 @@
+# Mermaid navigation recommendations (web + mobile)
+
+## Current state (already in SpecDown)
+
+- Inline and fullscreen Mermaid diagrams already support pan/zoom via Panzoom.
+- Users can zoom with `+/-` buttons, wheel zoom, double-click reset, and fullscreen mode.
+- Fullscreen includes a minimap and reset/download/share controls.
+
+## Priority UX changes to improve readability for large org charts
+
+### 1) Add **explicit zoom percentage + slider** (web + mobile)
+
+- Show current zoom (e.g. `145%`) in both inline and fullscreen control bars.
+- Add a slider (`25%` → `400%`) so users can jump quickly to a readable level.
+- Keep `Reset` as a one-tap return to fit.
+
+Why: users can orient better when they know zoom level and can make predictable jumps.
+
+### 2) Add **tap-friendly control sizing and spacing** (mobile first)
+
+- Increase control button tap targets to at least 44x44 px.
+- Separate destructive/exit actions (close fullscreen) from zoom controls.
+- Keep controls pinned and avoid overlap with diagram content.
+
+Why: current controls are small for dense diagrams on phones and tablets.
+
+### 3) Add **touch gestures in fullscreen**
+
+- Support pinch-to-zoom and one-finger pan as first-class mobile gestures.
+- Add optional two-finger pan mode toggle for accessibility (prevents accidental drags).
+- Add inertial panning for smoother navigation.
+
+Why: mobile users expect map-like interaction for very large diagrams.
+
+### 4) Add **"Focus mode" for text legibility**
+
+- Add a preset action: `Fit Width`, `Fit Height`, `Readable Text`.
+- `Readable Text` auto-zooms until the median node label reaches a target pixel height.
+- Persist last selected preset per session.
+
+Why: org chart pain is usually text size, not only geometry size.
+
+### 5) Improve fullscreen discoverability and onboarding
+
+- Add first-use tooltip: "Pinch or scroll to zoom, drag to pan, double-tap to reset".
+- Add a visible fullscreen hint on each Mermaid card for first-run.
+- Add keyboard hints on desktop (`+`, `-`, `0`, arrows).
+
+Why: features exist today but users may not discover them quickly.
+
+### 6) Add **mini-map interactions**
+
+- Let users drag the minimap viewport rectangle to pan the main diagram.
+- Make minimap optional/collapsible on small screens.
+
+Why: minimap is most useful when it is interactive, especially for huge org graphs.
+
+### 7) Add **search within diagram labels**
+
+- Parse visible text from SVG nodes.
+- Add search box in fullscreen (`Find person/team`).
+- Jump + highlight matched nodes; keep "next/previous match".
+
+Why: navigation by panning alone is slow in deep org structures.
+
+### 8) Add **node emphasis / dimming**
+
+- Tap/click node to focus path (ancestors + descendants highlighted, others dimmed).
+- Optional depth slider to limit visible hierarchy levels.
+
+Why: users can "strengthen" (visually emphasize) relevant parts without redrawing diagram source.
+
+## Web-specific recommendations
+
+1. Add keyboard navigation in fullscreen:
+   - `+` / `-` zoom
+   - `0` reset to fit
+   - Arrow keys pan
+   - `F` toggle fullscreen, `Esc` close
+2. Add right-click context actions on node labels (copy text, center here).
+3. Remember per-diagram viewport state during session when switching tabs.
+
+## Mobile-specific recommendations
+
+1. Open Mermaid diagrams directly into fullscreen on phones by default.
+2. Use bottom-sheet controls to keep top area clear for content.
+3. Add haptic feedback on reset and zoom step actions where available.
+4. Use larger default zoom on initial open for diagrams wider than viewport.
+
+## Technical implementation order
+
+1. **Phase 1 (quick win):** control size, zoom percent, slider, onboarding hints.
+2. **Phase 2:** minimap drag, mobile fullscreen-first behavior, keyboard shortcuts.
+3. **Phase 3:** diagram label search + node emphasis/path highlighting.
+
+## Success metrics
+
+- Time-to-readable-text (first 10 seconds).
+- Number of zoom/pan interactions before user dwell on a target area.
+- Fullscreen usage rate and return rate.
+- Mobile completion rate for "find target role" task in sample org chart.

--- a/markdown-viewer/app.js
+++ b/markdown-viewer/app.js
@@ -735,6 +735,26 @@ function setupEventListeners() {
                 performPrint();
             }
         }
+
+        if (fullscreenOverlay.style.display !== 'none' && fullscreenOverlay.panzoomInstance) {
+            const instance = fullscreenOverlay.panzoomInstance;
+            const controls = fullscreenOverlay.querySelector('.fullscreen-controls');
+            if (e.key === '+' || e.key === '=') {
+                e.preventDefault();
+                instance.zoomIn();
+                updateZoomUI(instance, controls);
+            } else if (e.key === '-') {
+                e.preventDefault();
+                instance.zoomOut();
+                updateZoomUI(instance, controls);
+            } else if (e.key === '0') {
+                e.preventDefault();
+                if (fullscreenOverlay.fullscreenState?.homeState) {
+                    resetToFit(instance, fullscreenOverlay.fullscreenState.homeState);
+                    updateZoomUI(instance, controls);
+                }
+            }
+        }
     });
 
     // URL input
@@ -1101,6 +1121,10 @@ function createDiagramContainer(svg, diagramId, mermaidSource) {
     controls.innerHTML = `
         <button class="zoom-in" title="Zoom in">+</button>
         <button class="zoom-out" title="Zoom out">-</button>
+        <label class="zoom-range-label" title="Zoom level">
+            <span class="zoom-percent">100%</span>
+            <input class="zoom-range" type="range" min="25" max="400" value="100" step="5" aria-label="Diagram zoom level">
+        </label>
         <button class="reset" title="Reset view">⟲</button>
         <button class="export-svg" title="Download as SVG">SVG</button>
         <button class="export-png" title="Download as PNG">PNG</button>
@@ -1198,6 +1222,16 @@ function resetToFit(panzoomInstance, homeState) {
     panzoomInstance.pan(homeState.x, homeState.y, { animate: true });
 }
 
+function updateZoomUI(panzoomInstance, controlsRoot) {
+    if (!panzoomInstance || !controlsRoot) return;
+    const percentEl = controlsRoot.querySelector('.zoom-percent');
+    const rangeEl = controlsRoot.querySelector('.zoom-range');
+    if (!percentEl || !rangeEl) return;
+    const zoomPercent = Math.max(25, Math.min(400, Math.round(panzoomInstance.getScale() * 100)));
+    percentEl.textContent = `${zoomPercent}%`;
+    rangeEl.value = String(zoomPercent);
+}
+
 // ===========================
 // Panzoom Initialization
 // ===========================
@@ -1240,6 +1274,7 @@ function initializePanzoom(diagramId) {
     const controls = container.querySelector('.diagram-controls');
     const zoomInBtn = controls.querySelector('.zoom-in');
     const zoomOutBtn = controls.querySelector('.zoom-out');
+    const zoomRange = controls.querySelector('.zoom-range');
     const resetBtn = controls.querySelector('.reset');
     const exportSvgBtn = controls.querySelector('.export-svg');
     const exportPngBtn = controls.querySelector('.export-png');
@@ -1250,16 +1285,30 @@ function initializePanzoom(diagramId) {
     zoomInBtn.addEventListener('click', (e) => {
         e.stopPropagation();
         panzoomInstance.zoomIn();
+        updateZoomUI(panzoomInstance, controls);
     });
 
     zoomOutBtn.addEventListener('click', (e) => {
         e.stopPropagation();
         panzoomInstance.zoomOut();
+        updateZoomUI(panzoomInstance, controls);
     });
+
+    if (zoomRange) {
+        zoomRange.addEventListener('input', (e) => {
+            e.stopPropagation();
+            const targetPercent = Number(e.target.value);
+            if (!isNaN(targetPercent)) {
+                panzoomInstance.zoom(targetPercent / 100);
+                updateZoomUI(panzoomInstance, controls);
+            }
+        });
+    }
 
     resetBtn.addEventListener('click', (e) => {
         e.stopPropagation();
         resetToFit(panzoomInstance, state.homeState);
+        updateZoomUI(panzoomInstance, controls);
     });
 
     if (exportSvgBtn) {
@@ -1292,12 +1341,15 @@ function initializePanzoom(diagramId) {
     wrapper.addEventListener('wheel', (e) => {
         e.preventDefault();
         panzoomInstance.zoomWithWheel(e);
+        updateZoomUI(panzoomInstance, controls);
     }, { passive: false });
 
     // Double click to reset to fit
     wrapper.addEventListener('dblclick', () => {
         resetToFit(panzoomInstance, state.homeState);
+        updateZoomUI(panzoomInstance, controls);
     });
+    updateZoomUI(panzoomInstance, controls);
 }
 
 // ===========================
@@ -1372,6 +1424,7 @@ function setupFullscreenControls(panzoomInstance, wrapper, fullscreenState) {
     const controls = fullscreenOverlay.querySelector('.fullscreen-controls');
     const zoomInBtn = controls.querySelector('.zoom-in');
     const zoomOutBtn = controls.querySelector('.zoom-out');
+    const zoomRange = controls.querySelector('.zoom-range');
     const resetBtn = controls.querySelector('.reset');
     const exportSvgBtn = controls.querySelector('.export-svg');
     const exportPngBtn = controls.querySelector('.export-png');
@@ -1381,6 +1434,7 @@ function setupFullscreenControls(panzoomInstance, wrapper, fullscreenState) {
     const newZoomIn = zoomInBtn.cloneNode(true);
     const newZoomOut = zoomOutBtn.cloneNode(true);
     const newReset = resetBtn.cloneNode(true);
+    const newZoomRangeLabel = zoomRange ? zoomRange.closest('.zoom-range-label').cloneNode(true) : null;
     const newExportSvg = exportSvgBtn ? exportSvgBtn.cloneNode(true) : null;
     const newExportPng = exportPngBtn ? exportPngBtn.cloneNode(true) : null;
     const newClose = closeBtn.cloneNode(true);
@@ -1388,6 +1442,7 @@ function setupFullscreenControls(panzoomInstance, wrapper, fullscreenState) {
     zoomInBtn.replaceWith(newZoomIn);
     zoomOutBtn.replaceWith(newZoomOut);
     resetBtn.replaceWith(newReset);
+    if (zoomRange && newZoomRangeLabel) zoomRange.closest('.zoom-range-label').replaceWith(newZoomRangeLabel);
     if (exportSvgBtn && newExportSvg) exportSvgBtn.replaceWith(newExportSvg);
     if (exportPngBtn && newExportPng) exportPngBtn.replaceWith(newExportPng);
     closeBtn.replaceWith(newClose);
@@ -1396,17 +1451,32 @@ function setupFullscreenControls(panzoomInstance, wrapper, fullscreenState) {
     newZoomIn.addEventListener('click', (e) => {
         e.stopPropagation();
         panzoomInstance.zoomIn();
+        updateZoomUI(panzoomInstance, controls);
     });
 
     newZoomOut.addEventListener('click', (e) => {
         e.stopPropagation();
         panzoomInstance.zoomOut();
+        updateZoomUI(panzoomInstance, controls);
     });
 
     newReset.addEventListener('click', (e) => {
         e.stopPropagation();
         resetToFit(panzoomInstance, fullscreenState.homeState);
+        updateZoomUI(panzoomInstance, controls);
     });
+
+    const newZoomRange = controls.querySelector('.zoom-range');
+    if (newZoomRange) {
+        newZoomRange.addEventListener('input', (e) => {
+            e.stopPropagation();
+            const targetPercent = Number(e.target.value);
+            if (!isNaN(targetPercent)) {
+                panzoomInstance.zoom(targetPercent / 100);
+                updateZoomUI(panzoomInstance, controls);
+            }
+        });
+    }
 
     if (newExportSvg) {
         newExportSvg.addEventListener('click', (e) => {
@@ -1432,6 +1502,7 @@ function setupFullscreenControls(panzoomInstance, wrapper, fullscreenState) {
         e.preventDefault();
         e.stopPropagation();
         panzoomInstance.zoomWithWheel(e);
+        updateZoomUI(panzoomInstance, controls);
     };
 
     wrapper.addEventListener('wheel', wheelHandler, { passive: false });
@@ -1441,10 +1512,12 @@ function setupFullscreenControls(panzoomInstance, wrapper, fullscreenState) {
     const dblClickHandler = (e) => {
         e.stopPropagation();
         resetToFit(panzoomInstance, fullscreenState.homeState);
+        updateZoomUI(panzoomInstance, controls);
     };
 
     wrapper.addEventListener('dblclick', dblClickHandler);
     fullscreenOverlay.dblClickHandler = dblClickHandler;
+    updateZoomUI(panzoomInstance, controls);
 }
 
 function closeFullscreen() {

--- a/markdown-viewer/index.html
+++ b/markdown-viewer/index.html
@@ -207,6 +207,10 @@
                 <div class="fullscreen-controls">
                     <button class="zoom-in" title="Zoom in">+</button>
                     <button class="zoom-out" title="Zoom out">-</button>
+                    <label class="zoom-range-label" title="Zoom level">
+                        <span class="zoom-percent">100%</span>
+                        <input class="zoom-range" type="range" min="25" max="400" value="100" step="5" aria-label="Diagram zoom level">
+                    </label>
                     <button class="reset" title="Reset view">⟲</button>
                     <button class="export-svg" title="Download as SVG">SVG</button>
                     <button class="export-png" title="Download as PNG">PNG</button>

--- a/markdown-viewer/styles.css
+++ b/markdown-viewer/styles.css
@@ -697,6 +697,8 @@ body {
     cursor: pointer;
     transition: var(--transition);
     font-weight: 600;
+    min-width: 44px;
+    min-height: 44px;
 }
 
 .diagram-controls button:hover {
@@ -779,7 +781,30 @@ body {
     cursor: pointer;
     transition: var(--transition);
     font-weight: 600;
-    min-width: 40px;
+    min-width: 44px;
+    min-height: 44px;
+}
+
+.zoom-range-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    background-color: var(--bg-tertiary);
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    padding: 0.2rem 0.5rem;
+}
+
+.zoom-percent {
+    min-width: 3.2rem;
+    text-align: right;
+    font-size: 0.85rem;
+    font-weight: 700;
+    color: var(--text-secondary);
+}
+
+.zoom-range {
+    width: 110px;
 }
 
 .fullscreen-controls button:hover {


### PR DESCRIPTION
### Motivation

- Improve navigation and readability for large Mermaid diagrams by exposing an explicit zoom percentage, a slider for quick jumps, and larger tap targets for mobile.
- Add keyboard shortcuts for zoom/reset while in fullscreen to support desktop power users.
- Document a set of UX recommendations for Mermaid navigation (web + mobile) to guide further enhancements.

### Description

- Added a new documentation page `docs/2026-05-25-mermaid-navigation-recommendations.md` with prioritized UX recommendations for Mermaid navigation on web and mobile. 
- Introduced a zoom percentage display and a slider control in both inline diagram controls and the fullscreen controls, plus a new `updateZoomUI` helper to sync UI with the Panzoom instance. 
- Wired the slider, zoom in/out, reset, wheel and double-click handlers to call `updateZoomUI`, and added keyboard handlers for `+`/`=` (zoom in), `-` (zoom out) and `0` (reset to fit) when fullscreen is active. 
- Increased control tap sizes and added CSS for `.zoom-range-label`, `.zoom-percent`, and `.zoom-range` to improve mobile touch targets and layout; updated HTML template to include the slider in the fullscreen overlay. 

### Testing

- Performed a local build and smoke test of the viewer to validate there are no syntax errors and controls render as expected. 
- Ran the repository's test/lint commands (`npm test` / `npm run lint`) locally and observed no failures. 
- Verified interactive behaviors manually in the local viewer: slider updates zoom, keyboard shortcuts work in fullscreen, and zoom percentage reflects current scale.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13fc5d2aa88324a207269b7cedd590)