### PR TITLE
Phase 1: extract platform/ios-chrome.js (+ migrate tabs to state)

### DIFF
--- a/markdown-viewer/src/core/state.js
+++ b/markdown-viewer/src/core/state.js
@@ -15,6 +15,7 @@ export const state = {
 
   // Tabs (the `tabs` array itself stays in main.js for now — it appears in a
   // user-facing string/comment and is migrated with the tabs extraction)
+  tabs: [], // open file tabs: { id, filename, filePath, rawMarkdown, viewMode, scrollTop, watching }
   activeTabId: null,
   nextTabId: 0,
 

--- a/markdown-viewer/src/main.js
+++ b/markdown-viewer/src/main.js
@@ -39,6 +39,16 @@ import {
 import { handleRepoUrl } from './features/repo-browser.js';
 import { updateMinimap, updateMinimapViewport } from './features/minimap.js';
 import { applyCustomCss } from './features/custom-css.js';
+import {
+  setupIOSNativeUI,
+  syncIOSChrome,
+  requestNativeOpenIfAvailable,
+  requestBundledSampleIfAvailable,
+  performPrint,
+  closeIOSActionSheet,
+  closeIOSTocSheet,
+  setIOSSheetVisibility,
+} from './platform/ios-chrome.js';
 
 // ===========================
 // Constants
@@ -56,7 +66,6 @@ const MAX_DIAGRAM_URL_PARAM_LENGTH = 65536;
 // ===========================
 
 // Tab state
-let tabs = [];         // Array of { id, filename, filePath, rawMarkdown, viewMode, scrollTop, watching }
 const MAX_TABS = 10;
 const watchRefCounts = new Map(); // filePath -> number of watching tabs
 
@@ -70,7 +79,6 @@ const watchRefCounts = new Map(); // filePath -> number of watching tabs
 const dropZone = document.getElementById('drop-zone');
 const fileInput = document.getElementById('file-input');
 const browseButton = document.getElementById('browse-button');
-const iosSampleSection = document.getElementById('ios-sample-section');
 const openSampleBasic = document.getElementById('open-sample-basic');
 const openSampleMermaid = document.getElementById('open-sample-mermaid');
 const contentArea = document.getElementById('content-area');
@@ -94,12 +102,10 @@ const splitRawContent = document.getElementById('split-raw-content');
 const printButton = document.getElementById('print-button');
 const searchBar = document.getElementById('search-bar');
 const searchInput = document.getElementById('search-input');
-const searchCount = document.getElementById('search-count');
 const searchPrev = document.getElementById('search-prev');
 const searchNext = document.getElementById('search-next');
 const searchClose = document.getElementById('search-close');
 const shareToast = document.getElementById('share-toast');
-const iosActionBar = document.getElementById('ios-action-bar');
 const iosOpenButton = document.getElementById('ios-open-button');
 const iosContentsButton = document.getElementById('ios-contents-button');
 const iosViewButton = document.getElementById('ios-view-button');
@@ -128,294 +134,6 @@ function init() {
     if (isDesktop) {
         setupDesktopIPC();
     }
-}
-
-function setupIOSNativeUI() {
-    document.body.classList.toggle('ios-native', isIOSNative);
-    document.documentElement.classList.toggle('ios-native', isIOSNative);
-    if (iosSampleSection) {
-        iosSampleSection.style.display = isIOSNative ? '' : 'none';
-    }
-    document.body.classList.toggle('ios-pad', isIOSNative && state.iosLayoutMode === 'pad');
-    document.documentElement.classList.toggle('ios-pad', isIOSNative && state.iosLayoutMode === 'pad');
-    syncIOSChrome();
-}
-
-function requestNativeOpenIfAvailable() {
-    if (isDesktop && window.specdown && window.specdown.requestFileOpen) {
-        window.specdown.requestFileOpen();
-        return true;
-    }
-    if (isIOSNative && window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.specdown) {
-        window.webkit.messageHandlers.specdown.postMessage({ action: 'openFilePicker' });
-        return true;
-    }
-    return false;
-}
-
-function requestBundledSampleIfAvailable(sampleName) {
-    if (!isIOSNative || !window.webkit || !window.webkit.messageHandlers || !window.webkit.messageHandlers.specdown) {
-        return false;
-    }
-    window.webkit.messageHandlers.specdown.postMessage({
-        action: 'openBundledSample',
-        data: { name: sampleName }
-    });
-    return true;
-}
-
-function requestNativePrintIfAvailable() {
-    if (!isIOSNative || !window.webkit || !window.webkit.messageHandlers || !window.webkit.messageHandlers.specdown || !hasLoadedContent()) {
-        return false;
-    }
-    window.webkit.messageHandlers.specdown.postMessage({
-        action: 'printDocument',
-        data: {
-            title: fileName ? fileName.textContent : '',
-            html: buildPrintableDocument()
-        }
-    });
-    return true;
-}
-
-function hasLoadedContent() {
-    return !!(contentArea && contentArea.style.display !== 'none' && state.currentRawMarkdown);
-}
-
-function setIOSSheetVisibility(sheet, visible) {
-    if (!sheet) return;
-    sheet.style.display = visible ? 'flex' : 'none';
-}
-
-function closeIOSActionSheet() {
-    setIOSSheetVisibility(iosActionSheet, false);
-}
-
-function closeIOSTocSheet() {
-    setIOSSheetVisibility(iosTocSheet, false);
-    state.tocVisible = false;
-    if (tocToggle) tocToggle.classList.remove('active');
-    syncIOSChrome();
-}
-
-function updateIOSActionButtonLabel(button, label) {
-    if (!button) return;
-    const labelEl = button.querySelector('.ios-action-label');
-    if (labelEl) {
-        labelEl.textContent = label;
-    }
-}
-
-function updateIOSSheetButton(button, label, active) {
-    if (!button) return;
-    button.textContent = label;
-    button.classList.toggle('active', !!active);
-}
-
-function performPrint() {
-    if (requestNativePrintIfAvailable()) {
-        return;
-    }
-    window.print();
-}
-
-window.setIOSLayoutMode = function(mode) {
-    state.iosLayoutMode = mode === 'pad' ? 'pad' : 'phone';
-    if (isIOSNative) {
-        document.body.classList.toggle('ios-pad', state.iosLayoutMode === 'pad');
-        document.documentElement.classList.toggle('ios-pad', state.iosLayoutMode === 'pad');
-        if (state.iosLayoutMode === 'pad') {
-            closeIOSActionSheet();
-            closeIOSTocSheet();
-        }
-    }
-    syncIOSChrome();
-};
-
-function buildPrintableDocument() {
-    const title = (fileName && fileName.textContent) ? fileName.textContent : 'Specdown Document';
-    const printableContent = markdownContent.cloneNode(true);
-
-    printableContent.querySelectorAll('.diagram-controls, .annotation-popover, .search-highlight, .search-highlight-current')
-        .forEach((element) => element.remove());
-    printableContent.querySelectorAll('.annotation-badge').forEach((badge) => badge.remove());
-    printableContent.querySelectorAll('.has-annotation').forEach((element) => {
-        element.classList.remove('has-annotation');
-    });
-    printableContent.querySelectorAll('.diagram-wrapper').forEach((wrapper) => {
-        wrapper.style.height = 'auto';
-        wrapper.style.overflow = 'visible';
-    });
-    printableContent.querySelectorAll('.diagram-wrapper svg').forEach((svg) => {
-        svg.style.maxWidth = '100%';
-        svg.style.height = 'auto';
-        svg.style.position = 'static';
-        svg.style.transform = 'none';
-    });
-
-    return `<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>${escapeHtml(title)}</title>
-    <style>
-        @page {
-            margin: 18mm 14mm;
-        }
-        html {
-            box-sizing: border-box;
-            background: #ffffff;
-        }
-        *,
-        *::before,
-        *::after {
-            box-sizing: inherit;
-        }
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-            color: #111827;
-            background: #ffffff;
-            margin: 0;
-            padding: 0;
-            line-height: 1.6;
-        }
-        .print-shell {
-            max-width: 100%;
-            padding: 12px 10px 16px;
-        }
-        .print-title {
-            margin: 0 0 24px;
-            font-size: 28px;
-            font-weight: 700;
-        }
-        .print-content h1,
-        .print-content h2,
-        .print-content h3,
-        .print-content h4,
-        .print-content h5,
-        .print-content h6 {
-            margin-top: 1.5em;
-            margin-bottom: 0.5em;
-            line-height: 1.3;
-        }
-        .print-content h1,
-        .print-content h2 {
-            padding-bottom: 0.3em;
-            border-bottom: 1px solid #d1d5db;
-        }
-        .print-content p,
-        .print-content ul,
-        .print-content ol,
-        .print-content table,
-        .print-content blockquote,
-        .print-content pre,
-        .print-content .diagram-container {
-            margin-bottom: 1em;
-        }
-        .print-content ul,
-        .print-content ol {
-            padding-left: 2em;
-        }
-        .print-content code {
-            font-family: "SFMono-Regular", SFMono-Regular, ui-monospace, Menlo, monospace;
-            background: #f3f4f6;
-            padding: 0.15em 0.35em;
-            border-radius: 4px;
-            font-size: 0.92em;
-        }
-        .print-content pre {
-            white-space: pre-wrap;
-            word-break: break-word;
-            overflow: visible;
-            border: 1px solid #d1d5db;
-            background: #f9fafb;
-            border-radius: 8px;
-            padding: 1em;
-        }
-        .print-content pre code {
-            background: transparent;
-            padding: 0;
-        }
-        .print-content table {
-            width: 100%;
-            border-collapse: collapse;
-            table-layout: fixed;
-        }
-        .print-content th,
-        .print-content td {
-            border: 1px solid #d1d5db;
-            padding: 0.6em;
-            text-align: left;
-            vertical-align: top;
-            word-break: break-word;
-        }
-        .print-content blockquote {
-            margin-left: 0;
-            padding-left: 1em;
-            border-left: 4px solid #60a5fa;
-            color: #4b5563;
-        }
-        .print-content img,
-        .print-content svg {
-            max-width: 100%;
-            height: auto;
-        }
-        .print-content .raw-markdown,
-        .print-content .html-comment-block,
-        .print-content .diagram-container,
-        .print-content pre,
-        .print-content table,
-        .print-content blockquote {
-            max-width: 100%;
-        }
-        .print-content .diagram-container,
-        .print-content .diagram-wrapper {
-            page-break-inside: avoid;
-            break-inside: avoid;
-        }
-    </style>
-</head>
-<body>
-    <main class="print-shell">
-        <h1 class="print-title">${escapeHtml(title)}</h1>
-        <section class="print-content">${printableContent.innerHTML}</section>
-    </main>
-</body>
-</html>`;
-}
-
-function syncIOSChrome() {
-    if (!isIOSNative) return;
-
-    const hasContent = hasLoadedContent();
-    const showActionBar = (hasContent || tabs.length > 0) && state.iosLayoutMode !== 'pad';
-    const canShowContents = hasContent && state.currentViewMode === 'preview' && state.tocEntries.length > 0;
-
-    if (iosActionBar) {
-        iosActionBar.style.display = showActionBar ? 'grid' : 'none';
-    }
-
-    if (iosContentsButton) {
-        iosContentsButton.disabled = !canShowContents;
-        iosContentsButton.classList.toggle('active', state.tocVisible);
-    }
-
-    if (iosViewButton) {
-        iosViewButton.disabled = !hasContent;
-        iosViewButton.classList.toggle('active', state.currentViewMode === 'raw');
-        updateIOSActionButtonLabel(iosViewButton, state.currentViewMode === 'preview' ? 'Raw' : 'Preview');
-    }
-
-    if (iosMoreButton) {
-        iosMoreButton.disabled = !hasContent;
-    }
-
-    updateIOSSheetButton(iosSplitButton, state.splitViewActive ? 'Hide Split View' : 'Show Split View', state.splitViewActive);
-    updateIOSSheetButton(iosThemeButton, state.currentTheme === 'light' ? 'Switch to Dark Mode' : 'Switch to Light Mode', false);
-
-    if (iosSplitButton) iosSplitButton.disabled = !hasContent;
-    if (iosPrintButton) iosPrintButton.disabled = !hasContent;
 }
 
 // ===========================
@@ -535,7 +253,7 @@ function toggleViewMode() {
 
     // Persist view mode to active tab state
     if (state.activeTabId !== null) {
-        const tab = tabs.find(t => t.id === state.activeTabId);
+        const tab = state.tabs.find(t => t.id === state.activeTabId);
         if (tab) tab.viewMode = state.currentViewMode;
     }
 
@@ -799,7 +517,7 @@ function setupEventListeners() {
     // content area (when the drop zone is hidden).
     document.addEventListener('drop', (e) => {
         e.preventDefault();
-        if (tabs.length > 0 && e.dataTransfer && e.dataTransfer.files.length > 0) {
+        if (state.tabs.length > 0 && e.dataTransfer && e.dataTransfer.files.length > 0) {
             for (let i = 0; i < e.dataTransfer.files.length; i++) {
                 handleFile(e.dataTransfer.files[i]);
             }
@@ -1569,7 +1287,7 @@ function showDropZone() {
     updateViewToggleButton();
 
     // Clear tab state
-    tabs = [];
+    state.tabs = [];
     state.activeTabId = null;
     renderTabBar();
 
@@ -1650,7 +1368,7 @@ async function reRenderMermaidDiagrams() {
 // ===========================
 function saveActiveTabState() {
     if (state.activeTabId === null) return;
-    const tab = tabs.find(t => t.id === state.activeTabId);
+    const tab = state.tabs.find(t => t.id === state.activeTabId);
     if (!tab) return;
     tab.viewMode = state.currentViewMode;
     tab.scrollTop = markdownContent.scrollTop;
@@ -1659,7 +1377,7 @@ function saveActiveTabState() {
 function renderTabBar() {
     if (!tabBar) return;
 
-    if (tabs.length === 0) {
+    if (state.tabs.length === 0) {
         tabBar.style.display = 'none';
         tabBar.innerHTML = '';
         return;
@@ -1668,7 +1386,7 @@ function renderTabBar() {
     tabBar.style.display = 'flex';
 
     let html = '';
-    for (const tab of tabs) {
+    for (const tab of state.tabs) {
         const isActive = tab.id === state.activeTabId;
         const hasChanges = !!tab.hasUnseenChanges;
         const classes = ['tab'];
@@ -1713,7 +1431,7 @@ function renderTabBar() {
 }
 
 function createTab(filename, content, filePath) {
-    if (tabs.length >= MAX_TABS) {
+    if (state.tabs.length >= MAX_TABS) {
         alert('Maximum of ' + MAX_TABS + ' tabs reached. Close a tab to open another file.');
         return;
     }
@@ -1732,7 +1450,7 @@ function createTab(filename, content, filePath) {
         watching: !!(isDesktop && filePath),
         hasUnseenChanges: false
     };
-    tabs.push(tab);
+    state.tabs.push(tab);
     state.activeTabId = id;
 
     if (tab.watching) {
@@ -1752,7 +1470,7 @@ async function switchTab(id) {
 
     saveActiveTabState();
     state.activeTabId = id;
-    const tab = tabs.find(t => t.id === id);
+    const tab = state.tabs.find(t => t.id === id);
     if (!tab) return;
 
     // Clear the "unseen changes" flag now that the user is looking at it.
@@ -1786,11 +1504,11 @@ async function switchTab(id) {
 }
 
 async function closeTab(id) {
-    const idx = tabs.findIndex(t => t.id === id);
+    const idx = state.tabs.findIndex(t => t.id === id);
     if (idx === -1) return;
 
     const wasActive = (id === state.activeTabId);
-    const closedTab = tabs[idx];
+    const closedTab = state.tabs[idx];
 
     // Stop watching before removing the tab
     if (isDesktop && closedTab.watching && closedTab.filePath) {
@@ -1801,18 +1519,18 @@ async function closeTab(id) {
         cleanupPanzoomInstances();
     }
 
-    tabs.splice(idx, 1);
+    state.tabs.splice(idx, 1);
 
     if (isDesktop) saveDesktopSession();
 
-    if (tabs.length === 0) {
+    if (state.tabs.length === 0) {
         state.activeTabId = null;
         renderTabBar();
         if (isDesktop) updateWatchToggle();
         showDropZone();
     } else if (wasActive) {
-        const newIdx = Math.min(idx, tabs.length - 1);
-        const newTab = tabs[newIdx];
+        const newIdx = Math.min(idx, state.tabs.length - 1);
+        const newTab = state.tabs[newIdx];
         state.activeTabId = newTab.id;
         renderTabBar();
         if (isDesktop) updateWatchToggle();
@@ -1847,7 +1565,7 @@ async function closeTab(id) {
 function updateWatchToggle() {
     if (!watchToggle) return;
 
-    const tab = state.activeTabId !== null ? tabs.find(t => t.id === state.activeTabId) : null;
+    const tab = state.activeTabId !== null ? state.tabs.find(t => t.id === state.activeTabId) : null;
     const canWatch = !!(tab && tab.filePath);
 
     if (!canWatch) {
@@ -1914,7 +1632,7 @@ function stopWatchingFilePath(filePath) {
 
 function toggleWatching() {
     if (!isDesktop) return;
-    const tab = state.activeTabId !== null ? tabs.find(t => t.id === state.activeTabId) : null;
+    const tab = state.activeTabId !== null ? state.tabs.find(t => t.id === state.activeTabId) : null;
     if (!tab || !tab.filePath) return;
 
     tab.watching = !tab.watching;
@@ -1944,7 +1662,7 @@ function setupDesktopIPC() {
 
     // Listen for file-changed events (watched file updated on disk)
     window.specdown.onFileChanged(async function(fileData) {
-        const tab = tabs.find(t => t.filePath === fileData.filePath);
+        const tab = state.tabs.find(t => t.filePath === fileData.filePath);
         if (!tab) return;
 
         tab.rawMarkdown = fileData.content;
@@ -2010,7 +1728,7 @@ function setupDesktopIPC() {
 
 function saveDesktopSession() {
     if (!isDesktop || !window.specdown.saveSession) return;
-    window.specdown.saveSession(tabs.map(t => ({
+    window.specdown.saveSession(state.tabs.map(t => ({
         filePath: t.filePath,
         filename: t.filename
     })));

--- a/markdown-viewer/src/platform/ios-chrome.js
+++ b/markdown-viewer/src/platform/ios-chrome.js
@@ -1,0 +1,314 @@
+// iOS native chrome + print.
+//
+// The iOS shell talks to the web app through window.webkit.messageHandlers and
+// a window.setIOSLayoutMode bridge, and the app drives a native-feeling action
+// bar / sheets. This module owns that layer (plus the print pipeline, which is
+// entangled with the iOS native-print path). DOM elements are looked up by id
+// so the module is self-contained.
+
+import { state } from '../core/state.js';
+import { isDesktop, isIOSNative } from '../core/platform.js';
+import { escapeHtml } from '../core/utils.js';
+
+const el = (id) => document.getElementById(id);
+
+export function setupIOSNativeUI() {
+  document.body.classList.toggle('ios-native', isIOSNative);
+  document.documentElement.classList.toggle('ios-native', isIOSNative);
+  const iosSampleSection = el('ios-sample-section');
+  if (iosSampleSection) {
+    iosSampleSection.style.display = isIOSNative ? '' : 'none';
+  }
+  document.body.classList.toggle('ios-pad', isIOSNative && state.iosLayoutMode === 'pad');
+  document.documentElement.classList.toggle('ios-pad', isIOSNative && state.iosLayoutMode === 'pad');
+  syncIOSChrome();
+}
+
+export function requestNativeOpenIfAvailable() {
+  if (isDesktop && window.specdown && window.specdown.requestFileOpen) {
+    window.specdown.requestFileOpen();
+    return true;
+  }
+  if (isIOSNative && window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.specdown) {
+    window.webkit.messageHandlers.specdown.postMessage({ action: 'openFilePicker' });
+    return true;
+  }
+  return false;
+}
+
+export function requestBundledSampleIfAvailable(sampleName) {
+  if (!isIOSNative || !window.webkit || !window.webkit.messageHandlers || !window.webkit.messageHandlers.specdown) {
+    return false;
+  }
+  window.webkit.messageHandlers.specdown.postMessage({
+    action: 'openBundledSample',
+    data: { name: sampleName },
+  });
+  return true;
+}
+
+function requestNativePrintIfAvailable() {
+  if (!isIOSNative || !window.webkit || !window.webkit.messageHandlers || !window.webkit.messageHandlers.specdown || !hasLoadedContent()) {
+    return false;
+  }
+  const fileName = el('file-name');
+  window.webkit.messageHandlers.specdown.postMessage({
+    action: 'printDocument',
+    data: {
+      title: fileName ? fileName.textContent : '',
+      html: buildPrintableDocument(),
+    },
+  });
+  return true;
+}
+
+export function hasLoadedContent() {
+  const contentArea = el('content-area');
+  return !!(contentArea && contentArea.style.display !== 'none' && state.currentRawMarkdown);
+}
+
+export function setIOSSheetVisibility(sheet, visible) {
+  if (!sheet) return;
+  sheet.style.display = visible ? 'flex' : 'none';
+}
+
+export function closeIOSActionSheet() {
+  setIOSSheetVisibility(el('ios-action-sheet'), false);
+}
+
+export function closeIOSTocSheet() {
+  setIOSSheetVisibility(el('ios-toc-sheet'), false);
+  state.tocVisible = false;
+  const tocToggle = el('toc-toggle');
+  if (tocToggle) tocToggle.classList.remove('active');
+  syncIOSChrome();
+}
+
+function updateIOSActionButtonLabel(button, label) {
+  if (!button) return;
+  const labelEl = button.querySelector('.ios-action-label');
+  if (labelEl) {
+    labelEl.textContent = label;
+  }
+}
+
+function updateIOSSheetButton(button, label, active) {
+  if (!button) return;
+  button.textContent = label;
+  button.classList.toggle('active', !!active);
+}
+
+export function performPrint() {
+  if (requestNativePrintIfAvailable()) {
+    return;
+  }
+  window.print();
+}
+
+window.setIOSLayoutMode = function (mode) {
+  state.iosLayoutMode = mode === 'pad' ? 'pad' : 'phone';
+  if (isIOSNative) {
+    document.body.classList.toggle('ios-pad', state.iosLayoutMode === 'pad');
+    document.documentElement.classList.toggle('ios-pad', state.iosLayoutMode === 'pad');
+    if (state.iosLayoutMode === 'pad') {
+      closeIOSActionSheet();
+      closeIOSTocSheet();
+    }
+  }
+  syncIOSChrome();
+};
+
+function buildPrintableDocument() {
+  const fileName = el('file-name');
+  const markdownContent = el('markdown-content');
+  const title = fileName && fileName.textContent ? fileName.textContent : 'Specdown Document';
+  const printableContent = markdownContent.cloneNode(true);
+
+  printableContent
+    .querySelectorAll('.diagram-controls, .annotation-popover, .search-highlight, .search-highlight-current')
+    .forEach((element) => element.remove());
+  printableContent.querySelectorAll('.annotation-badge').forEach((badge) => badge.remove());
+  printableContent.querySelectorAll('.has-annotation').forEach((element) => {
+    element.classList.remove('has-annotation');
+  });
+  printableContent.querySelectorAll('.diagram-wrapper').forEach((wrapper) => {
+    wrapper.style.height = 'auto';
+    wrapper.style.overflow = 'visible';
+  });
+  printableContent.querySelectorAll('.diagram-wrapper svg').forEach((svg) => {
+    svg.style.maxWidth = '100%';
+    svg.style.height = 'auto';
+    svg.style.position = 'static';
+    svg.style.transform = 'none';
+  });
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>${escapeHtml(title)}</title>
+    <style>
+        @page {
+            margin: 18mm 14mm;
+        }
+        html {
+            box-sizing: border-box;
+            background: #ffffff;
+        }
+        *,
+        *::before,
+        *::after {
+            box-sizing: inherit;
+        }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            color: #111827;
+            background: #ffffff;
+            margin: 0;
+            padding: 0;
+            line-height: 1.6;
+        }
+        .print-shell {
+            max-width: 100%;
+            padding: 12px 10px 16px;
+        }
+        .print-title {
+            margin: 0 0 24px;
+            font-size: 28px;
+            font-weight: 700;
+        }
+        .print-content h1,
+        .print-content h2,
+        .print-content h3,
+        .print-content h4,
+        .print-content h5,
+        .print-content h6 {
+            margin-top: 1.5em;
+            margin-bottom: 0.5em;
+            line-height: 1.3;
+        }
+        .print-content h1,
+        .print-content h2 {
+            padding-bottom: 0.3em;
+            border-bottom: 1px solid #d1d5db;
+        }
+        .print-content p,
+        .print-content ul,
+        .print-content ol,
+        .print-content table,
+        .print-content blockquote,
+        .print-content pre,
+        .print-content .diagram-container {
+            margin-bottom: 1em;
+        }
+        .print-content ul,
+        .print-content ol {
+            padding-left: 2em;
+        }
+        .print-content code {
+            font-family: "SFMono-Regular", SFMono-Regular, ui-monospace, Menlo, monospace;
+            background: #f3f4f6;
+            padding: 0.15em 0.35em;
+            border-radius: 4px;
+            font-size: 0.92em;
+        }
+        .print-content pre {
+            white-space: pre-wrap;
+            word-break: break-word;
+            overflow: visible;
+            border: 1px solid #d1d5db;
+            background: #f9fafb;
+            border-radius: 8px;
+            padding: 1em;
+        }
+        .print-content pre code {
+            background: transparent;
+            padding: 0;
+        }
+        .print-content table {
+            width: 100%;
+            border-collapse: collapse;
+            table-layout: fixed;
+        }
+        .print-content th,
+        .print-content td {
+            border: 1px solid #d1d5db;
+            padding: 0.6em;
+            text-align: left;
+            vertical-align: top;
+            word-break: break-word;
+        }
+        .print-content blockquote {
+            margin-left: 0;
+            padding-left: 1em;
+            border-left: 4px solid #60a5fa;
+            color: #4b5563;
+        }
+        .print-content img,
+        .print-content svg {
+            max-width: 100%;
+            height: auto;
+        }
+        .print-content .raw-markdown,
+        .print-content .html-comment-block,
+        .print-content .diagram-container,
+        .print-content pre,
+        .print-content table,
+        .print-content blockquote {
+            max-width: 100%;
+        }
+        .print-content .diagram-container,
+        .print-content .diagram-wrapper {
+            page-break-inside: avoid;
+            break-inside: avoid;
+        }
+    </style>
+</head>
+<body>
+    <main class="print-shell">
+        <h1 class="print-title">${escapeHtml(title)}</h1>
+        <section class="print-content">${printableContent.innerHTML}</section>
+    </main>
+</body>
+</html>`;
+}
+
+export function syncIOSChrome() {
+  if (!isIOSNative) return;
+
+  const hasContent = hasLoadedContent();
+  const showActionBar = (hasContent || state.tabs.length > 0) && state.iosLayoutMode !== 'pad';
+  const canShowContents = hasContent && state.currentViewMode === 'preview' && state.tocEntries.length > 0;
+
+  const iosActionBar = el('ios-action-bar');
+  if (iosActionBar) {
+    iosActionBar.style.display = showActionBar ? 'grid' : 'none';
+  }
+
+  const iosContentsButton = el('ios-contents-button');
+  if (iosContentsButton) {
+    iosContentsButton.disabled = !canShowContents;
+    iosContentsButton.classList.toggle('active', state.tocVisible);
+  }
+
+  const iosViewButton = el('ios-view-button');
+  if (iosViewButton) {
+    iosViewButton.disabled = !hasContent;
+    iosViewButton.classList.toggle('active', state.currentViewMode === 'raw');
+    updateIOSActionButtonLabel(iosViewButton, state.currentViewMode === 'preview' ? 'Raw' : 'Preview');
+  }
+
+  const iosMoreButton = el('ios-more-button');
+  if (iosMoreButton) {
+    iosMoreButton.disabled = !hasContent;
+  }
+
+  updateIOSSheetButton(el('ios-split-button'), state.splitViewActive ? 'Hide Split View' : 'Show Split View', state.splitViewActive);
+  updateIOSSheetButton(el('ios-theme-button'), state.currentTheme === 'light' ? 'Switch to Dark Mode' : 'Switch to Light Mode', false);
+
+  const iosSplitButton = el('ios-split-button');
+  const iosPrintButton = el('ios-print-button');
+  if (iosSplitButton) iosSplitButton.disabled = !hasContent;
+  if (iosPrintButton) iosPrintButton.disabled = !hasContent;
+}

--- a/tests/unit/desktopRenderer.test.js
+++ b/tests/unit/desktopRenderer.test.js
@@ -53,8 +53,8 @@ describe('Desktop renderer integration', () => {
     createTab('one.md', '# One again', '/tmp/one.md');
     expect(window.specdown.watchFile).toHaveBeenCalledTimes(1);
 
-    const firstTabId = tabs[0].id;
-    const secondTabId = tabs[1].id;
+    const firstTabId = state.tabs[0].id;
+    const secondTabId = state.tabs[1].id;
 
     await closeTab(firstTabId);
     expect(window.specdown.unwatchFile).not.toHaveBeenCalled();
@@ -73,8 +73,8 @@ describe('Desktop renderer integration', () => {
     createTab('b.md', '# B', '/tmp/b.md');
 
     // Tab b is now active; deliver a file-changed event for tab a.
-    const backgroundTab = tabs.find(t => t.filePath === '/tmp/a.md');
-    const activeTab = tabs.find(t => t.filePath === '/tmp/b.md');
+    const backgroundTab = state.tabs.find(t => t.filePath === '/tmp/a.md');
+    const activeTab = state.tabs.find(t => t.filePath === '/tmp/b.md');
     expect(state.activeTabId).toBe(activeTab.id);
 
     await fileChangedCallback({

--- a/tests/unit/diagramShare.test.js
+++ b/tests/unit/diagramShare.test.js
@@ -159,9 +159,9 @@ describe('Shareable Diagram Links', () => {
   describe('checkForDiagramLink', () => {
     it('does nothing when there is no ?diagram= param', () => {
       // window.location.search is '' in jsdom by default
-      const initialTabs = tabs.length;
+      const initialTabs = state.tabs.length;
       checkForDiagramLink();
-      expect(tabs.length).toBe(initialTabs);
+      expect(state.tabs.length).toBe(initialTabs);
     });
 
     it('creates a tab when a valid encoded diagram is in the URL', () => {
@@ -175,8 +175,8 @@ describe('Shareable Diagram Links', () => {
 
       checkForDiagramLink();
 
-      expect(tabs.length).toBeGreaterThan(0);
-      const tab = tabs[tabs.length - 1];
+      expect(state.tabs.length).toBeGreaterThan(0);
+      const tab = state.tabs[state.tabs.length - 1];
       expect(tab.filename).toBe('shared-diagram.md');
       expect(tab.rawMarkdown).toContain(source);
 

--- a/tests/unit/iosRenderer.test.js
+++ b/tests/unit/iosRenderer.test.js
@@ -72,14 +72,14 @@ describe('iOS renderer integration', () => {
   });
 
   it('opens native-loaded files as tabs', () => {
-    expect(tabs).toHaveLength(0);
+    expect(state.tabs).toHaveLength(0);
 
     window.loadFileContent('# Native file', 'native.md');
 
-    expect(tabs).toHaveLength(1);
-    expect(state.activeTabId).toBe(tabs[0].id);
-    expect(tabs[0].filename).toBe('native.md');
-    expect(tabs[0].rawMarkdown).toBe('# Native file');
+    expect(state.tabs).toHaveLength(1);
+    expect(state.activeTabId).toBe(state.tabs[0].id);
+    expect(state.tabs[0].filename).toBe('native.md');
+    expect(state.tabs[0].rawMarkdown).toBe('# Native file');
     expect(document.getElementById('ios-action-bar').style.display).toBe('grid');
   });
 


### PR DESCRIPTION
The first coupled-tier extraction, on top of the `core/state.js` + `core/platform.js` foundation. Pure refactor — no behavior change.

## Extraction
`platform/ios-chrome.js` (~314 lines) — the iOS native chrome + print cluster:
- `syncIOSChrome` (the action-bar/sheet state sync), `setupIOSNativeUI`
- the `window.webkit.messageHandlers` bridges (`requestNativeOpenIfAvailable`, `requestBundledSampleIfAvailable`, native print) and the `window.setIOSLayoutMode` bridge
- sheet show/hide helpers (`setIOSSheetVisibility`, `closeIOSActionSheet`, `closeIOSTocSheet`)
- the print pipeline (`performPrint` + `buildPrintableDocument`, entangled with iOS native print)

It imports `state` / `platform` / `escapeHtml` and looks up its DOM by id.

## Enabling change
`syncIOSChrome` reads `state.tabs.length`, so this migrates the **final shared field `tabs`** into `core/state.js`. Done as a code-only rewrite so the user-facing `"…tabs reached"` alert string and a comment are untouched. Also removed three now-dead DOM consts from `main.js`.

## Impact
`main.js`: **2,225 → 1,943 lines** (from 2,814 at the split's start). This unblocks TOC / split-view / view-mode, which depend on the iOS-chrome layer.

## Verified
- `npm run build` ✓, `npm run lint` ✓ (clean), `npm test` → **297 passed**.

https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA)_