### PR TITLE
Phase 1 module split (final): tabs + desktop IPC — main.js 992 → 588

### DIFF
--- a/docs/project-modernization/2026-06-14-tasks-session-03-phase1-module-split.md
+++ b/docs/project-modernization/2026-06-14-tasks-session-03-phase1-module-split.md
@@ -48,9 +48,14 @@ Everything here is a **pure refactor** (no behavior change); the gate is
 | `features/share-links.js` | diagram deep links (DI: createTab → `openTab`) |
 | `features/file-loading.js` | local file + URL loading (DI: createTab → `openTab`) |
 | `platform/ios-chrome.js` | iOS action bar / sheets / native print bridge |
-| `features/diagrams.js` | (in progress) mermaid render + panzoom + fullscreen engine |
+| `features/diagrams.js` | mermaid render + panzoom + fullscreen engine |
+| `features/tabs.js` | tab create/switch/close + tab bar + drop-zone reset (DI: renderMarkdown + desktop watch/session) |
+| `platform/desktop.js` | Electron file-watch + watch toggle + IPC + session (imports tabs; DI: renderMarkdown) |
 
-`src/main.js`: **2,814 → ~1,540 lines** and falling.
+`src/main.js`: **2,814 → 588 lines.** What remains is the genuine entry: the
+import graph, DOM-handle constants, `init()` DI wiring, `setupEventListeners`
+(the event-wiring hub), the drag/drop handlers, and `renderMarkdown` (the
+render core the feature modules call back into).
 
 ## Patterns / gotchas (for future extractions)
 
@@ -61,21 +66,25 @@ Everything here is a **pure refactor** (no behavior change); the gate is
   modules at global scope, a module-level `let`/`const` whose name matches a
   main.js global silently shadows it. Hit twice:
   - a local `state` in `initializePanzoom` (renamed `instanceState`);
