### PR TITLE
Phase 1: migrate shared state into core/state.js

### DIFF
--- a/markdown-viewer/src/core/state.js
+++ b/markdown-viewer/src/core/state.js
@@ -7,8 +7,23 @@
 // into feature modules that need to share state.
 
 export const state = {
+  // Render / view
+  currentPanzoomInstances: [],
+  currentTheme: localStorage.getItem('theme') || 'light',
+  currentRawMarkdown: '',
+  currentViewMode: 'preview', // 'preview' or 'raw'
+
+  // Tabs (the `tabs` array itself stays in main.js for now — it appears in a
+  // user-facing string/comment and is migrated with the tabs extraction)
+  activeTabId: null,
+  nextTabId: 0,
+
   // Table of contents
   tocVisible: false,
   tocEntries: [],
   tocScrollSpyScheduled: false,
+
+  // Split view / iOS layout
+  splitViewActive: false,
+  iosLayoutMode: 'phone',
 };

--- a/markdown-viewer/src/main.js
+++ b/markdown-viewer/src/main.js
@@ -54,22 +54,14 @@ const MAX_DIAGRAM_URL_PARAM_LENGTH = 65536;
 // ===========================
 // Global State
 // ===========================
-let currentPanzoomInstances = [];
-let currentTheme = localStorage.getItem('theme') || 'light';
-let currentRawMarkdown = '';
-let currentViewMode = 'preview'; // 'preview' or 'raw'
 
 // Tab state
 let tabs = [];         // Array of { id, filename, filePath, rawMarkdown, viewMode, scrollTop, watching }
-let activeTabId = null;
-let nextTabId = 0;
 const MAX_TABS = 10;
 const watchRefCounts = new Map(); // filePath -> number of watching tabs
 
 
 // Split view state
-let splitViewActive = false;
-let iosLayoutMode = 'phone';
 
 
 // ===========================
@@ -144,8 +136,8 @@ function setupIOSNativeUI() {
     if (iosSampleSection) {
         iosSampleSection.style.display = isIOSNative ? '' : 'none';
     }
-    document.body.classList.toggle('ios-pad', isIOSNative && iosLayoutMode === 'pad');
-    document.documentElement.classList.toggle('ios-pad', isIOSNative && iosLayoutMode === 'pad');
+    document.body.classList.toggle('ios-pad', isIOSNative && state.iosLayoutMode === 'pad');
+    document.documentElement.classList.toggle('ios-pad', isIOSNative && state.iosLayoutMode === 'pad');
     syncIOSChrome();
 }
 
