### PR TITLE
Fix iOS WKWebView asset loading (strip crossorigin + allow file: in CSP)

### DIFF
--- a/markdown-viewer/index.html
+++ b/markdown-viewer/index.html
@@ -4,13 +4,15 @@
     <meta charset="UTF-8">
     <!--
       Content-Security-Policy: defense-in-depth on top of DOMPurify. Scripts are
-      restricted to same-origin vendored files ('unsafe-eval' is required by
+      restricted to same-origin bundled files ('unsafe-eval' is required by
       Mermaid's runtime); styles allow inline because Mermaid and the app inject
-      <style> blocks and style attributes. connect-src / img-src stay permissive
-      (https/http) because the viewer intentionally fetches user-supplied URLs
-      and the GitHub API/raw hosts.
+      <style> blocks and style attributes. The `file:` scheme is allowed so the
+      bundled assets load inside the Electron and iOS WKWebView shells (which
+      serve from file://, where 'self' is not reliably matched). connect-src /
+      img-src stay permissive (https/http) because the viewer intentionally
+      fetches user-supplied URLs and the GitHub API/raw hosts.
     -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https: http:; font-src 'self' data:; connect-src 'self' https: http:; object-src 'none'; base-uri 'self'; form-action 'none'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self' file:; script-src 'self' 'unsafe-eval' file:; style-src 'self' 'unsafe-inline' file:; img-src 'self' data: blob: https: http: file:; font-src 'self' data: file:; connect-src 'self' https: http: file:; object-src 'none'; base-uri 'self'; form-action 'none'">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>SpecDown: A Markdown Viewer</title>
     <link rel="icon" type="image/svg+xml" href="favicon.svg">

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,18 @@
 import { defineConfig } from 'vite';
 
-// Vite build for the shared SpecDown viewer (Phase 1 — modernization roadmap).
+// Strips the `crossorigin` attribute Vite stamps onto the generated
+// <script>/<link> tags. Over file:// (iOS WKWebView), crossorigin triggers a
+// CORS check that blocks the bundled CSS/JS, leaving an unstyled page with no
+// app logic. Electron's Chromium tolerates it, but WKWebView does not. The
+// attribute is unnecessary for our same-origin/local assets on every surface.
+const stripCrossorigin = {
+  name: 'strip-crossorigin',
+  transformIndexHtml(html) {
+    return html.replace(/\s+crossorigin(?:=("|')[^"']*\1)?/g, '');
+  },
+};
+
+// Vite build for the shared SpecDown viewer (modernization roadmap).
 //
 // The same `dist/` output is consumed by all three surfaces, so the config is
 // deliberately portable:
@@ -10,9 +22,11 @@ import { defineConfig } from 'vite';
 //     bootstrap script, which the app's Content-Security-Policy (script-src
 //     'self', no 'unsafe-inline') would block. Native modulepreload support is
 //     fine for our targets; the polyfill is unnecessary.
+//   - stripCrossorigin plugin → see above; required for iOS WKWebView file://.
 export default defineConfig({
   root: 'markdown-viewer',
   base: './',
+  plugins: [stripCrossorigin],
   build: {
     outDir: 'dist',
     emptyOutDir: true,


### PR DESCRIPTION
## Problem

After the Phase 1 Vite migration, the **iOS app rendered as unstyled HTML with no app logic** — the bundled CSS and module script failed to load in WKWebView over `file://`. (Desktop/Electron and web were fine.)

## Cause

Two `file://` issues that Electron's Chromium tolerates but WKWebView does not:

1. **`crossorigin` attribute** — Vite stamps it on the generated `<script>`/`<link>` tags. Over `file://` it triggers a CORS check that blocks the assets.
2. **CSP `'self'`** — not reliably matched for `file://` origins in WKWebView, so the bundle is blocked even once CORS passes.

## Fix

- Added a small Vite `transformIndexHtml` plugin to **strip `crossorigin`** from the built tags (it's unnecessary for our local/same-origin assets on every surface).
- Added the **`file:` scheme** to the CSP fetch directives.

Both are safe for web (https) and desktop — they only relax the local-file case.

## Verified (headless)
- Built `dist/index.html` now has **0 `crossorigin`** attributes and a `file:`-aware CSP.
- `npm run lint` clean; `npm test` → **297 passed**.

## Needs a re-check
- **iOS simulator/device** — rebuild (`npm run build && cd ios && xcodegen generate`) and confirm the app renders styled with the native iOS chrome (this is the actual fix being validated; can't run WKWebView in CI).

Unrelated, for context: the desktop `.dmg` Gatekeeper block is the separate unsigned-app issue (→ signing/notarization, Phase 3); running desktop from source works.

https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA)_