-  - a DI var `createTab` in share-links/file-loading (renamed `openTab`).
-  Rule: never name a module-top `let`/`const` after a main.js global.
+  - a DI var `createTab` in share-links/file-loading (renamed `openTab`);
+  - a render DI var that would be `renderDoc` in both tabs.js and desktop.js —
+    desktop.js's is named `reloadDoc` so the two modules don't share one global.
+  Rule: never name a module-top `let`/`const` after a main.js global **or after
+  another module's same-named DI var**.
+- **Breaking the tabs ↔ desktop cycle:** tabs and desktop call into each other
+  (tabs → watch/session; desktop → createTab/closeTab). To avoid a circular
+  import (which the depth-first harness can't order), the dependency is made
+  one-way: `desktop.js` imports `tabs.js` directly, while `tabs.js` receives the
+  desktop callbacks via `configureTabs` DI. main.js wires both in `init()`.
 - The Vite build is the guard for cross-module **state reassignment** (Rollup
   errors on reassigning an imported binding); the 297 tests guard behavior.
 
-## Remaining (the interwoven core)
+## Remaining / next
 
-- `features/diagrams.js` (mermaid render / panzoom / fullscreen) — being
-  extracted; it's import-only (no callbacks into main), so it moves cleanly.
-- **Tab management** (`createTab`/`switchTab`/`closeTab`/`renderTabBar`/…) and
-  **Desktop IPC** (`setupDesktopIPC` + file-watch) are tightly intertwined with
-  each other and with `renderMarkdown`; these need a careful, deliberate pass
-  (likely a `features/tabs.js` + `platform/desktop.js` with DI). `renderMarkdown`
-  + `revealHtmlComments` + the `setupEventListeners` wiring hub remain the
-  natural core of `main.js`.
+- The internal split is **done**: every cohesive unit is now a module and
+  `main.js` is the 588-line entry (wiring hub + render core). No file is wildly
+  oversized; `setupEventListeners` is the one dense block left and it's
+  inherently the entry's job, so further splitting is low-value.
 - After the split: lazy-load the Mermaid engine, then gradual TypeScript
   (`checkJs`).
 

--- a/markdown-viewer/src/features/tabs.js
+++ b/markdown-viewer/src/features/tabs.js
@@ -1,0 +1,279 @@
+// Tab management: the open-document model (create / switch / close), the tab
+// bar UI, and the empty-state drop zone reset.
+//
+// Tabs are coupled to two things that live elsewhere: the render core
+// (`renderMarkdown`, main.js) and the desktop file-watch / session layer
+// (platform/desktop.js). Both are supplied via configureTabs so this module
+// has no import cycle with the desktop layer. The DI vars are named to avoid
+// colliding with those globals under the test harness (which flattens every
+// module to global scope).
+
+import { state } from '../core/state.js';
+import { isDesktop } from '../core/platform.js';
+import { escapeHtml } from '../core/utils.js';
+import { cleanupPanzoomInstances, closeFullscreen } from './diagrams.js';
+import { closeSearch } from './search.js';
+import { toggleToc } from './toc.js';
+import { toggleSplitView } from './split-view.js';
+import { updateViewToggleButton } from './view-mode.js';
+import {
+  requestNativeOpenIfAvailable,
+  syncIOSChrome,
+  closeIOSActionSheet,
+  closeIOSTocSheet,
+} from '../platform/ios-chrome.js';
+
+const MAX_TABS = 10;
+const el = (id) => document.getElementById(id);
+
+// Render-core / desktop callbacks, wired by configureTabs in init().
+let renderDoc = () => {};
+let refreshWatchUI = () => {};
+let persistSession = () => {};
+let beginWatch = () => {};
+let endWatch = () => {};
+
+export function configureTabs(deps) {
+  if (!deps) return;
+  if (typeof deps.renderMarkdown === 'function') renderDoc = deps.renderMarkdown;
+  if (typeof deps.updateWatchToggle === 'function') refreshWatchUI = deps.updateWatchToggle;
+  if (typeof deps.saveDesktopSession === 'function') persistSession = deps.saveDesktopSession;
+  if (typeof deps.startWatchingFilePath === 'function') beginWatch = deps.startWatchingFilePath;
+  if (typeof deps.stopWatchingFilePath === 'function') endWatch = deps.stopWatchingFilePath;
+}
+
+function saveActiveTabState() {
+  if (state.activeTabId === null) return;
+  const tab = state.tabs.find((t) => t.id === state.activeTabId);
+  if (!tab) return;
+  tab.viewMode = state.currentViewMode;
+  const markdownContent = el('markdown-content');
+  if (markdownContent) tab.scrollTop = markdownContent.scrollTop;
+}
+
+export function renderTabBar() {
+  const tabBar = el('tab-bar');
+  if (!tabBar) return;
+
+  if (state.tabs.length === 0) {
+    tabBar.style.display = 'none';
+    tabBar.innerHTML = '';
+    return;
+  }
+
+  tabBar.style.display = 'flex';
+
+  let html = '';
+  for (const tab of state.tabs) {
+    const isActive = tab.id === state.activeTabId;
+    const hasChanges = !!tab.hasUnseenChanges;
+    const classes = ['tab'];
+    if (isActive) classes.push('tab-active');
+    if (hasChanges) classes.push('tab-has-changes');
+    html += `<div class="${classes.join(' ')}" data-tab-id="${tab.id}">`;
+    if (tab.watching) {
+      const dotTitle = hasChanges ? 'File changed on disk' : 'Watching for changes';
+      html += `<span class="tab-watching-dot" title="${dotTitle}"></span>`;
+    }
+    html += `<span class="tab-filename">${escapeHtml(tab.filename)}</span>`;
+    html += `<button class="tab-close" data-close-id="${tab.id}" title="Close tab">×</button>`;
+    html += `</div>`;
+  }
+  html += `<button class="tab-new" title="Open new file">+</button>`;
+
+  tabBar.innerHTML = html;
+
+  tabBar.querySelectorAll('.tab').forEach((tabEl) => {
+    tabEl.addEventListener('click', (e) => {
+      if (e.target.classList.contains('tab-close')) return;
+      const id = parseInt(tabEl.getAttribute('data-tab-id'), 10);
+      switchTab(id);
+    });
+  });
+
+  tabBar.querySelectorAll('.tab-close').forEach((btn) => {
+    btn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const id = parseInt(btn.getAttribute('data-close-id'), 10);
+      closeTab(id);
+    });
+  });
+
+  const newTabBtn = tabBar.querySelector('.tab-new');
+  if (newTabBtn) {
+    newTabBtn.addEventListener('click', () => {
+      if (requestNativeOpenIfAvailable()) return;
+      const fileInput = el('file-input');
+      if (fileInput) fileInput.click();
+    });
+  }
+}
+
+export function createTab(filename, content, filePath) {
+  if (state.tabs.length >= MAX_TABS) {
+    alert('Maximum of ' + MAX_TABS + ' tabs reached. Close a tab to open another file.');
+    return;
+  }
+
+  // Save current tab state before switching
+  saveActiveTabState();
+
+  const id = ++state.nextTabId;
+  const tab = {
+    id,
+    filename,
+    filePath: filePath || null,
+    rawMarkdown: content,
+    viewMode: 'preview',
+    scrollTop: 0,
+    watching: !!(isDesktop && filePath),
+    hasUnseenChanges: false,
+  };
+  state.tabs.push(tab);
+  state.activeTabId = id;
+
+  if (tab.watching) {
+    beginWatch(tab.filePath);
+  }
+
+  renderTabBar();
+  if (isDesktop) {
+    refreshWatchUI();
+    persistSession();
+  }
+  renderDoc(content, filename);
+}
+
+export async function switchTab(id) {
+  if (id === state.activeTabId) return;
+
+  saveActiveTabState();
+  state.activeTabId = id;
+  const tab = state.tabs.find((t) => t.id === id);
+  if (!tab) return;
+
+  // Clear the "unseen changes" flag now that the user is looking at it.
+  tab.hasUnseenChanges = false;
+
+  renderTabBar();
+  if (isDesktop) refreshWatchUI();
+  cleanupPanzoomInstances();
+
+  const markdownContent = el('markdown-content');
+
+  if (tab.viewMode === 'raw') {
+    if (state.tocVisible) {
+      toggleToc(false);
+    }
+    state.currentRawMarkdown = tab.rawMarkdown;
+    state.currentViewMode = 'raw';
+    const escaped = tab.rawMarkdown
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+    markdownContent.innerHTML = `<pre class="raw-markdown"><code>${escaped}</code></pre>`;
+    el('file-name').textContent = tab.filename;
+    el('drop-zone').style.display = 'none';
+    el('content-area').style.display = 'flex';
+    updateViewToggleButton();
+    markdownContent.scrollTop = tab.scrollTop;
+    syncIOSChrome();
+  } else {
+    await renderDoc(tab.rawMarkdown, tab.filename);
+    markdownContent.scrollTop = tab.scrollTop;
+  }
+}
+
+export async function closeTab(id) {
+  const idx = state.tabs.findIndex((t) => t.id === id);
+  if (idx === -1) return;
+
+  const wasActive = id === state.activeTabId;
+  const closedTab = state.tabs[idx];
+
+  // Stop watching before removing the tab
+  if (isDesktop && closedTab.watching && closedTab.filePath) {
+    endWatch(closedTab.filePath);
+  }
+
+  if (wasActive) {
+    cleanupPanzoomInstances();
+  }
+
+  state.tabs.splice(idx, 1);
+
+  if (isDesktop) persistSession();
+
+  if (state.tabs.length === 0) {
+    state.activeTabId = null;
+    renderTabBar();
+    if (isDesktop) refreshWatchUI();
+    showDropZone();
+  } else if (wasActive) {
+    const newIdx = Math.min(idx, state.tabs.length - 1);
+    const newTab = state.tabs[newIdx];
+    state.activeTabId = newTab.id;
+    renderTabBar();
+    if (isDesktop) refreshWatchUI();
+
+    if (newTab.viewMode === 'raw') {
+      if (state.tocVisible) {
+        toggleToc(false);
+      }
+      state.currentRawMarkdown = newTab.rawMarkdown;
+      state.currentViewMode = 'raw';
+      const escaped = newTab.rawMarkdown
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+      el('markdown-content').innerHTML = `<pre class="raw-markdown"><code>${escaped}</code></pre>`;
+      el('file-name').textContent = newTab.filename;
+      el('drop-zone').style.display = 'none';
+      el('content-area').style.display = 'flex';
+      updateViewToggleButton();
+      syncIOSChrome();
+    } else {
+      await renderDoc(newTab.rawMarkdown, newTab.filename);
+    }
+  } else {
+    renderTabBar();
+  }
+}
+
+export function showDropZone() {
+  // Cleanup
+  cleanupPanzoomInstances();
+  closeFullscreen();
+  closeSearch();
+  closeIOSActionSheet();
+  closeIOSTocSheet();
+
+  // Clear content
+  el('markdown-content').innerHTML = '';
+  el('file-name').textContent = '';
+  el('file-input').value = '';
+  state.currentRawMarkdown = '';
+  state.currentViewMode = 'preview';
+  updateViewToggleButton();
+
+  // Clear tab state
+  state.tabs = [];
+  state.activeTabId = null;
+  renderTabBar();
+
+  // Reset TOC and split view
+  if (state.tocVisible) toggleToc(false);
+  if (state.splitViewActive) toggleSplitView();
+  const tocNav = el('toc-nav');
+  if (tocNav) tocNav.innerHTML = '';
+  const iosTocNav = el('ios-toc-nav');
+  if (iosTocNav) iosTocNav.innerHTML = '';
+  state.tocEntries = [];
+  const tocSidebar = el('toc-sidebar');
+  if (tocSidebar) tocSidebar.style.display = 'none';
+
+  // Show drop zone, hide content
+  el('content-area').style.display = 'none';
+  el('drop-zone').style.display = 'flex';
+  syncIOSChrome();
+}

