### PR TITLE
Phase 1: extract features/repo-browser.js

### DIFF
--- a/markdown-viewer/src/features/repo-browser.js
+++ b/markdown-viewer/src/features/repo-browser.js
@@ -1,0 +1,127 @@
+// GitHub repo file browser: accept a github.com/<owner>/<repo> URL and show a
+// list of the repo's markdown files to pick from.
+//
+// Decoupled from the rest of the app via dependency injection — the caller
+// supplies the URL-error UI hooks and the file-selection handler.
+
+import { escapeHtml } from '../core/utils.js';
+
+/**
+ * Fetch the markdown files for a GitHub repo URL via the Search API.
+ * @returns {Promise<Array<{path,url,rawUrl}>|null>} files, [] if none, or null
+ *   when the URL isn't a recognized repo URL / the fetch failed.
+ */
+export async function fetchGitHubRepoFiles(repoUrl) {
+  // Match: https://github.com/<owner>/<repo>
+  const repoPattern = /^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/?$/;
+  const match = repoUrl.match(repoPattern);
+  if (!match) return null;
+
+  const owner = match[1];
+  const repo = match[2].replace(/\.git$/, '');
+
+  // Use GitHub Search API to find .md files (avoids full tree traversal)
+  const apiUrl = `https://api.github.com/search/code?q=extension:md+repo:${owner}/${repo}&per_page=100`;
+
+  try {
+    const resp = await fetch(apiUrl, {
+      headers: { Accept: 'application/vnd.github+json' },
+    });
+    if (!resp.ok) return null;
+    const data = await resp.json();
+    if (!data.items || data.items.length === 0) return [];
+
+    return data.items.map((item) => ({
+      path: item.path,
+      url: item.html_url,
+      rawUrl: `https://raw.githubusercontent.com/${owner}/${repo}/HEAD/${item.path}`,
+    }));
+  } catch (e) {
+    return null;
+  }
+}
+
+/**
+ * Handle a repo URL: fetch its markdown files and present the browser.
+ * @param {string} url
+ * @param {{ clearError: Function, showError: Function, onSelectFile: Function }} hooks
+ * @returns {Promise<boolean>} true if handled as a repo URL (caller should stop).
+ */
+export async function handleRepoUrl(url, { clearError, showError, onSelectFile }) {
+  clearError();
+  const files = await fetchGitHubRepoFiles(url);
+  if (files === null) {
+    // Not a repo URL or fetch failed — fall through to normal URL handling
+    return false;
+  }
+  if (files.length === 0) {
+    showError('No markdown files found in this repository.');
+    return true;
+  }
+
+  showRepoBrowser(files, url, onSelectFile);
+  return true;
+}
+
+function showRepoBrowser(files, repoUrl, onSelectFile) {
+  let modal = document.getElementById('repo-browser-modal');
+  if (!modal) {
+    modal = document.createElement('div');
+    modal.id = 'repo-browser-modal';
+    modal.className = 'repo-browser-modal';
+    document.body.appendChild(modal);
+  }
+
+  const repoName = repoUrl.replace(/^https?:\/\/github\.com\//, '').replace(/\/$/, '');
+
+  modal.innerHTML = `
+        <div class="repo-browser-content">
+            <div class="repo-browser-header">
+                <span class="repo-browser-title">${escapeHtml(repoName)}</span>
+                <button class="repo-browser-close" title="Close">&#10005;</button>
+            </div>
+            <div class="repo-browser-search">
+                <input type="text" class="repo-browser-filter" placeholder="Filter files..." autocomplete="off">
+            </div>
+            <ul class="repo-browser-list">
+                ${files
+                  .map(
+                    (f) => `
+                    <li class="repo-browser-item" data-raw-url="${escapeHtml(f.rawUrl)}">
+                        <span class="repo-file-icon">📄</span>
+                        <span class="repo-file-path">${escapeHtml(f.path)}</span>
+                    </li>
+                `
+                  )
+                  .join('')}
+            </ul>
+        </div>
+    `;
+  modal.style.display = 'flex';
+
+  modal.querySelector('.repo-browser-close').addEventListener('click', () => {
+    modal.style.display = 'none';
+  });
+
+  modal.addEventListener('click', (e) => {
+    if (e.target === modal) modal.style.display = 'none';
+  });
+
+  const filterInput = modal.querySelector('.repo-browser-filter');
+  filterInput.addEventListener('input', () => {
+    const q = filterInput.value.toLowerCase();
+    modal.querySelectorAll('.repo-browser-item').forEach((item) => {
+      const path = item.querySelector('.repo-file-path').textContent.toLowerCase();
+      item.style.display = path.includes(q) ? '' : 'none';
+    });
+  });
+  filterInput.focus();
+
+  modal.querySelectorAll('.repo-browser-item').forEach((item) => {
+    item.addEventListener('click', () => {
+      const rawUrl = item.getAttribute('data-raw-url');
+      modal.style.display = 'none';
+      onSelectFile(rawUrl);
+    });
+  });
+}

--- a/markdown-viewer/src/main.js
+++ b/markdown-viewer/src/main.js
@@ -34,6 +34,7 @@ import {
   toggleAnnotationMode,
   renderAnnotations,
 } from './features/annotations.js';
+import { handleRepoUrl } from './features/repo-browser.js';
 
 // ===========================
 // Constants
@@ -929,7 +930,11 @@ async function handleUrl(url) {
     // Check if this is a GitHub repo URL to show the file browser
     const isRepoBrowserUrl = /^https?:\/\/github\.com\/[^/]+\/[^/]+\/?$/.test(url);
     if (isRepoBrowserUrl) {
-        const handled = await handleRepoUrl(url);
+        const handled = await handleRepoUrl(url, {
+            clearError: clearUrlError,
+            showError: showUrlError,
+            onSelectFile: handleUrl,
+        });
         if (handled) {
             if (urlInput) urlInput.value = '';
             return;
@@ -2311,117 +2316,6 @@ function applyCustomCss(cssContent) {
         document.head.appendChild(customStyleEl);
     }
     customStyleEl.textContent = cssContent || '';
-}
-
-// ===========================
-// Feature: GitHub Repo File Browser
-// ===========================
-// Enhances the URL input to accept github.com/<owner>/<repo> URLs and
-// show a list of .md files from the repo for the user to pick one.
-
-async function fetchGitHubRepoFiles(repoUrl) {
-    // Match: https://github.com/<owner>/<repo>
-    const repoPattern = /^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/?$/;
-    const match = repoUrl.match(repoPattern);
-    if (!match) return null;
-
-    const owner = match[1];
-    const repo = match[2].replace(/\.git$/, '');
-
-    // Use GitHub Search API to find .md files (avoids full tree traversal)
-    const apiUrl = `https://api.github.com/search/code?q=extension:md+repo:${owner}/${repo}&per_page=100`;
-
-    try {
-        const resp = await fetch(apiUrl, {
-            headers: { Accept: 'application/vnd.github+json' }
-        });
-        if (!resp.ok) return null;
-        const data = await resp.json();
-        if (!data.items || data.items.length === 0) return [];
-
-        return data.items.map((item) => ({
-            path: item.path,
-            url: item.html_url,
-            rawUrl: `https://raw.githubusercontent.com/${owner}/${repo}/HEAD/${item.path}`
-        }));
-    } catch (e) {
-        return null;
-    }
-}
-
-async function handleRepoUrl(url) {
-    clearUrlError();
-    const files = await fetchGitHubRepoFiles(url);
-    if (files === null) {
-        // Not a repo URL or fetch failed — fall through to normal URL handling
-        return false;
-    }
-    if (files.length === 0) {
-        showUrlError('No markdown files found in this repository.');
-        return true;
-    }
-
-    showRepoBrowser(files, url);
-    return true;
-}
-
-function showRepoBrowser(files, repoUrl) {
-    let modal = document.getElementById('repo-browser-modal');
-    if (!modal) {
-        modal = document.createElement('div');
-        modal.id = 'repo-browser-modal';
-        modal.className = 'repo-browser-modal';
-        document.body.appendChild(modal);
-    }
-
-    const repoName = repoUrl.replace(/^https?:\/\/github\.com\//, '').replace(/\/$/, '');
-
-    modal.innerHTML = `
-        <div class="repo-browser-content">
-            <div class="repo-browser-header">
-                <span class="repo-browser-title">${escapeHtml(repoName)}</span>
-                <button class="repo-browser-close" title="Close">&#10005;</button>
-            </div>
-            <div class="repo-browser-search">
-                <input type="text" class="repo-browser-filter" placeholder="Filter files..." autocomplete="off">
-            </div>
-            <ul class="repo-browser-list">
-                ${files.map((f) => `
-                    <li class="repo-browser-item" data-raw-url="${escapeHtml(f.rawUrl)}">
-                        <span class="repo-file-icon">📄</span>
-                        <span class="repo-file-path">${escapeHtml(f.path)}</span>
-                    </li>
-                `).join('')}
-            </ul>
-        </div>
-    `;
-    modal.style.display = 'flex';
-
-    modal.querySelector('.repo-browser-close').addEventListener('click', () => {
-        modal.style.display = 'none';
-    });
-
-    modal.addEventListener('click', (e) => {
-        if (e.target === modal) modal.style.display = 'none';
-    });
-
-    const filterInput = modal.querySelector('.repo-browser-filter');
-    filterInput.addEventListener('input', () => {
-        const q = filterInput.value.toLowerCase();
-        modal.querySelectorAll('.repo-browser-item').forEach((item) => {
-            const path = item.querySelector('.repo-file-path').textContent.toLowerCase();
-            item.style.display = path.includes(q) ? '' : 'none';
-        });
-    });
-    filterInput.focus();
-
-    modal.querySelectorAll('.repo-browser-item').forEach((item) => {
-        item.addEventListener('click', () => {
-            const rawUrl = item.getAttribute('data-raw-url');
-            modal.style.display = 'none';
-            handleUrl(rawUrl);
-        });
-    });
 }
 
 // ===========================

--- a/tests/unit/githubRepoBrowser.test.js
+++ b/tests/unit/githubRepoBrowser.test.js
@@ -214,16 +214,22 @@ describe('GitHub Repo Browser', () => {
   // handleRepoUrl
   // ===========================
   describe('handleRepoUrl', () => {
+    const hooks = () => ({
+      clearError: jest.fn(),
+      showError: jest.fn(),
+      onSelectFile: jest.fn(),
+    });
+
     it('returns false for a non-GitHub URL', async () => {
       global.fetch = jest.fn(); // should not be called
-      const result = await handleRepoUrl('https://example.com/not-a-repo');
+      const result = await handleRepoUrl('https://example.com/not-a-repo', hooks());
       expect(result).toBe(false);
     });
 
     it('returns false when fetchGitHubRepoFiles returns null (fetch failed)', async () => {
       global.fetch = jest.fn().mockResolvedValue({ ok: false });
 
-      const result = await handleRepoUrl('https://github.com/owner/repo');
+      const result = await handleRepoUrl('https://github.com/owner/repo', hooks());
       expect(result).toBe(false);
     });
 
@@ -233,7 +239,7 @@ describe('GitHub Repo Browser', () => {
         json: async () => ({ items: [] }),
       });
 
-      const result = await handleRepoUrl('https://github.com/owner/repo');
+      const result = await handleRepoUrl('https://github.com/owner/repo', hooks());
       expect(result).toBe(true);
     });
 
@@ -245,7 +251,7 @@ describe('GitHub Repo Browser', () => {
         }),
       });
 
-      const result = await handleRepoUrl('https://github.com/owner/repo');
+      const result = await handleRepoUrl('https://github.com/owner/repo', hooks());
       expect(result).toBe(true);
 
       const modal = document.getElementById('repo-browser-modal');


### PR DESCRIPTION
Continues the Phase 1 module split. Pure refactor — no behavior change.

## Extraction
`markdown-viewer/src/features/repo-browser.js` — the GitHub repo file browser (`fetchGitHubRepoFiles`, `handleRepoUrl`, and the private `showRepoBrowser` modal).

This one couples to the URL-loading pipeline (error UI + file loading), so it's extracted via **dependency injection** rather than reaching back into the entry:

```js
handleRepoUrl(url, { clearError, showError, onSelectFile })
```

`main.js` passes `clearUrlError`, `showUrlError`, and `handleUrl` (as `onSelectFile`). The repo-browser tests were updated to pass the hooks.

`main.js`: 2,430 → **2,324 lines** (from 2,814 at the split's start).

## Verified
- `npm run build` ✓, `npm run lint` ✓, `npm test` → **297 passed**.

https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA)_