### PR TITLE
Fix release pipeline: drop README dependency from sync-version

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -55,7 +55,7 @@ jobs:
         if: github.event_name == 'push'
         run: |
           VERSION=$(node -p "require('./package.json').version")
-          git add package.json markdown-viewer/app.js README.md
+          git add package.json markdown-viewer/app.js
           git commit -m "Bump version to v${VERSION} [version bump]"
           git push origin main
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "version": "node scripts/sync-version.js && git add markdown-viewer/app.js README.md"
+    "version": "node scripts/sync-version.js && git add markdown-viewer/app.js"
   },
   "keywords": [
     "markdown",

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * Syncs the version from package.json into app.js (APP_VERSION constant)
- * and README.md (Version History section).
+ * Syncs the version from package.json into app.js (APP_VERSION constant).
  *
  * This runs automatically via the npm "version" lifecycle script, so
  * bumping the version is a single command:
@@ -17,7 +16,6 @@ const path = require('path');
 
 const pkgPath = path.join(__dirname, '..', 'package.json');
 const appPath = path.join(__dirname, '..', 'markdown-viewer', 'app.js');
-const readmePath = path.join(__dirname, '..', 'README.md');
 
 const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
 const version = pkg.version;
@@ -35,16 +33,5 @@ appCode = appCode.replace(versionRegex, "const APP_VERSION = '" + version + "';"
 fs.writeFileSync(appPath, appCode, 'utf8');
 console.log('Synced version ' + version + ' into app.js');
 
-// Update README.md version
-let readmeContent = fs.readFileSync(readmePath, 'utf8');
-
-const readmeVersionRegex = /^(\s*#### v)\S+ (\(Current\))/m;
-if (!readmeVersionRegex.test(readmeContent)) {
-    console.error('Could not find version in README.md');
-    process.exit(1);
-}
-
-readmeContent = readmeContent.replace(readmeVersionRegex, '$1' + version + ' $2');
-
-fs.writeFileSync(readmePath, readmeContent, 'utf8');
-console.log('Synced version ' + version + ' into README.md');
+// The README no longer carries a per-build "#### vX.Y.Z (Current)" line — the
+// version is a build counter, not a changelog. Nothing to sync there.


### PR DESCRIPTION
## Problem

The version-bump job has been **failing on every merge to `main` since Phase 0** (#92). The Phase 0 README rewrite removed the `#### vX.Y.Z (Current)` line that `scripts/sync-version.js` greps for, so `npm version patch` aborts:

```
Could not find version in README.md
npm error command sh -c node scripts/sync-version.js && git add markdown-viewer/app.js README.md
```

No version bumped → no tag → **no desktop or web build has shipped since Phase 0**. (All 7 Dependabot merges, #93–#99, hit this failure.)

## Fix

- `scripts/sync-version.js` now only updates `APP_VERSION` in `markdown-viewer/app.js`. The README version was a build counter, not a changelog, and Phase 0 intentionally removed that line — so there's nothing to sync there.
- Dropped `README.md` from the `git add` in `version-bump.yml` and the `package.json` "version" script to match.

Minimal and self-contained — independent of the in-progress Phase 1 branch.

## Verification

- `node scripts/sync-version.js` → exits 0 (`Synced version 0.0.83 into app.js`).
- `npm run lint` → clean; `npm test` → 297 passed.

After this merges, the next push to `main` should bump the version and produce a fresh release/build.

https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA)_