--- a/markdown-viewer/src/main.js
+++ b/markdown-viewer/src/main.js
@@ -17,7 +17,6 @@ import 'highlight.js/styles/github-dark.css';
 import { isDesktop, isIOSNative } from './core/platform.js';
 import { state } from './core/state.js';
 import {
-  escapeHtml,
   normalizeMarkdownUrl,
   getSvgNaturalDimensions,
   revealHtmlComments,
@@ -93,6 +92,14 @@ import {
   checkForDiagramLink,
   configureShareLinks,
 } from './features/share-links.js';
+import {
+  createTab,
+  switchTab,
+  closeTab,
+  renderTabBar,
+  showDropZone,
+  configureTabs,
+} from './features/tabs.js';
 
 // ===========================
 // Constants
@@ -106,13 +113,8 @@ const SOURCE_REPO_URL = 'https://github.com/' + SOURCE_REPO;
 // Global State
 // ===========================
 
-// Tab state
-const MAX_TABS = 10;
+// Desktop file-watch state
 const watchRefCounts = new Map(); // filePath -> number of watching tabs
-
-
-// Split view state
-
 
 // ===========================
 // DOM Elements
@@ -125,7 +127,6 @@ const openSampleMermaid = document.getElementById('open-sample-mermaid');
 const contentArea = document.getElementById('content-area');
 const markdownContent = document.getElementById('markdown-content');
 const fileName = document.getElementById('file-name');
-const tabBar = document.getElementById('tab-bar');
 const themeToggle = document.getElementById('theme-toggle');
 const fullscreenOverlay = document.getElementById('fullscreen-overlay');
 const viewToggle = document.getElementById('view-toggle');
@@ -135,8 +136,6 @@ const openUrlBtn = document.getElementById('open-url-btn');
 const urlError = document.getElementById('url-error');
 const tocToggle = document.getElementById('toc-toggle');
 const annotationToggle = document.getElementById('annotation-toggle');
-const tocSidebar = document.getElementById('toc-sidebar');
-const tocNav = document.getElementById('toc-nav');
 const splitToggle = document.getElementById('split-toggle');
 const splitRawPane = document.getElementById('split-raw-pane');
 const splitRawContent = document.getElementById('split-raw-content');
@@ -158,7 +157,6 @@ const iosPrintButton = document.getElementById('ios-print-button');
 const iosThemeButton = document.getElementById('ios-theme-button');
 const iosTocSheet = document.getElementById('ios-toc-sheet');
 const iosTocClose = document.getElementById('ios-toc-close');
-const iosTocNav = document.getElementById('ios-toc-nav');
 
 // ===========================
 // Initialization
@@ -170,6 +168,13 @@ function init() {
     configureViewMode({
         renderMarkdown: (content, title) => renderMarkdown(content, title),
         cleanupPanzoom: () => cleanupPanzoomInstances(),
+    });
+    configureTabs({
+        renderMarkdown: (content, title) => renderMarkdown(content, title),
+        updateWatchToggle: () => updateWatchToggle(),
+        saveDesktopSession: () => saveDesktopSession(),
+        startWatchingFilePath: (filePath) => startWatchingFilePath(filePath),
+        stopWatchingFilePath: (filePath) => stopWatchingFilePath(filePath),
     });
     setupVersionInfo();
     setupTheme();
@@ -573,237 +578,6 @@ async function renderMarkdown(content, filename) {
     }
 }
 
-
-function showDropZone() {
-    // Cleanup
-    cleanupPanzoomInstances();
-    closeFullscreen();
-    closeSearch();
-    closeIOSActionSheet();
-    closeIOSTocSheet();
-
-    // Clear content
-    markdownContent.innerHTML = '';
-    fileName.textContent = '';
-    fileInput.value = '';
-    state.currentRawMarkdown = '';
-    state.currentViewMode = 'preview';
-    updateViewToggleButton();
-
-    // Clear tab state
-    state.tabs = [];
-    state.activeTabId = null;
-    renderTabBar();
-
-    // Reset TOC and split view
-    if (state.tocVisible) toggleToc(false);
-    if (state.splitViewActive) toggleSplitView();
-    if (tocNav) tocNav.innerHTML = '';
-    if (iosTocNav) iosTocNav.innerHTML = '';
-    state.tocEntries = [];
-    if (tocSidebar) tocSidebar.style.display = 'none';
-
-    // Show drop zone, hide content
-    contentArea.style.display = 'none';
-    dropZone.style.display = 'flex';
-    syncIOSChrome();
-}
-
-// ===========================
-// Tab Management
-// ===========================
-function saveActiveTabState() {
-    if (state.activeTabId === null) return;
-    const tab = state.tabs.find(t => t.id === state.activeTabId);
-    if (!tab) return;
-    tab.viewMode = state.currentViewMode;
-    tab.scrollTop = markdownContent.scrollTop;
-}
-
-function renderTabBar() {
-    if (!tabBar) return;
-
-    if (state.tabs.length === 0) {
-        tabBar.style.display = 'none';
-        tabBar.innerHTML = '';
-        return;
-    }
-
-    tabBar.style.display = 'flex';
-
-    let html = '';
-    for (const tab of state.tabs) {
-        const isActive = tab.id === state.activeTabId;
-        const hasChanges = !!tab.hasUnseenChanges;
-        const classes = ['tab'];
-        if (isActive) classes.push('tab-active');
-        if (hasChanges) classes.push('tab-has-changes');
-        html += `<div class="${classes.join(' ')}" data-tab-id="${tab.id}">`;
-        if (tab.watching) {
-            const dotTitle = hasChanges ? 'File changed on disk' : 'Watching for changes';
-            html += `<span class="tab-watching-dot" title="${dotTitle}"></span>`;
-        }
-        html += `<span class="tab-filename">${escapeHtml(tab.filename)}</span>`;
-        html += `<button class="tab-close" data-close-id="${tab.id}" title="Close tab">×</button>`;
-        html += `</div>`;
-    }
-    html += `<button class="tab-new" title="Open new file">+</button>`;
-
-    tabBar.innerHTML = html;
-
-    tabBar.querySelectorAll('.tab').forEach(tabEl => {
-        tabEl.addEventListener('click', (e) => {
-            if (e.target.classList.contains('tab-close')) return;
-            const id = parseInt(tabEl.getAttribute('data-tab-id'), 10);
-            switchTab(id);
-        });
-    });
-
-    tabBar.querySelectorAll('.tab-close').forEach(btn => {
-        btn.addEventListener('click', (e) => {
-            e.stopPropagation();
-            const id = parseInt(btn.getAttribute('data-close-id'), 10);
-            closeTab(id);
-        });
-    });
-
-    const newTabBtn = tabBar.querySelector('.tab-new');
-    if (newTabBtn) {
-        newTabBtn.addEventListener('click', () => {
-            if (requestNativeOpenIfAvailable()) return;
-            fileInput.click();
-        });
-    }
-}
-
-function createTab(filename, content, filePath) {
-    if (state.tabs.length >= MAX_TABS) {
-        alert('Maximum of ' + MAX_TABS + ' tabs reached. Close a tab to open another file.');
-        return;
-    }
-
-    // Save current tab state before switching
-    saveActiveTabState();
-
-    const id = ++state.nextTabId;
-    const tab = {
-        id,
-        filename,
-        filePath: filePath || null,
-        rawMarkdown: content,
-        viewMode: 'preview',
-        scrollTop: 0,
-        watching: !!(isDesktop && filePath),
-        hasUnseenChanges: false
-    };
-    state.tabs.push(tab);
-    state.activeTabId = id;
-
-    if (tab.watching) {
-        startWatchingFilePath(tab.filePath);
-    }
-
-    renderTabBar();
-    if (isDesktop) {
-        updateWatchToggle();
-        saveDesktopSession();
-    }
-    renderMarkdown(content, filename);
-}
-
-async function switchTab(id) {
-    if (id === state.activeTabId) return;
-
-    saveActiveTabState();
-    state.activeTabId = id;
-    const tab = state.tabs.find(t => t.id === id);
-    if (!tab) return;
-
-    // Clear the "unseen changes" flag now that the user is looking at it.
-    tab.hasUnseenChanges = false;
-
-    renderTabBar();
-    if (isDesktop) updateWatchToggle();
-    cleanupPanzoomInstances();
-
-    if (tab.viewMode === 'raw') {
-        if (state.tocVisible) {
-            toggleToc(false);
-        }
-        state.currentRawMarkdown = tab.rawMarkdown;
-        state.currentViewMode = 'raw';
-        const escaped = tab.rawMarkdown
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;');
-        markdownContent.innerHTML = `<pre class="raw-markdown"><code>${escaped}</code></pre>`;
-        fileName.textContent = tab.filename;
-        dropZone.style.display = 'none';
-        contentArea.style.display = 'flex';
-        updateViewToggleButton();
-        markdownContent.scrollTop = tab.scrollTop;
-        syncIOSChrome();
-    } else {
-        await renderMarkdown(tab.rawMarkdown, tab.filename);
-        markdownContent.scrollTop = tab.scrollTop;
-    }
-}
-
-async function closeTab(id) {
-    const idx = state.tabs.findIndex(t => t.id === id);
-    if (idx === -1) return;
-
-    const wasActive = (id === state.activeTabId);
-    const closedTab = state.tabs[idx];
-
-    // Stop watching before removing the tab
-    if (isDesktop && closedTab.watching && closedTab.filePath) {
-        stopWatchingFilePath(closedTab.filePath);
-    }
-
-    if (wasActive) {
-        cleanupPanzoomInstances();
-    }
-
-    state.tabs.splice(idx, 1);
-
-    if (isDesktop) saveDesktopSession();
-
-    if (state.tabs.length === 0) {
-        state.activeTabId = null;
-        renderTabBar();
-        if (isDesktop) updateWatchToggle();
-        showDropZone();
-    } else if (wasActive) {
-        const newIdx = Math.min(idx, state.tabs.length - 1);
-        const newTab = state.tabs[newIdx];
-        state.activeTabId = newTab.id;
-        renderTabBar();
-        if (isDesktop) updateWatchToggle();
-
-        if (newTab.viewMode === 'raw') {
-            if (state.tocVisible) {
-                toggleToc(false);
-            }
-            state.currentRawMarkdown = newTab.rawMarkdown;
-            state.currentViewMode = 'raw';
-            const escaped = newTab.rawMarkdown
-                .replace(/&/g, '&amp;')
-                .replace(/</g, '&lt;')
-                .replace(/>/g, '&gt;');
-            markdownContent.innerHTML = `<pre class="raw-markdown"><code>${escaped}</code></pre>`;
-            fileName.textContent = newTab.filename;
-            dropZone.style.display = 'none';
-            contentArea.style.display = 'flex';
-            updateViewToggleButton();
-            syncIOSChrome();
-        } else {
-            await renderMarkdown(newTab.rawMarkdown, newTab.filename);
-        }
-    } else {
-        renderTabBar();
-    }
-}
 
 // ===========================
 // Desktop IPC Integration

--- a/markdown-viewer/src/main.js
+++ b/markdown-viewer/src/main.js
@@ -49,7 +49,6 @@ import {
 } from './features/annotations.js';
 import { handleRepoUrl } from './features/repo-browser.js';
 import { updateMinimap, updateMinimapViewport } from './features/minimap.js';
-import { applyCustomCss } from './features/custom-css.js';
 import {
   processMermaidDiagrams,
   cleanupPanzoomInstances,
@@ -92,14 +91,15 @@ import {
   checkForDiagramLink,
   configureShareLinks,
 } from './features/share-links.js';
+import { createTab, configureTabs } from './features/tabs.js';
 import {
-  createTab,
-  switchTab,
-  closeTab,
-  renderTabBar,
-  showDropZone,
-  configureTabs,
-} from './features/tabs.js';
+  setupDesktopIPC,
+  updateWatchToggle,
+  saveDesktopSession,
+  startWatchingFilePath,
+  stopWatchingFilePath,
+  configureDesktop,
+} from './platform/desktop.js';
 
 // ===========================
 // Constants
@@ -112,9 +112,6 @@ const SOURCE_REPO_URL = 'https://github.com/' + SOURCE_REPO;
 // ===========================
 // Global State
 // ===========================
-
-// Desktop file-watch state
-const watchRefCounts = new Map(); // filePath -> number of watching tabs
 
 // ===========================
 // DOM Elements
@@ -130,7 +127,6 @@ const fileName = document.getElementById('file-name');
 const themeToggle = document.getElementById('theme-toggle');
 const fullscreenOverlay = document.getElementById('fullscreen-overlay');
 const viewToggle = document.getElementById('view-toggle');
-const watchToggle = document.getElementById('watch-toggle');
 const urlInput = document.getElementById('url-input');
 const openUrlBtn = document.getElementById('open-url-btn');
 const urlError = document.getElementById('url-error');
@@ -176,6 +172,7 @@ function init() {
         startWatchingFilePath: (filePath) => startWatchingFilePath(filePath),
         stopWatchingFilePath: (filePath) => stopWatchingFilePath(filePath),
     });
