### PR TITLE
Phase 1: extract features/annotations.js

### DIFF
--- a/markdown-viewer/src/features/annotations.js
+++ b/markdown-viewer/src/features/annotations.js
@@ -1,0 +1,150 @@
+// Lightweight sticky-note annotations stored in localStorage, keyed by
+// filename. Users can double-click any paragraph or heading to add/edit one.
+// State is private to this module.
+
+const ANNOTATIONS_KEY = 'specdown-annotations';
+
+let annotationMode = false;
+let annotationKey = '';
+
+const content = () => document.getElementById('markdown-content');
+
+function loadAnnotations(key) {
+  try {
+    const raw = localStorage.getItem(ANNOTATIONS_KEY);
+    const all = raw ? JSON.parse(raw) : {};
+    return all[key] || {};
+  } catch (e) {
+    return {};
+  }
+}
+
+function saveAnnotations(key, annotations) {
+  try {
+    const raw = localStorage.getItem(ANNOTATIONS_KEY);
+    const all = raw ? JSON.parse(raw) : {};
+    if (Object.keys(annotations).length === 0) {
+      delete all[key];
+    } else {
+      all[key] = annotations;
+    }
+    localStorage.setItem(ANNOTATIONS_KEY, JSON.stringify(all));
+  } catch (e) {
+    // localStorage quota exceeded — silently ignore
+  }
+}
+
+/**
+ * Toggle annotation mode. Callers are responsible for any platform chrome
+ * sync (e.g. the iOS action bar) after toggling.
+ */
+export function toggleAnnotationMode() {
+  annotationMode = !annotationMode;
+  const btn = document.getElementById('annotation-toggle');
+  if (btn) btn.classList.toggle('active', annotationMode);
+
+  if (annotationMode && annotationKey) {
+    attachAnnotationHandlers();
+  } else {
+    detachAnnotationHandlers();
+  }
+}
+
+/** Render saved annotation badges for a document, keyed by filename. */
+export function renderAnnotations(key) {
+  const markdownContent = content();
+  annotationKey = key;
+  // Remove old annotation badges
+  markdownContent.querySelectorAll('.annotation-badge').forEach((b) => b.remove());
+
+  const annotations = loadAnnotations(key);
+  Object.entries(annotations).forEach(([idx, text]) => {
+    const el = markdownContent.querySelectorAll('[data-annot-idx]')[parseInt(idx, 10)];
+    if (el) attachAnnotationBadge(el, parseInt(idx, 10), text);
+  });
+
+  // Re-arm double-click handlers if the user is currently annotating.
+  if (annotationMode) attachAnnotationHandlers();
+}
+
+function attachAnnotationHandlers() {
+  // Index all annotatable elements
+  const els = content().querySelectorAll('p, h1, h2, h3, h4, h5, h6, li, blockquote');
+  els.forEach((el, idx) => {
+    el.setAttribute('data-annot-idx', idx);
+    el.classList.add('annotatable');
+    el.addEventListener('dblclick', handleAnnotationDblClick);
+  });
+}
+
+function detachAnnotationHandlers() {
+  content()
+    .querySelectorAll('.annotatable')
+    .forEach((el) => {
+      el.removeEventListener('dblclick', handleAnnotationDblClick);
+      el.classList.remove('annotatable');
+    });
+}
+
+function handleAnnotationDblClick(e) {
+  if (!annotationMode) return;
+  const el = e.currentTarget;
+  const idx = parseInt(el.getAttribute('data-annot-idx'), 10);
+  const annotations = loadAnnotations(annotationKey);
+  const existing = annotations[idx] || '';
+
+  const note = prompt('Add annotation (leave blank to remove):', existing);
+  if (note === null) return; // cancelled
+
+  if (note.trim() === '') {
+    delete annotations[idx];
+    const badge = el.querySelector('.annotation-badge');
+    if (badge) badge.remove();
+  } else {
+    annotations[idx] = note.trim();
+    attachAnnotationBadge(el, idx, note.trim());
+  }
+  saveAnnotations(annotationKey, annotations);
+}
+
+function attachAnnotationBadge(el, idx, text) {
+  // Remove existing badge first
+  const existing = el.querySelector('.annotation-badge');
+  if (existing) existing.remove();
+
+  el.setAttribute('data-annot-idx', idx);
+  el.classList.add('has-annotation');
+
+  const badge = document.createElement('span');
+  badge.className = 'annotation-badge';
+  badge.title = text;
+  badge.textContent = '✎';
+  badge.addEventListener('click', (e) => {
+    e.stopPropagation();
+    showAnnotationPopover(badge, text);
+  });
+  el.appendChild(badge);
+}
+
+function showAnnotationPopover(anchor, text) {
+  let popover = document.getElementById('annotation-popover');
+  if (!popover) {
+    popover = document.createElement('div');
+    popover.id = 'annotation-popover';
+    popover.className = 'annotation-popover';
+    document.body.appendChild(popover);
+  }
+  popover.textContent = text;
+  const rect = anchor.getBoundingClientRect();
+  popover.style.top = rect.bottom + window.scrollY + 4 + 'px';
+  popover.style.left = rect.left + window.scrollX + 'px';
+  popover.style.display = '';
+
+  const hide = (e) => {
+    if (!popover.contains(e.target) && e.target !== anchor) {
+      popover.style.display = 'none';
+      document.removeEventListener('click', hide);
+    }
+  };
+  setTimeout(() => document.addEventListener('click', hide), 0);
+}

