### PR TITLE
Phase 1: core/platform.js + core/state.js foundation

### DIFF
--- a/markdown-viewer/src/core/platform.js
+++ b/markdown-viewer/src/core/platform.js
@@ -1,0 +1,18 @@
+// Platform detection. The native shells inject their flags before the bundle
+// runs — the Electron preload sets window.specdown, and the iOS WKUserScript
+// sets window.iosNative at document start — so these evaluate correctly when
+// this module is first imported.
+
+export const isDesktop = !!(
+  typeof window !== 'undefined' &&
+  window.specdown &&
+  window.specdown.isDesktop
+);
+
+export const isIOSNative = !!(
+  typeof window !== 'undefined' &&
+  window.iosNative &&
+  window.webkit &&
+  window.webkit.messageHandlers &&
+  window.webkit.messageHandlers.specdown
+);

--- a/markdown-viewer/src/core/state.js
+++ b/markdown-viewer/src/core/state.js
@@ -1,0 +1,14 @@
+// Shared mutable app state.
+//
+// Modules import this object and read/mutate its fields. ESM forbids
+// reassigning an imported binding, but mutating a property of an imported
+// object is fine — so shared state lives here as object fields rather than
+// bare module-level `let`s. This object grows as the entry module is split
+// into feature modules that need to share state.
+
+export const state = {
+  // Table of contents
+  tocVisible: false,
+  tocEntries: [],
+  tocScrollSpyScheduled: false,
+};

--- a/markdown-viewer/src/main.js
+++ b/markdown-viewer/src/main.js
@@ -14,6 +14,8 @@ import DOMPurify from 'dompurify';
 import 'highlight.js/styles/github-dark.css';
 
 // Internal modules (Phase 1 split — extracting cohesive units out of this entry).