+    configureDesktop({ renderMarkdown: (content, title) => renderMarkdown(content, title) });
     setupVersionInfo();
     setupTheme();
     setupIOSNativeUI();
@@ -578,181 +575,6 @@ async function renderMarkdown(content, filename) {
     }
 }
 
-
-// ===========================
-// Desktop IPC Integration
-// ===========================
-function updateWatchToggle() {
-    if (!watchToggle) return;
-
-    const tab = state.activeTabId !== null ? state.tabs.find(t => t.id === state.activeTabId) : null;
-    const canWatch = !!(tab && tab.filePath);
-
-    if (!canWatch) {
-        watchToggle.style.display = 'none';
-        return;
-    }
-
-    watchToggle.style.display = '';
-    if (tab.watching) {
-        watchToggle.classList.add('active');
-        watchToggle.title = 'Watching — click to stop';
-    } else {
-        watchToggle.classList.remove('active');
-        watchToggle.title = 'Auto-reload when file changes on disk';
-    }
-}
-
-// Briefly animate the watch toggle to signal that an auto-reload just
-// happened. Without this, the reload is invisible if the user happens
-// not to be looking at the content area when the disk write lands.
-let watchTogglePulseTimer = null;
-function pulseWatchToggle() {
-    if (!watchToggle) return;
-    watchToggle.classList.remove('reloaded');
-    // Force reflow so re-adding the class restarts the animation even
-    // when multiple reloads happen in quick succession.
-    // eslint-disable-next-line no-unused-expressions
-    void watchToggle.offsetWidth;
-    watchToggle.classList.add('reloaded');
-    watchToggle.title = 'Reloaded from disk';
-
-    if (watchTogglePulseTimer) clearTimeout(watchTogglePulseTimer);
-    watchTogglePulseTimer = setTimeout(() => {
-        watchToggle.classList.remove('reloaded');
-        // Restore the state-appropriate tooltip.
-        updateWatchToggle();
-        watchTogglePulseTimer = null;
-    }, 1200);
-}
-
-function startWatchingFilePath(filePath) {
-    if (!isDesktop || !filePath || !window.specdown || !window.specdown.watchFile) return;
-
-    const currentCount = watchRefCounts.get(filePath) || 0;
-    watchRefCounts.set(filePath, currentCount + 1);
-
-    if (currentCount === 0) {
-        window.specdown.watchFile(filePath);
-    }
-}
-
-function stopWatchingFilePath(filePath) {
-    if (!isDesktop || !filePath || !window.specdown || !window.specdown.unwatchFile) return;
-
-    const currentCount = watchRefCounts.get(filePath) || 0;
-    if (currentCount <= 1) {
-        watchRefCounts.delete(filePath);
-        window.specdown.unwatchFile(filePath);
-        return;
-    }
-
-    watchRefCounts.set(filePath, currentCount - 1);
-}
-
-function toggleWatching() {
-    if (!isDesktop) return;
-    const tab = state.activeTabId !== null ? state.tabs.find(t => t.id === state.activeTabId) : null;
-    if (!tab || !tab.filePath) return;
-
-    tab.watching = !tab.watching;
-
-    if (tab.watching) {
-        startWatchingFilePath(tab.filePath);
-    } else {
-        stopWatchingFilePath(tab.filePath);
-    }
-
-    renderTabBar();
-    updateWatchToggle();
-}
-
-function setupDesktopIPC() {
-    // Listen for files opened from the main process (Cmd+O, Finder, drag-to-dock)
-    window.specdown.onFileOpened(function(fileData) {
-        createTab(fileData.filename, fileData.content, fileData.filePath);
-    });
-
-    // Listen for close-tab command from native menu (Cmd+W)
-    window.specdown.onCloseTab(function() {
-        if (state.activeTabId !== null) {
-            closeTab(state.activeTabId);
-        }
-    });
-
-    // Listen for file-changed events (watched file updated on disk)
-    window.specdown.onFileChanged(async function(fileData) {
-        const tab = state.tabs.find(t => t.filePath === fileData.filePath);
-        if (!tab) return;
-
-        tab.rawMarkdown = fileData.content;
-        tab.filename = fileData.filename;
-
-        if (tab.id === state.activeTabId) {
-            // Preserve scroll position across the re-render so an
-            // auto-reload doesn't yank the user back to the top.
-            const savedScrollTop = markdownContent.scrollTop;
-
-            if (tab.viewMode === 'raw') {
-                state.currentRawMarkdown = fileData.content;
-                const escaped = fileData.content
-                    .replace(/&/g, '&amp;')
-                    .replace(/</g, '&lt;')
-                    .replace(/>/g, '&gt;');
-                markdownContent.innerHTML = `<pre class="raw-markdown"><code>${escaped}</code></pre>`;
-                markdownContent.scrollTop = savedScrollTop;
-            } else {
-                await renderMarkdown(fileData.content, fileData.filename);
-                markdownContent.scrollTop = savedScrollTop;
-            }
-
-            // Visual feedback that an auto-reload happened — otherwise
-            // the user has no way to tell the content just changed.
-            pulseWatchToggle();
-        } else {
-            // Background tab: flag it so the user sees that something
-            // changed when they come back to it.
-            tab.hasUnseenChanges = true;
-            renderTabBar();
-        }
-    });
-
-    // Wire up watch toggle button
-    if (watchToggle) {
-        watchToggle.addEventListener('click', toggleWatching);
-    }
-
-    // Native menu: File > Print
-    if (window.specdown.onTriggerPrint) {
-        window.specdown.onTriggerPrint(function() {
-            performPrint();
-        });
-    }
-
-    // Native menu: Edit > Find
-    if (window.specdown.onTriggerSearch) {
-        window.specdown.onTriggerSearch(function() {
-            if (contentArea.style.display !== 'none') {
-                openSearch();
-            }
-        });
-    }
-
-    // Appearance menu: apply custom CSS theme
-    if (window.specdown.onApplyCustomCss) {
-        window.specdown.onApplyCustomCss(function(cssContent) {
-            applyCustomCss(cssContent);
-        });
-    }
-}
-
-function saveDesktopSession() {
-    if (!isDesktop || !window.specdown.saveSession) return;
-    window.specdown.saveSession(state.tabs.map(t => ({
-        filePath: t.filePath,
-        filename: t.filename
-    })));
-}
 
 // ===========================
 // Feature: Print / PDF Export