--- a/markdown-viewer/src/main.js
+++ b/markdown-viewer/src/main.js
@@ -30,6 +30,10 @@ import {
   navigateSearch,
   clearSearchHighlights,
 } from './features/search.js';
+import {
+  toggleAnnotationMode,
+  renderAnnotations,
+} from './features/annotations.js';
 
 // ===========================
 // Constants
@@ -623,9 +627,12 @@ function setupEventListeners() {
         tocToggle.addEventListener('click', toggleToc);
     }
 
-    // Annotation toggle
+    // Annotation toggle (sync iOS chrome after toggling)
     if (annotationToggle) {
-        annotationToggle.addEventListener('click', toggleAnnotationMode);
+        annotationToggle.addEventListener('click', () => {
+            toggleAnnotationMode();
+            syncIOSChrome();
+        });
     }
 
     // Split view toggle
@@ -1041,9 +1048,8 @@ async function renderMarkdown(content, filename) {
         // Clear any active search
         clearSearchHighlights();
 
-        // Render annotations for this document
+        // Render annotations for this document (re-arms handlers if active)
         renderAnnotations(filename);
-        if (annotationMode) attachAnnotationHandlers();
 
         // Scroll to top
         markdownContent.scrollTop = 0;
@@ -2416,148 +2422,6 @@ function showRepoBrowser(files, repoUrl) {
             handleUrl(rawUrl);
         });
     });