@@ -187,7 +179,7 @@ function requestNativePrintIfAvailable() {
 }
 
 function hasLoadedContent() {
-    return !!(contentArea && contentArea.style.display !== 'none' && currentRawMarkdown);
+    return !!(contentArea && contentArea.style.display !== 'none' && state.currentRawMarkdown);
 }
 
 function setIOSSheetVisibility(sheet, visible) {
@@ -228,11 +220,11 @@ function performPrint() {
 }
 
 window.setIOSLayoutMode = function(mode) {
-    iosLayoutMode = mode === 'pad' ? 'pad' : 'phone';
+    state.iosLayoutMode = mode === 'pad' ? 'pad' : 'phone';
     if (isIOSNative) {
-        document.body.classList.toggle('ios-pad', iosLayoutMode === 'pad');
-        document.documentElement.classList.toggle('ios-pad', iosLayoutMode === 'pad');
-        if (iosLayoutMode === 'pad') {
+        document.body.classList.toggle('ios-pad', state.iosLayoutMode === 'pad');
+        document.documentElement.classList.toggle('ios-pad', state.iosLayoutMode === 'pad');
+        if (state.iosLayoutMode === 'pad') {
             closeIOSActionSheet();
             closeIOSTocSheet();
         }
@@ -397,8 +389,8 @@ function syncIOSChrome() {
     if (!isIOSNative) return;
 
     const hasContent = hasLoadedContent();
-    const showActionBar = (hasContent || tabs.length > 0) && iosLayoutMode !== 'pad';
-    const canShowContents = hasContent && currentViewMode === 'preview' && state.tocEntries.length > 0;
+    const showActionBar = (hasContent || tabs.length > 0) && state.iosLayoutMode !== 'pad';
+    const canShowContents = hasContent && state.currentViewMode === 'preview' && state.tocEntries.length > 0;
 
     if (iosActionBar) {
         iosActionBar.style.display = showActionBar ? 'grid' : 'none';
@@ -411,16 +403,16 @@ function syncIOSChrome() {
 
     if (iosViewButton) {
         iosViewButton.disabled = !hasContent;
-        iosViewButton.classList.toggle('active', currentViewMode === 'raw');
-        updateIOSActionButtonLabel(iosViewButton, currentViewMode === 'preview' ? 'Raw' : 'Preview');
+        iosViewButton.classList.toggle('active', state.currentViewMode === 'raw');
+        updateIOSActionButtonLabel(iosViewButton, state.currentViewMode === 'preview' ? 'Raw' : 'Preview');
     }
 
     if (iosMoreButton) {
         iosMoreButton.disabled = !hasContent;
     }
 
-    updateIOSSheetButton(iosSplitButton, splitViewActive ? 'Hide Split View' : 'Show Split View', splitViewActive);
-    updateIOSSheetButton(iosThemeButton, currentTheme === 'light' ? 'Switch to Dark Mode' : 'Switch to Light Mode', false);
+    updateIOSSheetButton(iosSplitButton, state.splitViewActive ? 'Hide Split View' : 'Show Split View', state.splitViewActive);
+    updateIOSSheetButton(iosThemeButton, state.currentTheme === 'light' ? 'Switch to Dark Mode' : 'Switch to Light Mode', false);
 
     if (iosSplitButton) iosSplitButton.disabled = !hasContent;
     if (iosPrintButton) iosPrintButton.disabled = !hasContent;
@@ -476,14 +468,14 @@ function checkForUpdates() {
 // Theme Management
 // ===========================
 function setupTheme() {
-    document.documentElement.setAttribute('data-theme', currentTheme);
+    document.documentElement.setAttribute('data-theme', state.currentTheme);
     updateThemeIcon();
 }
 
 function toggleTheme() {
-    currentTheme = currentTheme === 'light' ? 'dark' : 'light';
-    document.documentElement.setAttribute('data-theme', currentTheme);
-    localStorage.setItem('theme', currentTheme);
+    state.currentTheme = state.currentTheme === 'light' ? 'dark' : 'light';
+    document.documentElement.setAttribute('data-theme', state.currentTheme);
+    localStorage.setItem('theme', state.currentTheme);
     updateThemeIcon();
     syncIOSChrome();
     
@@ -495,14 +487,14 @@ function toggleTheme() {
 
 function updateThemeIcon() {
     const icon = themeToggle.querySelector('.theme-icon');
-    icon.textContent = currentTheme === 'light' ? '🌙' : '☀️';
+    icon.textContent = state.currentTheme === 'light' ? '🌙' : '☀️';
 }
 
 // iOS API: called by Swift shell to set theme externally
 window.setTheme = function(theme) {
-    currentTheme = theme;
-    document.documentElement.setAttribute('data-theme', currentTheme);
-    localStorage.setItem('theme', currentTheme);
+    state.currentTheme = theme;
+    document.documentElement.setAttribute('data-theme', state.currentTheme);
+    localStorage.setItem('theme', state.currentTheme);
     updateThemeIcon();
     syncIOSChrome();
     if (contentArea && contentArea.style.display !== 'none') {
@@ -519,32 +511,32 @@ window.loadFileContent = function(content, filename) {
 // View Mode Toggle
 // ===========================
 function toggleViewMode() {
-    if (!currentRawMarkdown) return;
+    if (!state.currentRawMarkdown) return;
 
-    if (currentViewMode === 'preview') {
-        currentViewMode = 'raw';
+    if (state.currentViewMode === 'preview') {
+        state.currentViewMode = 'raw';
         if (state.tocVisible) {
             toggleToc(false);
         }
         // Clean up panzoom before switching
         cleanupPanzoomInstances();
         // Show raw markdown in a pre/code block
-        const escaped = currentRawMarkdown
+        const escaped = state.currentRawMarkdown
             .replace(/&/g, '&amp;')
             .replace(/</g, '&lt;')
             .replace(/>/g, '&gt;');
         markdownContent.innerHTML = '<pre class="raw-markdown"><code>' + escaped + '</code></pre>';
     } else {
-        currentViewMode = 'preview';
+        state.currentViewMode = 'preview';
         // Re-render the preview
-        renderMarkdown(currentRawMarkdown, fileName.textContent);
+        renderMarkdown(state.currentRawMarkdown, fileName.textContent);
         return; // renderMarkdown handles the rest
     }
 
     // Persist view mode to active tab state
-    if (activeTabId !== null) {
-        const tab = tabs.find(t => t.id === activeTabId);
-        if (tab) tab.viewMode = currentViewMode;
+    if (state.activeTabId !== null) {
+        const tab = tabs.find(t => t.id === state.activeTabId);
+        if (tab) tab.viewMode = state.currentViewMode;
     }
 
     updateViewToggleButton();
@@ -554,7 +546,7 @@ function toggleViewMode() {
 function updateViewToggleButton() {
     const label = viewToggle.querySelector('.view-toggle-label');
     const icon = viewToggle.querySelector('.view-toggle-icon');
-    if (currentViewMode === 'preview') {
+    if (state.currentViewMode === 'preview') {
         label.textContent = 'Raw';
         icon.innerHTML = '&lt;/&gt;';
         viewToggle.classList.remove('active');
@@ -985,7 +977,7 @@ function configureMarked() {
 function getMermaidConfig() {
     return {
         startOnLoad: false,
-        theme: currentTheme === 'dark' ? 'dark' : 'default',
+        theme: state.currentTheme === 'dark' ? 'dark' : 'default',
         securityLevel: 'strict',
         fontFamily: FONT_FAMILY,
         // Render node labels as SVG <text> rather than <foreignObject> HTML.
@@ -1010,8 +1002,8 @@ async function renderMarkdown(content, filename) {
         cleanupPanzoomInstances();
 
         // Store raw markdown for toggle
-        currentRawMarkdown = content;
-        currentViewMode = 'preview';
+        state.currentRawMarkdown = content;
+        state.currentViewMode = 'preview';
         updateViewToggleButton();
 
         // Parse markdown to HTML
@@ -1036,7 +1028,7 @@ async function renderMarkdown(content, filename) {
         buildToc();
 
         // Update split raw pane if active
-        if (splitViewActive) {
+        if (state.splitViewActive) {
             updateSplitRawPane(content);
         }
 
@@ -1248,19 +1240,19 @@ function initializePanzoom(diagramId) {
     // Initial fit runs immediately; a deferred fit via requestAnimationFrame
     // recalculates after the browser has laid out the container (in case
     // clientWidth/Height weren't available synchronously).
-    const state = {
+    const instanceState = {
         homeState: fitDiagramToContainer(wrapper, svgElement, panzoomInstance)
     };
     requestAnimationFrame(() => {
-        state.homeState = fitDiagramToContainer(wrapper, svgElement, panzoomInstance);
+        instanceState.homeState = fitDiagramToContainer(wrapper, svgElement, panzoomInstance);
     });
 
     // Store instance for cleanup
-    currentPanzoomInstances.push({
+    state.currentPanzoomInstances.push({
         id: diagramId,
         instance: panzoomInstance,
         element: svgElement,
-        state: state
+        state: instanceState
     });
 
     // Get controls
@@ -1301,7 +1293,7 @@ function initializePanzoom(diagramId) {
 
     resetBtn.addEventListener('click', (e) => {
         e.stopPropagation();
-        resetToFit(panzoomInstance, state.homeState);
+        resetToFit(panzoomInstance, instanceState.homeState);
         updateZoomUI(panzoomInstance, controls);
     });
 
@@ -1340,7 +1332,7 @@ function initializePanzoom(diagramId) {
 
     // Double click to reset to fit
     wrapper.addEventListener('dblclick', () => {
-        resetToFit(panzoomInstance, state.homeState);
+        resetToFit(panzoomInstance, instanceState.homeState);
         updateZoomUI(panzoomInstance, controls);
     });
     updateZoomUI(panzoomInstance, controls);
@@ -1550,14 +1542,14 @@ function closeFullscreen() {
 // Cleanup
 // ===========================
 function cleanupPanzoomInstances() {
-    currentPanzoomInstances.forEach(({ instance }) => {
+    state.currentPanzoomInstances.forEach(({ instance }) => {
         try {
             instance.destroy();
         } catch (error) {
             console.error('Error destroying panzoom instance:', error);
         }
     });
-    currentPanzoomInstances = [];
+    state.currentPanzoomInstances = [];
 }
 
 function showDropZone() {
@@ -1572,18 +1564,18 @@ function showDropZone() {
     markdownContent.innerHTML = '';
     fileName.textContent = '';
     fileInput.value = '';
-    currentRawMarkdown = '';
-    currentViewMode = 'preview';
+    state.currentRawMarkdown = '';
+    state.currentViewMode = 'preview';
     updateViewToggleButton();
 
     // Clear tab state
     tabs = [];
-    activeTabId = null;
+    state.activeTabId = null;
     renderTabBar();
 
     // Reset TOC and split view
     if (state.tocVisible) toggleToc(false);
-    if (splitViewActive) toggleSplitView();
+    if (state.splitViewActive) toggleSplitView();
     if (tocNav) tocNav.innerHTML = '';
     if (iosTocNav) iosTocNav.innerHTML = '';
     state.tocEntries = [];
@@ -1624,10 +1616,10 @@ async function reRenderMermaidDiagrams() {
             const { svg } = await mermaid.render(`${diagramId}-rerender`, mermaidCode);
 
             // Clean up old panzoom
-            const oldInstance = currentPanzoomInstances.find(p => p.id === diagramId);
+            const oldInstance = state.currentPanzoomInstances.find(p => p.id === diagramId);
             if (oldInstance) {
                 oldInstance.instance.destroy();
-                currentPanzoomInstances = currentPanzoomInstances.filter(p => p.id !== diagramId);
+                state.currentPanzoomInstances = state.currentPanzoomInstances.filter(p => p.id !== diagramId);
             }
 
             // Update wrapper content
@@ -1657,10 +1649,10 @@ async function reRenderMermaidDiagrams() {
 // Tab Management
 // ===========================
 function saveActiveTabState() {
-    if (activeTabId === null) return;
-    const tab = tabs.find(t => t.id === activeTabId);
+    if (state.activeTabId === null) return;
+    const tab = tabs.find(t => t.id === state.activeTabId);
     if (!tab) return;
-    tab.viewMode = currentViewMode;
+    tab.viewMode = state.currentViewMode;
     tab.scrollTop = markdownContent.scrollTop;
 }
 
@@ -1677,7 +1669,7 @@ function renderTabBar() {
 
     let html = '';
     for (const tab of tabs) {
-        const isActive = tab.id === activeTabId;
+        const isActive = tab.id === state.activeTabId;
         const hasChanges = !!tab.hasUnseenChanges;
         const classes = ['tab'];
         if (isActive) classes.push('tab-active');
@@ -1729,7 +1721,7 @@ function createTab(filename, content, filePath) {
     // Save current tab state before switching
     saveActiveTabState();
 
-    const id = ++nextTabId;
+    const id = ++state.nextTabId;
     const tab = {
         id,
         filename,
@@ -1741,7 +1733,7 @@ function createTab(filename, content, filePath) {
         hasUnseenChanges: false
     };
     tabs.push(tab);
-    activeTabId = id;
+    state.activeTabId = id;
 
     if (tab.watching) {
         startWatchingFilePath(tab.filePath);
@@ -1756,10 +1748,10 @@ function createTab(filename, content, filePath) {
 }
 
 async function switchTab(id) {
-    if (id === activeTabId) return;
+    if (id === state.activeTabId) return;
 
     saveActiveTabState();
-    activeTabId = id;
+    state.activeTabId = id;
     const tab = tabs.find(t => t.id === id);
     if (!tab) return;
 
@@ -1774,8 +1766,8 @@ async function switchTab(id) {
         if (state.tocVisible) {
             toggleToc(false);
         }
-        currentRawMarkdown = tab.rawMarkdown;
-        currentViewMode = 'raw';
+        state.currentRawMarkdown = tab.rawMarkdown;
+        state.currentViewMode = 'raw';
         const escaped = tab.rawMarkdown
             .replace(/&/g, '&amp;')
             .replace(/</g, '&lt;')
@@ -1797,7 +1789,7 @@ async function closeTab(id) {
     const idx = tabs.findIndex(t => t.id === id);
     if (idx === -1) return;
 
-    const wasActive = (id === activeTabId);
+    const wasActive = (id === state.activeTabId);
     const closedTab = tabs[idx];
 
     // Stop watching before removing the tab
@@ -1814,14 +1806,14 @@ async function closeTab(id) {
     if (isDesktop) saveDesktopSession();
 
     if (tabs.length === 0) {
-        activeTabId = null;
+        state.activeTabId = null;
         renderTabBar();
         if (isDesktop) updateWatchToggle();
         showDropZone();
     } else if (wasActive) {
         const newIdx = Math.min(idx, tabs.length - 1);
         const newTab = tabs[newIdx];
-        activeTabId = newTab.id;
+        state.activeTabId = newTab.id;
         renderTabBar();
         if (isDesktop) updateWatchToggle();
 
@@ -1829,8 +1821,8 @@ async function closeTab(id) {
             if (state.tocVisible) {
                 toggleToc(false);
             }
-            currentRawMarkdown = newTab.rawMarkdown;
-            currentViewMode = 'raw';
+            state.currentRawMarkdown = newTab.rawMarkdown;
+            state.currentViewMode = 'raw';
             const escaped = newTab.rawMarkdown
                 .replace(/&/g, '&amp;')
                 .replace(/</g, '&lt;')
@@ -1855,7 +1847,7 @@ async function closeTab(id) {
 function updateWatchToggle() {
     if (!watchToggle) return;
 
-    const tab = activeTabId !== null ? tabs.find(t => t.id === activeTabId) : null;
+    const tab = state.activeTabId !== null ? tabs.find(t => t.id === state.activeTabId) : null;
     const canWatch = !!(tab && tab.filePath);
 
     if (!canWatch) {
@@ -1922,7 +1914,7 @@ function stopWatchingFilePath(filePath) {
 
 function toggleWatching() {
     if (!isDesktop) return;
-    const tab = activeTabId !== null ? tabs.find(t => t.id === activeTabId) : null;
+    const tab = state.activeTabId !== null ? tabs.find(t => t.id === state.activeTabId) : null;
     if (!tab || !tab.filePath) return;
 
     tab.watching = !tab.watching;
@@ -1945,8 +1937,8 @@ function setupDesktopIPC() {
 
     // Listen for close-tab command from native menu (Cmd+W)
     window.specdown.onCloseTab(function() {
-        if (activeTabId !== null) {
-            closeTab(activeTabId);
+        if (state.activeTabId !== null) {
+            closeTab(state.activeTabId);
         }
     });
 
@@ -1958,13 +1950,13 @@ function setupDesktopIPC() {
         tab.rawMarkdown = fileData.content;
         tab.filename = fileData.filename;
 
-        if (tab.id === activeTabId) {
+        if (tab.id === state.activeTabId) {
             // Preserve scroll position across the re-render so an
             // auto-reload doesn't yank the user back to the top.
             const savedScrollTop = markdownContent.scrollTop;
 
             if (tab.viewMode === 'raw') {
-                currentRawMarkdown = fileData.content;
+                state.currentRawMarkdown = fileData.content;
                 const escaped = fileData.content
                     .replace(/&/g, '&amp;')
                     .replace(/</g, '&lt;')
@@ -2091,7 +2083,7 @@ function renderTocNavigation(navElement) {
 
 function toggleToc(forceState) {
     const nextVisible = typeof forceState === 'boolean' ? forceState : !state.tocVisible;
-    if (isIOSNative && nextVisible && (currentViewMode !== 'preview' || state.tocEntries.length === 0)) {
+    if (isIOSNative && nextVisible && (state.currentViewMode !== 'preview' || state.tocEntries.length === 0)) {
         return;
     }
 
@@ -2145,21 +2137,21 @@ function updateTocActiveHeading() {
 // Feature: Split View
 // ===========================
 function toggleSplitView() {
-    splitViewActive = !splitViewActive;
+    state.splitViewActive = !state.splitViewActive;
 
-    if (splitToggle) splitToggle.classList.toggle('active', splitViewActive);
+    if (splitToggle) splitToggle.classList.toggle('active', state.splitViewActive);
 
     const contentMain = document.getElementById('content-main');
     if (contentMain) {
-        contentMain.classList.toggle('split-active', splitViewActive);
+        contentMain.classList.toggle('split-active', state.splitViewActive);
     }
 
     if (splitRawPane) {
-        splitRawPane.style.display = splitViewActive ? '' : 'none';
+        splitRawPane.style.display = state.splitViewActive ? '' : 'none';
     }
 
-    if (splitViewActive && currentRawMarkdown) {
-        updateSplitRawPane(currentRawMarkdown);
+    if (state.splitViewActive && state.currentRawMarkdown) {
+        updateSplitRawPane(state.currentRawMarkdown);
     }
 
     syncIOSChrome();

--- a/tests/integration/mermaid.test.js
+++ b/tests/integration/mermaid.test.js
@@ -32,7 +32,7 @@ describe('Mermaid Diagram Processing', () => {
     it('should configure mermaid with correct theme for dark mode', () => {
       // Reset and configure for dark mode
       document.documentElement.setAttribute('data-theme', 'dark');
-      global.currentTheme = 'dark';
+      state.currentTheme = 'dark';
 
       configureMermaid();
 
@@ -505,12 +505,12 @@ describe('Mermaid Diagram Processing', () => {
       await processMermaidDiagrams();
 
       // currentPanzoomInstances should have state.homeState
-      expect(currentPanzoomInstances.length).toBeGreaterThan(0);
-      expect(currentPanzoomInstances[0].state).toBeDefined();
-      expect(currentPanzoomInstances[0].state.homeState).toBeDefined();
-      expect(currentPanzoomInstances[0].state.homeState).toHaveProperty('scale');
-      expect(currentPanzoomInstances[0].state.homeState).toHaveProperty('x');
-      expect(currentPanzoomInstances[0].state.homeState).toHaveProperty('y');
+      expect(state.currentPanzoomInstances.length).toBeGreaterThan(0);
+      expect(state.currentPanzoomInstances[0].state).toBeDefined();
+      expect(state.currentPanzoomInstances[0].state.homeState).toBeDefined();
+      expect(state.currentPanzoomInstances[0].state.homeState).toHaveProperty('scale');
+      expect(state.currentPanzoomInstances[0].state.homeState).toHaveProperty('x');
+      expect(state.currentPanzoomInstances[0].state.homeState).toHaveProperty('y');
     });
   });
 
@@ -584,7 +584,7 @@ describe('Mermaid Diagram Processing', () => {
       mermaid.initialize.mockClear();
 
       // Change theme and re-render
-      global.currentTheme = 'dark';
+      state.currentTheme = 'dark';
       await reRenderMermaidDiagrams();
 
       expect(mermaid.initialize).toHaveBeenCalledWith(

--- a/tests/unit/desktopRenderer.test.js
+++ b/tests/unit/desktopRenderer.test.js
@@ -75,7 +75,7 @@ describe('Desktop renderer integration', () => {
     // Tab b is now active; deliver a file-changed event for tab a.
     const backgroundTab = tabs.find(t => t.filePath === '/tmp/a.md');
     const activeTab = tabs.find(t => t.filePath === '/tmp/b.md');
-    expect(activeTabId).toBe(activeTab.id);
+    expect(state.activeTabId).toBe(activeTab.id);
 
     await fileChangedCallback({
       filename: 'a.md',

--- a/tests/unit/iosRenderer.test.js
+++ b/tests/unit/iosRenderer.test.js
@@ -77,7 +77,7 @@ describe('iOS renderer integration', () => {
     window.loadFileContent('# Native file', 'native.md');
 
     expect(tabs).toHaveLength(1);
-    expect(activeTabId).toBe(tabs[0].id);
+    expect(state.activeTabId).toBe(tabs[0].id);
     expect(tabs[0].filename).toBe('native.md');
     expect(tabs[0].rawMarkdown).toBe('# Native file');
     expect(document.getElementById('ios-action-bar').style.display).toBe('grid');

--- a/tests/unit/splitView.test.js
+++ b/tests/unit/splitView.test.js
@@ -20,18 +20,18 @@ describe('Split View', () => {
   // ===========================
   describe('toggleSplitView', () => {
     it('starts inactive by default', () => {
-      expect(splitViewActive).toBe(false);
+      expect(state.splitViewActive).toBe(false);
     });
 
     it('sets splitViewActive to true on first toggle', () => {
       toggleSplitView();
-      expect(splitViewActive).toBe(true);
+      expect(state.splitViewActive).toBe(true);
     });
 
     it('sets splitViewActive back to false on second toggle', () => {
       toggleSplitView();
       toggleSplitView();
-      expect(splitViewActive).toBe(false);
+      expect(state.splitViewActive).toBe(false);
     });
 
     it('adds active class to the split toggle button when enabled', () => {
@@ -133,11 +133,11 @@ describe('Split View', () => {
     it('disables split view when returning to drop zone', async () => {
       await renderMarkdown('# Test', 'test.md');
       toggleSplitView();
-      expect(splitViewActive).toBe(true);
+      expect(state.splitViewActive).toBe(true);
 
       showDropZone();
 
-      expect(splitViewActive).toBe(false);
+      expect(state.splitViewActive).toBe(false);
     });
 
     it('hides the raw pane when returning to drop zone', async () => {

--- a/tests/unit/viewToggle.test.js
+++ b/tests/unit/viewToggle.test.js
@@ -17,11 +17,11 @@ describe('View Toggle', () => {
 
   describe('initial state', () => {
     it('should default to preview mode', () => {
-      expect(currentViewMode).toBe('preview');
+      expect(state.currentViewMode).toBe('preview');
     });
 
     it('should have empty raw markdown initially', () => {
-      expect(currentRawMarkdown).toBe('');
+      expect(state.currentRawMarkdown).toBe('');
     });
 
     it('should render toggle button with Raw label', () => {
@@ -37,9 +37,9 @@ describe('View Toggle', () => {
 
   describe('toggleViewMode', () => {
     it('should do nothing when no markdown is loaded', () => {
-      currentRawMarkdown = '';
+      state.currentRawMarkdown = '';
       toggleViewMode();
-      expect(currentViewMode).toBe('preview');
+      expect(state.currentViewMode).toBe('preview');
     });
 
     it('should switch to raw mode and display escaped markdown', async () => {
@@ -48,7 +48,7 @@ describe('View Toggle', () => {
 
       toggleViewMode();
 
-      expect(currentViewMode).toBe('raw');
+      expect(state.currentViewMode).toBe('raw');
       const pre = document.querySelector('.raw-markdown');
       expect(pre).not.toBeNull();
       // HTML should be escaped
@@ -77,7 +77,7 @@ describe('View Toggle', () => {
       toggleViewMode(); // -> raw
       toggleViewMode(); // -> preview
 
-      expect(currentViewMode).toBe('preview');
+      expect(state.currentViewMode).toBe('preview');
       const btn = document.getElementById('view-toggle');
       expect(btn.classList.contains('active')).toBe(false);
     });
@@ -96,14 +96,14 @@ describe('View Toggle', () => {
     it('should store the raw markdown content', async () => {
       const md = '# Title\n\nParagraph';
       await renderMarkdown(md, 'doc.md');
-      expect(currentRawMarkdown).toBe(md);
+      expect(state.currentRawMarkdown).toBe(md);
     });
 
     it('should reset view mode to preview on new render', async () => {
       await renderMarkdown('# First', 'first.md');
       toggleViewMode(); // -> raw
       await renderMarkdown('# Second', 'second.md');
-      expect(currentViewMode).toBe('preview');
+      expect(state.currentViewMode).toBe('preview');
     });
   });
 
@@ -114,8 +114,8 @@ describe('View Toggle', () => {
 
       showDropZone();
 
-      expect(currentRawMarkdown).toBe('');
-      expect(currentViewMode).toBe('preview');
+      expect(state.currentRawMarkdown).toBe('');
+      expect(state.currentViewMode).toBe('preview');
     });
   });
 });


### PR DESCRIPTION
Completes the shared-state foundation (after #113). Pure refactor — no behavior change.

## What
Moves the broad mutable globals into the shared `state` object so the coupled features can be extracted **without per-feature dependency injection**:
`currentPanzoomInstances`, `currentTheme`, `currentRawMarkdown`, `currentViewMode`, `activeTabId`, `nextTabId`, `splitViewActive`, `iosLayoutMode`.

- **`tabs` is intentionally deferred** — it appears in a user-facing string (`"…tabs reached"`) and a comment, so it can't be blanket-renamed; it moves with the tabs extraction.
- Renamed a **local** `state` variable in `initializePanzoom` → `instanceState` (the panzoom instance's `homeState` container) to avoid colliding with the now-imported global `state`. This was a real shadowing bug the test suite caught.
- Updated the affected unit/integration tests to read `state.x`.

## Why
With all shared state in `state`, extracting TOC / split-view / view-mode / the iOS-chrome layer becomes a straightforward move (`import { state }`) rather than threading state through callbacks.

## Verified
- `npm run build` ✓, `npm run lint` ✓, `npm test` → **297 passed**.

https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA)_