### PR TITLE
Restore iOS WKURLSchemeHandler (missed in the #105 merge)

### DIFF
--- a/ios/SpecDown/WebView.swift
+++ b/ios/SpecDown/WebView.swift
@@ -39,6 +39,14 @@ struct WebView: UIViewRepresentable {
         )
         config.userContentController.addUserScript(touchScript)
 
+        // Serve the bundled web app over a custom URL scheme instead of file://.
+        // WKWebView refuses to execute ES-module <script type="module"> loaded
+        // from file:// (null-origin CORS rule for modules), which left the app
+        // unstyled with no JS. A custom scheme gives the page a real, same-origin
+        // context where the Vite module bundle loads normally.
+        let schemeHandler = BundleSchemeHandler()
+        config.setURLSchemeHandler(schemeHandler, forURLScheme: BundleSchemeHandler.scheme)
+
         let webView = WKWebView(frame: .zero, configuration: config)
         // Use .scrollableAxes to expose safe area insets to CSS env() variables without
         // automatic content inset adjustments. This allows CSS to handle Dynamic Island
@@ -48,14 +56,10 @@ struct WebView: UIViewRepresentable {
         webView.uiDelegate = context.coordinator
         bridge.webView = webView
 
-        // Load the bundled web app (Vite build output in dist/); allowingReadAccessTo covers all assets in dist/
-        if let url = Bundle.main.url(
-            forResource: "index",
-            withExtension: "html",
-            subdirectory: "dist"
-        ) {
+        // Load the bundled Vite build over the custom scheme (see above).
+        if BundleSchemeHandler.bundledIndexExists, let url = BundleSchemeHandler.indexURL {
             bridge.pageWillLoad()
-            webView.loadFileURL(url, allowingReadAccessTo: url.deletingLastPathComponent())
+            webView.load(URLRequest(url: url))
         } else {
             // Fallback: show an error page if assets are missing from the bundle
             loadErrorPage(
@@ -166,11 +170,7 @@ struct WebView: UIViewRepresentable {
         }
 
         private func reloadBundledViewer(in webView: WKWebView) {
-            guard let url = Bundle.main.url(
-                forResource: "index",
-                withExtension: "html",
-                subdirectory: "dist"
-            ) else {
+            guard BundleSchemeHandler.bundledIndexExists, let url = BundleSchemeHandler.indexURL else {
                 loadErrorPage(
                     in: webView,
                     title: "Missing bundled assets",
@@ -180,7 +180,7 @@ struct WebView: UIViewRepresentable {
             }
 
             bridge.pageWillLoad()
-            webView.loadFileURL(url, allowingReadAccessTo: url.deletingLastPathComponent())
+            webView.load(URLRequest(url: url))
         }
     }
 }
@@ -220,5 +220,81 @@ private class WeakMessageHandler: NSObject, WKScriptMessageHandler {
         didReceive message: WKScriptMessage
     ) {
         delegate?.userContentController(userContentController, didReceive: message)
+    }
+}
+
+// MARK: - BundleSchemeHandler
+
+/// Serves the bundled Vite build (dist/) over a custom URL scheme so the page
+/// has a real same-origin context. WKWebView will not execute ES-module scripts
+/// loaded from file://, so the app must not be served via loadFileURL.
+final class BundleSchemeHandler: NSObject, WKURLSchemeHandler {
+    static let scheme = "specdown"
+    static let host = "app"
+
+    /// The dist/ directory inside the app bundle.
+    static let rootURL: URL? = Bundle.main
+        .url(forResource: "index", withExtension: "html", subdirectory: "dist")?
+        .deletingLastPathComponent()
+
+    static var bundledIndexExists: Bool { rootURL != nil }
+
+    /// The entry URL to load, e.g. specdown://app/index.html
+    static var indexURL: URL? { URL(string: "\(scheme)://\(host)/index.html") }
+
+    func webView(_ webView: WKWebView, start urlSchemeTask: WKURLSchemeTask) {
+        guard let url = urlSchemeTask.request.url, let root = Self.rootURL else {
+            urlSchemeTask.didFailWithError(URLError(.fileDoesNotExist))
+            return
+        }
+
+        // Map the request path to a file under dist/. "/" → index.html.
+        var relativePath = url.path
+        if relativePath.hasPrefix("/") { relativePath.removeFirst() }
+        if relativePath.isEmpty { relativePath = "index.html" }
+
+        let rootStd = root.standardizedFileURL
+        let fileURL = rootStd.appendingPathComponent(relativePath).standardizedFileURL
+
+        // Guard against path traversal outside the bundled dist/ directory.
+        guard fileURL.path.hasPrefix(rootStd.path),
+              let data = try? Data(contentsOf: fileURL) else {
+            urlSchemeTask.didFailWithError(URLError(.fileDoesNotExist))
+            return
+        }
+
+        let response = HTTPURLResponse(
+            url: url,
+            statusCode: 200,
+            httpVersion: "HTTP/1.1",
+            headerFields: [
+                "Content-Type": Self.mimeType(forExtension: fileURL.pathExtension),
+                "Content-Length": String(data.count),
+                "Access-Control-Allow-Origin": "*",
+            ]
+        )!
+
+        urlSchemeTask.didReceive(response)
+        urlSchemeTask.didReceive(data)
+        urlSchemeTask.didFinish()
+    }
+
+    func webView(_ webView: WKWebView, stop urlSchemeTask: WKURLSchemeTask) {}
+
+    private static func mimeType(forExtension ext: String) -> String {
+        switch ext.lowercased() {
+        case "html": return "text/html; charset=utf-8"
+        case "css": return "text/css; charset=utf-8"
+        case "js", "mjs": return "text/javascript; charset=utf-8"
+        case "json": return "application/json; charset=utf-8"
+        case "svg": return "image/svg+xml"
+        case "png": return "image/png"
+        case "jpg", "jpeg": return "image/jpeg"
+        case "md", "markdown": return "text/markdown; charset=utf-8"
+        case "woff2": return "font/woff2"
+        case "woff": return "font/woff"
+        case "ttf": return "font/ttf"
+        default: return "application/octet-stream"
+        }
     }
 }

--- a/markdown-viewer/index.html
+++ b/markdown-viewer/index.html
@@ -12,7 +12,7 @@
       img-src stay permissive (https/http) because the viewer intentionally
       fetches user-supplied URLs and the GitHub API/raw hosts.
     -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self' file:; script-src 'self' 'unsafe-eval' file:; style-src 'self' 'unsafe-inline' file:; img-src 'self' data: blob: https: http: file:; font-src 'self' data: file:; connect-src 'self' https: http: file:; object-src 'none'; base-uri 'self'; form-action 'none'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self' file: specdown:; script-src 'self' 'unsafe-eval' file: specdown:; style-src 'self' 'unsafe-inline' file: specdown:; img-src 'self' data: blob: https: http: file: specdown:; font-src 'self' data: file: specdown:; connect-src 'self' https: http: file: specdown:; object-src 'none'; base-uri 'self'; form-action 'none'">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>SpecDown: A Markdown Viewer</title>
     <link rel="icon" type="image/svg+xml" href="favicon.svg">


### PR DESCRIPTION
## Why

The iOS fix that actually made the app work — the `WKURLSchemeHandler` (commit `2e1c451`) — **never reached main.** PR #105 merged as `458c0ed`, which only contained the *first* commit (strip `crossorigin` + `file:` CSP). The scheme-handler commit was left on the branch, so **main's iOS is still broken** (`WebView.swift` uses `loadFileURL`, and WKWebView won't run the ES-module bundle over `file://`). The build you smoke-tested had it; main does not.

This cherry-picks `2e1c451` onto current main.

## What it does
- Adds a `BundleSchemeHandler` (`WKURLSchemeHandler`) that serves the bundled `dist/` over `specdown://app/`, giving the page a real same-origin context where ES modules load. Loads `specdown://app/index.html` instead of `loadFileURL`.
- Adds `specdown:` to the CSP fetch directives.

This is the exact change that was verified working in the iOS simulator/device.

## Verified
- `BundleSchemeHandler` present, no `loadFileURL` calls remain.
- `npm run build` ✓, `npm run lint` ✓, `npm test` → **297 passed**. iOS build lane runs in CI.

https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA)_