--- a/markdown-viewer/src/platform/desktop.js
+++ b/markdown-viewer/src/platform/desktop.js
@@ -1,0 +1,205 @@
+// Desktop (Electron) integration: the file-watch model, the watch-toggle UI,
+// session persistence, and the IPC wiring to the main process (native menus,
+// file-open / file-changed / close-tab events, custom CSS).
+//
+// Tabs live in features/tabs.js; this layer drives them (createTab/closeTab on
+// IPC events) and supplies tabs with the watch/session callbacks via
+// configureTabs in main.js. The render core (renderMarkdown) is supplied here
+// via configureDesktop — its DI var is named to avoid colliding with tabs.js's
+// own render callback under the test harness.
+
+import { state } from '../core/state.js';
+import { isDesktop } from '../core/platform.js';
+import { createTab, closeTab, renderTabBar } from '../features/tabs.js';
+import { openSearch } from '../features/search.js';
+import { applyCustomCss } from '../features/custom-css.js';
+import { performPrint } from './ios-chrome.js';
+
+const el = (id) => document.getElementById(id);
+
+const watchRefCounts = new Map(); // filePath -> number of watching tabs
+
+// Render core (main.js), supplied via configureDesktop.
+let reloadDoc = () => {};
+
+export function configureDesktop(deps) {
+  if (deps && typeof deps.renderMarkdown === 'function') reloadDoc = deps.renderMarkdown;
+}
+
+export function updateWatchToggle() {
+  const watchToggle = el('watch-toggle');
+  if (!watchToggle) return;
+
+  const tab = state.activeTabId !== null ? state.tabs.find((t) => t.id === state.activeTabId) : null;
+  const canWatch = !!(tab && tab.filePath);
+
+  if (!canWatch) {
+    watchToggle.style.display = 'none';
+    return;
+  }
+
+  watchToggle.style.display = '';
+  if (tab.watching) {
+    watchToggle.classList.add('active');
+    watchToggle.title = 'Watching — click to stop';
+  } else {
+    watchToggle.classList.remove('active');
+    watchToggle.title = 'Auto-reload when file changes on disk';
+  }
+}
+
+// Briefly animate the watch toggle to signal that an auto-reload just
+// happened. Without this, the reload is invisible if the user happens
+// not to be looking at the content area when the disk write lands.
+let watchTogglePulseTimer = null;
+function pulseWatchToggle() {
+  const watchToggle = el('watch-toggle');
+  if (!watchToggle) return;
+  watchToggle.classList.remove('reloaded');
+  // Force reflow so re-adding the class restarts the animation even
+  // when multiple reloads happen in quick succession.
+  // eslint-disable-next-line no-unused-expressions
+  void watchToggle.offsetWidth;
+  watchToggle.classList.add('reloaded');
+  watchToggle.title = 'Reloaded from disk';
+
+  if (watchTogglePulseTimer) clearTimeout(watchTogglePulseTimer);
+  watchTogglePulseTimer = setTimeout(() => {
+    watchToggle.classList.remove('reloaded');
+    // Restore the state-appropriate tooltip.
+    updateWatchToggle();
+    watchTogglePulseTimer = null;
+  }, 1200);
+}
+
+export function startWatchingFilePath(filePath) {
+  if (!isDesktop || !filePath || !window.specdown || !window.specdown.watchFile) return;
+
+  const currentCount = watchRefCounts.get(filePath) || 0;
+  watchRefCounts.set(filePath, currentCount + 1);
+
+  if (currentCount === 0) {
+    window.specdown.watchFile(filePath);
+  }
+}
+
+export function stopWatchingFilePath(filePath) {
+  if (!isDesktop || !filePath || !window.specdown || !window.specdown.unwatchFile) return;
+
+  const currentCount = watchRefCounts.get(filePath) || 0;
+  if (currentCount <= 1) {
+    watchRefCounts.delete(filePath);
+    window.specdown.unwatchFile(filePath);
+    return;
+  }
+
+  watchRefCounts.set(filePath, currentCount - 1);
+}
+
+function toggleWatching() {
+  if (!isDesktop) return;
+  const tab = state.activeTabId !== null ? state.tabs.find((t) => t.id === state.activeTabId) : null;
+  if (!tab || !tab.filePath) return;
+
+  tab.watching = !tab.watching;
+
+  if (tab.watching) {
+    startWatchingFilePath(tab.filePath);
+  } else {
+    stopWatchingFilePath(tab.filePath);
+  }
+
+  renderTabBar();
+  updateWatchToggle();
+}
+
+export function setupDesktopIPC() {
+  // Listen for files opened from the main process (Cmd+O, Finder, drag-to-dock)
+  window.specdown.onFileOpened(function (fileData) {
+    createTab(fileData.filename, fileData.content, fileData.filePath);
+  });
+
+  // Listen for close-tab command from native menu (Cmd+W)
+  window.specdown.onCloseTab(function () {
+    if (state.activeTabId !== null) {
+      closeTab(state.activeTabId);
+    }
+  });
+
+  // Listen for file-changed events (watched file updated on disk)
+  window.specdown.onFileChanged(async function (fileData) {
+    const tab = state.tabs.find((t) => t.filePath === fileData.filePath);
+    if (!tab) return;
+
+    tab.rawMarkdown = fileData.content;
+    tab.filename = fileData.filename;
+
+    if (tab.id === state.activeTabId) {
+      // Preserve scroll position across the re-render so an
+      // auto-reload doesn't yank the user back to the top.
+      const markdownContent = el('markdown-content');
+      const savedScrollTop = markdownContent.scrollTop;
+
+      if (tab.viewMode === 'raw') {
+        state.currentRawMarkdown = fileData.content;
+        const escaped = fileData.content
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;');
+        markdownContent.innerHTML = `<pre class="raw-markdown"><code>${escaped}</code></pre>`;
+        markdownContent.scrollTop = savedScrollTop;
+      } else {
+        await reloadDoc(fileData.content, fileData.filename);
+        markdownContent.scrollTop = savedScrollTop;
+      }
+
+      // Visual feedback that an auto-reload happened — otherwise
+      // the user has no way to tell the content just changed.
+      pulseWatchToggle();
+    } else {
+      // Background tab: flag it so the user sees that something
+      // changed when they come back to it.
+      tab.hasUnseenChanges = true;
+      renderTabBar();
+    }
+  });
+
+  // Wire up watch toggle button
+  const watchToggle = el('watch-toggle');
+  if (watchToggle) {
+    watchToggle.addEventListener('click', toggleWatching);
+  }
+
+  // Native menu: File > Print
+  if (window.specdown.onTriggerPrint) {
+    window.specdown.onTriggerPrint(function () {
+      performPrint();
+    });
+  }
+
+  // Native menu: Edit > Find
+  if (window.specdown.onTriggerSearch) {
+    window.specdown.onTriggerSearch(function () {
+      if (el('content-area').style.display !== 'none') {
+        openSearch();
+      }
+    });
+  }
+
+  // Appearance menu: apply custom CSS theme
+  if (window.specdown.onApplyCustomCss) {
+    window.specdown.onApplyCustomCss(function (cssContent) {
+      applyCustomCss(cssContent);
+    });
+  }
+}
+
+export function saveDesktopSession() {
+  if (!isDesktop || !window.specdown.saveSession) return;
+  window.specdown.saveSession(
+    state.tabs.map((t) => ({
+      filePath: t.filePath,
+      filename: t.filename,
+    }))
+  );
+}


