### PR TITLE
Fix dark-mode accent button contrast

### DIFF
--- a/markdown-viewer/styles.css
+++ b/markdown-viewer/styles.css
@@ -26,9 +26,12 @@
     --text-primary: #ffffff;
     --text-secondary: #cccccc;
     --border-color: #444444;
-    /* Lighter accent on the dark background for readable contrast. */
-    --accent-color: #5aa0ec;
-    --accent-hover: #7ab4f0;
+    /* Accent for the dark theme. #5aa0ec read well as link text but made
+       white-on-accent buttons (Browse / Open / samples) too low-contrast;
+       this medium blue keeps both link text and button text legible on the
+       dark background. A fuller light/dark token split is Phase 2 work. */
+    --accent-color: #4a90e2;
+    --accent-hover: #357abd;
     --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.3);
     --shadow-md: 0 4px 8px rgba(0, 0, 0, 0.4);
     --shadow-lg: 0 8px 16px rgba(0, 0, 0, 0.5);


### PR DESCRIPTION
## Fix

The earlier contrast bump lightened the **dark-theme** accent to `#5aa0ec`, which read well as link text but made **white-on-accent buttons** (Browse / Open / sample buttons) too low-contrast in dark mode — a regression I introduced.

This restores the dark accent to `#4a90e2`, which keeps both link text *and* button text legible on the dark background. The **light-theme** accent (`#1f6bb8`, WCAG AA on white) is unchanged, so the original AA improvement stays.

A proper light/dark token split (separate accent for text vs. button surfaces, full WCAG pass) is Phase 2 design-system work.

## Verified
- `npm run build` ✓, `npm run lint` ✓, `npm test` → **297 passed**.

https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA)_