### PR TITLE
Phase 1: extract features/minimap.js + features/custom-css.js

### DIFF
--- a/markdown-viewer/src/features/custom-css.js
+++ b/markdown-viewer/src/features/custom-css.js
@@ -1,0 +1,12 @@
+// Custom CSS themes (desktop): inject a user-supplied stylesheet into the page.
+
+let customStyleEl = null;
+
+export function applyCustomCss(cssContent) {
+  if (!customStyleEl) {
+    customStyleEl = document.createElement('style');
+    customStyleEl.id = 'custom-theme';
+    document.head.appendChild(customStyleEl);
+  }
+  customStyleEl.textContent = cssContent || '';
+}

--- a/markdown-viewer/src/features/minimap.js
+++ b/markdown-viewer/src/features/minimap.js
@@ -1,0 +1,73 @@
+// Diagram minimap (shown in the fullscreen overlay): a scaled-down render of
+// the diagram plus a viewport indicator reflecting the current pan/zoom.
+
+import { getSvgNaturalDimensions } from '../core/utils.js';
+
+/** Render the diagram SVG into the minimap canvas. */
+export function updateMinimap(svgElement) {
+  const minimapEl = document.getElementById('fullscreen-minimap');
+  const canvas = document.getElementById('minimap-canvas');
+  if (!minimapEl || !canvas) return;
+
+  const dims = getSvgNaturalDimensions(svgElement);
+  if (!dims) {
+    minimapEl.style.display = 'none';
+    return;
+  }
+
+  minimapEl.style.display = '';
+
+  const MAX_MINIMAP = 160;
+  const scale = Math.min(MAX_MINIMAP / dims.width, MAX_MINIMAP / dims.height);
+  canvas.width = Math.round(dims.width * scale);
+  canvas.height = Math.round(dims.height * scale);
+  canvas.style.width = canvas.width + 'px';
+  canvas.style.height = canvas.height + 'px';
+
+  // Render the SVG into the minimap canvas via an image
+  const serializer = new XMLSerializer();
+  const svgStr = serializer.serializeToString(svgElement);
+  const blob = new Blob([svgStr], { type: 'image/svg+xml;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const img = new Image();
+  img.onload = () => {
+    const ctx = canvas.getContext('2d');
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+    URL.revokeObjectURL(url);
+  };
+  img.onerror = () => URL.revokeObjectURL(url);
+  img.src = url;
+}
+
+/** Position the minimap viewport rectangle for the current pan/zoom. */
+export function updateMinimapViewport(panzoomInstance, wrapper) {
+  const viewportEl = document.getElementById('minimap-viewport');
+  const canvas = document.getElementById('minimap-canvas');
+  if (!viewportEl || !canvas || !panzoomInstance) return;
+
+  const pan = panzoomInstance.getPan();
+  const scale = panzoomInstance.getScale();
+  const wW = wrapper.clientWidth;
+  const wH = wrapper.clientHeight;
+  const cW = canvas.width;
+  const cH = canvas.height;
+
+  // The SVG has dims.width x dims.height at scale 1.
+  // The viewport shows wW/scale x wH/scale of the SVG content.
+  // The minimap scale factor: cW / dims.width
+  const svgEl = wrapper.querySelector('svg');
+  const dims = svgEl ? getSvgNaturalDimensions(svgEl) : null;
+  if (!dims) return;
+
+  const minimapScale = cW / dims.width;
+  const vpW = Math.min((wW / scale) * minimapScale, cW);
+  const vpH = Math.min((wH / scale) * minimapScale, cH);
+  const vpX = (-pan.x / scale) * minimapScale;
+  const vpY = (-pan.y / scale) * minimapScale;
+
+  viewportEl.style.left = Math.max(0, vpX) + 'px';
+  viewportEl.style.top = Math.max(0, vpY) + 'px';
+  viewportEl.style.width = vpW + 'px';
+  viewportEl.style.height = vpH + 'px';
+}

--- a/markdown-viewer/src/main.js
+++ b/markdown-viewer/src/main.js
@@ -35,6 +35,8 @@ import {
   renderAnnotations,
 } from './features/annotations.js';
 import { handleRepoUrl } from './features/repo-browser.js';
+import { updateMinimap, updateMinimapViewport } from './features/minimap.js';
+import { applyCustomCss } from './features/custom-css.js';
 
 // ===========================
 // Constants
@@ -2235,87 +2237,6 @@ function checkForDiagramLink() {
     } catch (e) {
         // Silently ignore malformed deep links
     }
-}
-
-// ===========================
-// Feature: Diagram Minimap (Fullscreen)
-// ===========================
-function updateMinimap(svgElement) {
-    const minimapEl = document.getElementById('fullscreen-minimap');
-    const canvas = document.getElementById('minimap-canvas');
-    if (!minimapEl || !canvas) return;
-
-    const dims = getSvgNaturalDimensions(svgElement);
-    if (!dims) { minimapEl.style.display = 'none'; return; }
-
-    minimapEl.style.display = '';
-
-    const MAX_MINIMAP = 160;
-    const scale = Math.min(MAX_MINIMAP / dims.width, MAX_MINIMAP / dims.height);
-    canvas.width = Math.round(dims.width * scale);
-    canvas.height = Math.round(dims.height * scale);
-    canvas.style.width = canvas.width + 'px';
-    canvas.style.height = canvas.height + 'px';
-
-    // Render the SVG into the minimap canvas via an image
-    const serializer = new XMLSerializer();
-    const svgStr = serializer.serializeToString(svgElement);
-    const blob = new Blob([svgStr], { type: 'image/svg+xml;charset=utf-8' });
-    const url = URL.createObjectURL(blob);
-    const img = new Image();
-    img.onload = () => {
-        const ctx = canvas.getContext('2d');
-        ctx.clearRect(0, 0, canvas.width, canvas.height);
-        ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
-        URL.revokeObjectURL(url);
-    };
-    img.onerror = () => URL.revokeObjectURL(url);
-    img.src = url;
-}
-
-function updateMinimapViewport(panzoomInstance, wrapper) {
-    const viewportEl = document.getElementById('minimap-viewport');
-    const canvas = document.getElementById('minimap-canvas');
-    if (!viewportEl || !canvas || !panzoomInstance) return;
-
-    const pan = panzoomInstance.getPan();
-    const scale = panzoomInstance.getScale();
-    const wW = wrapper.clientWidth;
-    const wH = wrapper.clientHeight;
-    const cW = canvas.width;
-    const cH = canvas.height;
-
-    // The SVG has dims.width x dims.height at scale 1.
-    // The viewport shows wW/scale x wH/scale of the SVG content.
-    // The minimap scale factor: cW / dims.width
-    const svgEl = wrapper.querySelector('svg');
-    const dims = svgEl ? getSvgNaturalDimensions(svgEl) : null;
-    if (!dims) return;
-
-    const minimapScale = cW / dims.width;
-    const vpW = Math.min((wW / scale) * minimapScale, cW);
-    const vpH = Math.min((wH / scale) * minimapScale, cH);
-    const vpX = (-pan.x / scale) * minimapScale;
-    const vpY = (-pan.y / scale) * minimapScale;
-
-    viewportEl.style.left = Math.max(0, vpX) + 'px';
-    viewportEl.style.top = Math.max(0, vpY) + 'px';
-    viewportEl.style.width = vpW + 'px';
-    viewportEl.style.height = vpH + 'px';
-}
-
-// ===========================
-// Feature: Custom CSS Themes
-// ===========================
-let customStyleEl = null;
-
-function applyCustomCss(cssContent) {
-    if (!customStyleEl) {
-        customStyleEl = document.createElement('style');
-        customStyleEl.id = 'custom-theme';
-        document.head.appendChild(customStyleEl);
-    }
-    customStyleEl.textContent = cssContent || '';
 }
 
 // ===========================


### PR DESCRIPTION
Continues the Phase 1 module split. Pure refactor — no behavior change.

## Extractions
Two more **self-contained** features (no shared app state):
- `features/minimap.js` — `updateMinimap` / `updateMinimapViewport` (fullscreen diagram minimap). Operate on the passed SVG element / panzoom instance / wrapper + `getSvgNaturalDimensions` from `core/utils`.
- `features/custom-css.js` — `applyCustomCss` (desktop user stylesheet injection); its `customStyleEl` handle is now module-private.

`main.js`: 2,324 → **2,245 lines** (from 2,814 at the split's start).

> Branch is named `…core-state` — I'd intended to start the shared-state module, but TOC/split-view/tabs are entangled with the iOS-chrome layer *and* shared state, so I did these clean self-contained features first. The coupled tier needs `core/state.js` + a platform module as a deliberate next step (see below).

## What's left in the split
The remaining ~2,245 lines are the tightly-interconnected core — render pipeline, diagram/panzoom/fullscreen, tabs, theme, view-mode, TOC, split-view, iOS chrome, desktop IPC. They share mutable state (`currentViewMode`, `currentRawMarkdown`, `tocVisible`, `tabs`…) and call the iOS-chrome layer, so the next step is standing up `core/state.js` + `core/platform.js` before extracting those clusters.

## Verified
- `npm run build` ✓, `npm run lint` ✓, `npm test` → **297 passed**.

https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA)_