### PR DESCRIPTION
Finishes the Phase 1 internal split (after #117) by extracting the last two coupled units. **Pure refactor — no behavior change.** Every commit is independently green (`npm run build` + `npm run lint` + **297 tests**).

## Commits (atomic)
1. **`features/tabs.js`** — tab create/switch/close, the tab bar UI, and the empty-state drop-zone reset.
2. **`platform/desktop.js`** — Electron file-watch (ref-counted), the watch-toggle UI, session persistence, and main-process IPC wiring (file-open / file-changed / close-tab, native menus, custom CSS).
3. docs: session-03 progress.

## The coupling, and how it's broken
Tabs and desktop call into each other (tabs → watch/session callbacks; desktop → `createTab`/`closeTab`/`renderTabBar`). To avoid a circular import (which the depth-first test harness can't order), the dependency is made **one-way**:
- `platform/desktop.js` **imports** `features/tabs.js` directly.
- `features/tabs.js` receives the desktop watch/session callbacks via **`configureTabs` DI**.
- `main.js` wires both (`configureTabs` + `configureDesktop`) in `init()`, lazily so deps resolve at call time.

**Harness collision note:** both modules need a `renderMarkdown` DI var; under the inlining harness a module-top `let`/`const` is a global, so the two can't share the name. tabs.js uses `renderDoc`, desktop.js uses `reloadDoc`.

## Impact
`src/main.js`: **992 → 588 lines** (and **2,814 → 588** across the whole split). What's left is the genuine entry: the import graph, DOM-handle constants, `init()` DI wiring, `setupEventListeners` (the event-wiring hub), drag/drop handlers, and `renderMarkdown` (the render core the feature modules call back into). The internal split is now complete.

## Verified
- `npm run build` ✓, `npm run lint` ✓ (0 errors), `npm test` → **297 passed** — at every commit.
- `desktopRenderer.test.js` (watch ref-counting, background-tab change flagging, switch-clears-flag) passes against the extracted modules unchanged.

## Next (not in this PR)
Lazy-load the Mermaid engine, then gradual TypeScript (`checkJs`). Then Phase 2 (design system / a11y / WCAG) and Phase 3 (signing/notarization — the desktop Gatekeeper fix).

https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA)_