+import { isDesktop, isIOSNative } from './core/platform.js';
+import { state } from './core/state.js';
 import {
   escapeHtml,
   normalizeMarkdownUrl,
@@ -64,20 +66,6 @@ let nextTabId = 0;
 const MAX_TABS = 10;
 const watchRefCounts = new Map(); // filePath -> number of watching tabs
 
-// Desktop detection
-const isDesktop = !!(typeof window !== 'undefined' && window.specdown && window.specdown.isDesktop);
-const isIOSNative = !!(
-    typeof window !== 'undefined'
-    && window.iosNative
-    && window.webkit
-    && window.webkit.messageHandlers
-    && window.webkit.messageHandlers.specdown
-);
-
-// TOC state
-let tocVisible = false;
-let tocEntries = [];
-let tocScrollSpyScheduled = false;
 
 // Split view state
 let splitViewActive = false;
@@ -213,7 +201,7 @@ function closeIOSActionSheet() {
 
 function closeIOSTocSheet() {
     setIOSSheetVisibility(iosTocSheet, false);
-    tocVisible = false;
+    state.tocVisible = false;
     if (tocToggle) tocToggle.classList.remove('active');
     syncIOSChrome();
 }
@@ -410,7 +398,7 @@ function syncIOSChrome() {
 
     const hasContent = hasLoadedContent();
     const showActionBar = (hasContent || tabs.length > 0) && iosLayoutMode !== 'pad';
-    const canShowContents = hasContent && currentViewMode === 'preview' && tocEntries.length > 0;
+    const canShowContents = hasContent && currentViewMode === 'preview' && state.tocEntries.length > 0;
 
     if (iosActionBar) {
         iosActionBar.style.display = showActionBar ? 'grid' : 'none';
@@ -418,7 +406,7 @@ function syncIOSChrome() {
 
     if (iosContentsButton) {
         iosContentsButton.disabled = !canShowContents;
-        iosContentsButton.classList.toggle('active', tocVisible);
+        iosContentsButton.classList.toggle('active', state.tocVisible);
     }
 
     if (iosViewButton) {
@@ -535,7 +523,7 @@ function toggleViewMode() {
 
     if (currentViewMode === 'preview') {
         currentViewMode = 'raw';
-        if (tocVisible) {
+        if (state.tocVisible) {
             toggleToc(false);
         }
         // Clean up panzoom before switching
@@ -1594,11 +1582,11 @@ function showDropZone() {
     renderTabBar();
 
     // Reset TOC and split view
-    if (tocVisible) toggleToc(false);
+    if (state.tocVisible) toggleToc(false);
     if (splitViewActive) toggleSplitView();
     if (tocNav) tocNav.innerHTML = '';
     if (iosTocNav) iosTocNav.innerHTML = '';
-    tocEntries = [];
+    state.tocEntries = [];
     if (tocSidebar) tocSidebar.style.display = 'none';
 
     // Show drop zone, hide content
@@ -1783,7 +1771,7 @@ async function switchTab(id) {
     cleanupPanzoomInstances();
 
     if (tab.viewMode === 'raw') {
-        if (tocVisible) {
+        if (state.tocVisible) {
             toggleToc(false);
         }
         currentRawMarkdown = tab.rawMarkdown;
@@ -1838,7 +1826,7 @@ async function closeTab(id) {
         if (isDesktop) updateWatchToggle();
 
         if (newTab.viewMode === 'raw') {
-            if (tocVisible) {
+            if (state.tocVisible) {
                 toggleToc(false);
             }
             currentRawMarkdown = newTab.rawMarkdown;
@@ -2048,7 +2036,7 @@ function saveDesktopSession() {
 function buildToc() {
     if (!tocNav && !iosTocNav) return;
     const headings = markdownContent.querySelectorAll('h1, h2, h3, h4');
-    tocEntries = [];
+    state.tocEntries = [];
 
     headings.forEach((h, i) => {
         // Ensure each heading has an id for anchor linking
@@ -2056,7 +2044,7 @@ function buildToc() {
             h.id = 'toc-heading-' + i;
         }
 
-        tocEntries.push({
+        state.tocEntries.push({
             id: h.id,
             level: parseInt(h.tagName[1], 10),
             text: h.textContent
@@ -2067,10 +2055,10 @@ function buildToc() {
     renderTocNavigation(iosTocNav);
 
     if (tocToggle) {
-        tocToggle.style.display = tocEntries.length > 0 && !isIOSNative ? '' : 'none';
+        tocToggle.style.display = state.tocEntries.length > 0 && !isIOSNative ? '' : 'none';
     }
 
-    if (tocEntries.length === 0 && tocVisible) {
+    if (state.tocEntries.length === 0 && state.tocVisible) {
         toggleToc(false);
     } else {
         scheduleTocActiveHeadingUpdate();
@@ -2083,7 +2071,7 @@ function renderTocNavigation(navElement) {
     if (!navElement) return;
     navElement.innerHTML = '';
 
-    tocEntries.forEach((entry) => {
+    state.tocEntries.forEach((entry) => {
         const link = document.createElement('a');
         link.className = 'toc-link toc-level-' + entry.level;
         link.href = '#' + entry.id;
@@ -2102,14 +2090,14 @@ function renderTocNavigation(navElement) {
 }
 
 function toggleToc(forceState) {
-    const nextVisible = typeof forceState === 'boolean' ? forceState : !tocVisible;
-    if (isIOSNative && nextVisible && (currentViewMode !== 'preview' || tocEntries.length === 0)) {
+    const nextVisible = typeof forceState === 'boolean' ? forceState : !state.tocVisible;
+    if (isIOSNative && nextVisible && (currentViewMode !== 'preview' || state.tocEntries.length === 0)) {
         return;
     }
 
-    tocVisible = nextVisible;
+    state.tocVisible = nextVisible;
     if (isIOSNative) {
-        if (tocVisible) {
+        if (state.tocVisible) {
             closeIOSActionSheet();
             setIOSSheetVisibility(iosTocSheet, true);
             updateTocActiveHeading();
@@ -2117,23 +2105,23 @@ function toggleToc(forceState) {
             setIOSSheetVisibility(iosTocSheet, false);
         }
     } else if (tocSidebar) {
-        tocSidebar.style.display = tocVisible ? '' : 'none';
+        tocSidebar.style.display = state.tocVisible ? '' : 'none';
     }
-    if (tocToggle) tocToggle.classList.toggle('active', tocVisible);
+    if (tocToggle) tocToggle.classList.toggle('active', state.tocVisible);
     syncIOSChrome();
 }
 
 function scheduleTocActiveHeadingUpdate() {
-    if (!tocVisible || tocScrollSpyScheduled) return;
-    tocScrollSpyScheduled = true;
+    if (!state.tocVisible || state.tocScrollSpyScheduled) return;
+    state.tocScrollSpyScheduled = true;
     requestAnimationFrame(() => {
-        tocScrollSpyScheduled = false;
+        state.tocScrollSpyScheduled = false;
         updateTocActiveHeading();
     });
 }
 
 function updateTocActiveHeading() {
-    if (!tocVisible) return;
+    if (!state.tocVisible) return;
     const headings = markdownContent.querySelectorAll('h1, h2, h3, h4');
     const scrollTop = markdownContent.scrollTop;
     let activeId = null;

--- a/tests/unit/toc.test.js
+++ b/tests/unit/toc.test.js
@@ -140,11 +140,11 @@ describe('Table of Contents', () => {
     });
 
     it('updates tocVisible state correctly', () => {
-      expect(tocVisible).toBe(false);
+      expect(state.tocVisible).toBe(false);
       toggleToc();
-      expect(tocVisible).toBe(true);
+      expect(state.tocVisible).toBe(true);
       toggleToc();
-      expect(tocVisible).toBe(false);
+      expect(state.tocVisible).toBe(false);
     });
   });
 
@@ -181,11 +181,11 @@ describe('Table of Contents', () => {
     it('resets tocVisible to false', async () => {
       await renderMarkdown('# Title', 'test.md');
       toggleToc();
-      expect(tocVisible).toBe(true);
+      expect(state.tocVisible).toBe(true);
 
       showDropZone();
 
-      expect(tocVisible).toBe(false);
+      expect(state.tocVisible).toBe(false);
     });
   });
 });


### PR DESCRIPTION
Stands up the two foundation modules the interconnected core needs before its clusters can be split out. Pure refactor — no behavior change.

## New modules
- **`core/platform.js`** — `isDesktop` / `isIOSNative` constants. The native shells inject their flags before the bundle runs (Electron preload → `window.specdown`; iOS WKUserScript → `window.iosNative` at document start), so these evaluate correctly at import.
- **`core/state.js`** — a shared mutable `state` object. ESM forbids reassigning an imported binding but allows mutating an imported object's fields, so shared state lives here as `state.x` rather than bare module-level `let`s. Migrated the TOC state (`tocVisible`, `tocEntries`, `tocScrollSpyScheduled`) as the first fields; the object grows as coupled features are extracted.

The test harness inlines both modules (so `state` is a global object under test); `toc.test.js` updated to read `state.tocVisible`.

## Why this matters
The remaining `main.js` core (TOC, split-view, tabs, view-mode, render, iOS chrome) shares mutable state and can't be cleanly extracted while that state is bare globals. This unblocks those extractions — each coupled feature can now `import { state }` and migrate its fields incrementally (migrating only what it needs, since some identifiers like `tabs` appear in strings/comments and can't be blanket-renamed).

## Verified
- `npm run build` ✓, `npm run lint` ✓, `npm test` → **297 passed**.

https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA)_