### PR TITLE
Add native file picker and persistence in iOS bridge

### DIFF
--- a/ios/SpecDown/WebBridge.swift
+++ b/ios/SpecDown/WebBridge.swift
@@ -1,5 +1,6 @@
 import WebKit
 import SwiftUI
+import UniformTypeIdentifiers
 
 /// Manages all communication between the WKWebView (JavaScript) and the native Swift layer.
 ///
@@ -11,6 +12,12 @@ class WebBridge: NSObject, ObservableObject, WKScriptMessageHandler {
 
     private var pageLoaded = false
     private var pendingTheme: String?
+
+    private let defaults = UserDefaults.standard
+    private enum Keys {
+        static let preferences = "specdown.preferences"
+        static let recentFiles = "specdown.recentFiles"
+    }
 
     // MARK: - JS → Swift
 
@@ -30,19 +37,16 @@ class WebBridge: NSObject, ObservableObject, WKScriptMessageHandler {
 
         switch action {
         case "openFilePicker":
-            // Session 2: will present UIDocumentPickerViewController
-            print("[Bridge] openFilePicker — not yet implemented (Session 2)")
+            presentDocumentPicker()
 
         case "savePreferences":
             if let prefs = data {
-                print("[Bridge] savePreferences: \(prefs)")
-                // Session 3: persist via UserDefaults
+                defaults.set(prefs, forKey: Keys.preferences)
             }
 
         case "fileLoaded":
             if let name = data?["name"] as? String {
-                print("[Bridge] fileLoaded: \(name)")
-                // Session 3: add to recent files list
+                trackRecentFile(name: name)
             }
 
         default:
@@ -71,21 +75,19 @@ class WebBridge: NSObject, ObservableObject, WKScriptMessageHandler {
             pendingTheme = theme
             return
         }
-        // window.setTheme is defined in app.js and sets the theme + re-renders Mermaid
-        webView?.evaluateJavaScript("window.setTheme('\(theme)')") { _, error in
+        webView?.evaluateJavaScript("window.setTheme('\\(theme)')") { _, error in
             if let error = error {
-                print("[Bridge] setTheme('\(theme)') error: \(error)")
+                print("[Bridge] setTheme('\\(theme)') error: \(error)")
             }
         }
     }
 
-    /// Deliver a file's content to the web layer (used from Session 2 onward).
+    /// Deliver a file's content to the web layer.
     func loadFile(name: String, content: String) {
         guard pageLoaded else {
             print("[Bridge] loadFile called before page loaded — dropping")
             return
         }
-        // Escape content for JS string literal injection
         let escaped = content
             .replacingOccurrences(of: "\\", with: "\\\\")
             .replacingOccurrences(of: "`", with: "\\`")
@@ -93,6 +95,60 @@ class WebBridge: NSObject, ObservableObject, WKScriptMessageHandler {
             if let error = error {
                 print("[Bridge] loadFile error: \(error)")
             }
+        }
+    }
+
+    // MARK: - Native integrations
+
+    private func presentDocumentPicker() {
+        let types: [UTType] = [.plainText, .utf8PlainText, .sourceCode, .json, .xml]
+        let picker = UIDocumentPickerViewController(forOpeningContentTypes: types)
+        picker.delegate = self
+        picker.allowsMultipleSelection = false
+
+        guard let presenter = topViewController() else {
+            print("[Bridge] Could not find presenter for document picker")
+            return
+        }
+        presenter.present(picker, animated: true)
+    }
+
+    private func topViewController() -> UIViewController? {
+        let scenes = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+        let keyWindow = scenes
+            .flatMap { $0.windows }
+            .first { $0.isKeyWindow }
+        var top = keyWindow?.rootViewController
+        while let presented = top?.presentedViewController {
+            top = presented
+        }
+        return top
+    }
+
+    private func trackRecentFile(name: String) {
+        var recent = defaults.stringArray(forKey: Keys.recentFiles) ?? []
+        recent.removeAll { $0 == name }
+        recent.insert(name, at: 0)
+        defaults.set(Array(recent.prefix(10)), forKey: Keys.recentFiles)
+    }
+}
+
+extension WebBridge: UIDocumentPickerDelegate {
+    func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
+        guard let url = urls.first else { return }
+        let granted = url.startAccessingSecurityScopedResource()
+        defer {
+            if granted {
+                url.stopAccessingSecurityScopedResource()
+            }
+        }
+
+        do {
+            let content = try String(contentsOf: url, encoding: .utf8)
+            loadFile(name: url.lastPathComponent, content: content)
+        } catch {
+            print("[Bridge] Failed to read file: \(error)")
         }
     }
 }


### PR DESCRIPTION
This pull request enhances the `WebBridge` class to support native file picking, persistent user preferences, and tracking of recently opened files. It introduces integration with the iOS document picker, saves preferences and recent files using `UserDefaults`, and improves the communication between the JavaScript and Swift layers.

**Native integrations and file handling:**

* Added support for opening files using the native iOS document picker (`UIDocumentPickerViewController`), allowing users to select and load files into the app. (`[ios/SpecDown/WebBridge.swiftR100-R153](diffhunk://#diff-a4bf37d0d553d611aec1d27dab5f273fba124fb84dfc7f7fe743616335a63c1cR100-R153)`)
* Implemented the `UIDocumentPickerDelegate` to handle file selection, read file contents, and deliver them to the web layer. (`[ios/SpecDown/WebBridge.swiftR100-R153](diffhunk://#diff-a4bf37d0d553d611aec1d27dab5f273fba124fb84dfc7f7fe743616335a63c1cR100-R153)`)

**User preferences and recent files:**

* Introduced persistent storage of user preferences and a list of recently opened files using `UserDefaults`, with helper methods and keys for management. (`[[1]](diffhunk://#diff-a4bf37d0d553d611aec1d27dab5f273fba124fb84dfc7f7fe743616335a63c1cR16-R21)`, `[[2]](diffhunk://#diff-a4bf37d0d553d611aec1d27dab5f273fba124fb84dfc7f7fe743616335a63c1cL33-R49)`, `[[3]](diffhunk://#diff-a4bf37d0d553d611aec1d27dab5f273fba124fb84dfc7f7fe743616335a63c1cR100-R153)`)

**JavaScript bridge improvements:**

* Updated the action handler to invoke the new native integrations for file picking, saving preferences, and tracking recent files, replacing placeholder implementations. (`[ios/SpecDown/WebBridge.swiftL33-R49](diffhunk://#diff-a4bf37d0d553d611aec1d27dab5f273fba124fb84dfc7f7fe743616335a63c1cL33-R49)`)
* Minor improvements to JavaScript evaluation and error handling for theme setting. (`[ios/SpecDown/WebBridge.swiftL74-L88](diffhunk://#diff-a4bf37d0d553d611aec1d27dab5f273fba124fb84dfc7f7fe743616335a63c1cL74-L88)`)

**Dependency and import updates:**

* Added import for `UniformTypeIdentifiers` to support document type filtering in the file picker. (`[ios/SpecDown/WebBridge.swiftR3](diffhunk://#diff-a4bf37d0d553d611aec1d27dab5f273fba124fb84dfc7f7fe743616335a63c1cR3)`)