-}
-
-// ===========================
-// Feature: Annotation Mode
-// ===========================
-// Lightweight sticky-note annotations stored in localStorage, keyed by filename.
-// Users can double-click any paragraph or heading to add/edit an annotation.
-
-const ANNOTATIONS_KEY = 'specdown-annotations';
-
-function loadAnnotations(key) {
-    try {
-        const raw = localStorage.getItem(ANNOTATIONS_KEY);
-        const all = raw ? JSON.parse(raw) : {};
-        return all[key] || {};
-    } catch (e) {
-        return {};
-    }
-}
-
-function saveAnnotations(key, annotations) {
-    try {
-        const raw = localStorage.getItem(ANNOTATIONS_KEY);
-        const all = raw ? JSON.parse(raw) : {};
-        if (Object.keys(annotations).length === 0) {
-            delete all[key];
-        } else {
-            all[key] = annotations;
-        }
-        localStorage.setItem(ANNOTATIONS_KEY, JSON.stringify(all));
-    } catch (e) {
-        // localStorage quota exceeded — silently ignore
-    }
-}
-
-let annotationMode = false;
-let annotationKey = '';
-
-function toggleAnnotationMode() {
-    annotationMode = !annotationMode;
-    const btn = document.getElementById('annotation-toggle');
-    if (btn) btn.classList.toggle('active', annotationMode);
-
-    if (annotationMode && annotationKey) {
-        attachAnnotationHandlers();
-    } else {
-        detachAnnotationHandlers();
-    }
-
-    syncIOSChrome();
-}
-
-function renderAnnotations(key) {
-    annotationKey = key;
-    // Remove old annotation badges
-    markdownContent.querySelectorAll('.annotation-badge').forEach((b) => b.remove());
-
-    const annotations = loadAnnotations(key);
-    Object.entries(annotations).forEach(([idx, text]) => {
-        const el = markdownContent.querySelectorAll('[data-annot-idx]')[parseInt(idx, 10)];
-        if (el) attachAnnotationBadge(el, parseInt(idx, 10), text);
-    });
-}
-
-function attachAnnotationHandlers() {
-    // Index all annotatable elements
-    const els = markdownContent.querySelectorAll('p, h1, h2, h3, h4, h5, h6, li, blockquote');
-    els.forEach((el, idx) => {
-        el.setAttribute('data-annot-idx', idx);
-        el.classList.add('annotatable');
-        el.addEventListener('dblclick', handleAnnotationDblClick);
-    });
-}
-
-function detachAnnotationHandlers() {
-    markdownContent.querySelectorAll('.annotatable').forEach((el) => {
-        el.removeEventListener('dblclick', handleAnnotationDblClick);
-        el.classList.remove('annotatable');
-    });
-}
-
-function handleAnnotationDblClick(e) {
-    if (!annotationMode) return;
-    const el = e.currentTarget;
-    const idx = parseInt(el.getAttribute('data-annot-idx'), 10);
-    const annotations = loadAnnotations(annotationKey);
-    const existing = annotations[idx] || '';
-
-    const note = prompt('Add annotation (leave blank to remove):', existing);
-    if (note === null) return; // cancelled
-
-    if (note.trim() === '') {
-        delete annotations[idx];
-        const badge = el.querySelector('.annotation-badge');
-        if (badge) badge.remove();
-    } else {
-        annotations[idx] = note.trim();
-        attachAnnotationBadge(el, idx, note.trim());
-    }
-    saveAnnotations(annotationKey, annotations);
-}
-
-function attachAnnotationBadge(el, idx, text) {
-    // Remove existing badge first
-    const existing = el.querySelector('.annotation-badge');
-    if (existing) existing.remove();
-
-    el.setAttribute('data-annot-idx', idx);
-    el.classList.add('has-annotation');
-
-    const badge = document.createElement('span');
-    badge.className = 'annotation-badge';
-    badge.title = text;
-    badge.textContent = '✎';
-    badge.addEventListener('click', (e) => {
-        e.stopPropagation();
-        showAnnotationPopover(badge, text);
-    });
-    el.appendChild(badge);
-}
-
-function showAnnotationPopover(anchor, text) {
-    let popover = document.getElementById('annotation-popover');
-    if (!popover) {
-        popover = document.createElement('div');
-        popover.id = 'annotation-popover';
-        popover.className = 'annotation-popover';
-        document.body.appendChild(popover);
-    }
-    popover.textContent = text;
-    const rect = anchor.getBoundingClientRect();
-    popover.style.top = (rect.bottom + window.scrollY + 4) + 'px';
-    popover.style.left = (rect.left + window.scrollX) + 'px';
-    popover.style.display = '';
-
-    const hide = (e) => {
-        if (!popover.contains(e.target) && e.target !== anchor) {
-            popover.style.display = 'none';
-            document.removeEventListener('click', hide);
-        }
-    };
-    setTimeout(() => document.addEventListener('click', hide), 0);
 }
 
 // ===========================


### PR DESCRIPTION
Continues the Phase 1 module split. Pure refactor — no behavior change.

## Extraction
`markdown-viewer/src/features/annotations.js` — the localStorage sticky-note annotations feature.

State (`annotationMode`, `annotationKey`) is private to the module. Decoupling from `main.js`:
- looks up `#markdown-content` by id internally;
- `toggleAnnotationMode` no longer calls `syncIOSChrome` — its only caller (the toolbar click listener) now does that, so the module stays platform-agnostic;
- `renderAnnotations` re-arms the dblclick handlers itself when annotation mode is active, removing the `if (annotationMode) attachAnnotationHandlers()` check from `main.js`.

Public API: `toggleAnnotationMode`, `renderAnnotations`.

`main.js`: 2,566 → **2,430 lines** (from 2,814 at the split's start).

> Note: branch is named `…extract-toc` — I pivoted to annotations because TOC's state (`tocVisible`/`tocEntries`) is shared across view-mode/iOS/fullscreen and needs the shared-state module first.

## Verified
- `npm run build` ✓, `npm run lint` ✓, `npm test` → **297 passed**.

https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA)_