### PR TITLE
Phase 1: lazy-load Mermaid — defer ~2 MB until a diagram renders

### DIFF
--- a/markdown-viewer/src/core/render-config.js
+++ b/markdown-viewer/src/core/render-config.js
@@ -1,7 +1,7 @@
-// marked + mermaid configuration. Pure setup — no callbacks back into the app.
+// marked configuration + the lazy mermaid loader. Pure setup — no callbacks
+// back into the app.
 
 import { marked } from 'marked';
-import mermaid from 'mermaid';
 import hljs from 'highlight.js';
 import { state } from './state.js';
 
@@ -49,6 +49,25 @@ export function getMermaidConfig() {
   };
 }
 
-export function configureMermaid() {
-  mermaid.initialize(getMermaidConfig());
+// Mermaid is by far the heaviest dependency and most documents contain no
+// diagrams, so it is loaded on demand the first time a diagram is rendered
+// rather than shipped in the initial bundle. The dynamic import plus the
+// one-time initialize is cached behind a single promise.
+//
+// Under the Jest harness the module graph is flattened to globals and bare
+// imports are replaced by mocks, so a global `mermaid` stands in for the real
+// dynamic import (the `import('mermaid')` branch is never taken there).
+let mermaidPromise = null;
+export function loadMermaid() {
+  if (!mermaidPromise) {
+    const source =
+      typeof globalThis.mermaid !== 'undefined'
+        ? Promise.resolve(globalThis.mermaid)
+        : import('mermaid').then((module) => module.default);
+    mermaidPromise = source.then((instance) => {
+      instance.initialize(getMermaidConfig());
+      return instance;
+    });
+  }
+  return mermaidPromise;
 }

--- a/markdown-viewer/src/features/diagrams.js
+++ b/markdown-viewer/src/features/diagrams.js
@@ -1,10 +1,9 @@
 import Panzoom from '@panzoom/panzoom';
-import mermaid from 'mermaid';
 import DOMPurify from 'dompurify';
 import { state } from '../core/state.js';
 import { isIOSNative } from '../core/platform.js';
 import { getSvgNaturalDimensions } from '../core/utils.js';
-import { getMermaidConfig } from '../core/render-config.js';
+import { getMermaidConfig, loadMermaid } from '../core/render-config.js';
 import { updateMinimap, updateMinimapViewport } from './minimap.js';
 import { downloadDiagramSvg, downloadDiagramPng } from './diagram-export.js';
 import { shareDiagramLink } from './share-links.js';
@@ -19,6 +18,10 @@ export async function processMermaidDiagrams() {
     const codeBlocks = el('markdown-content').querySelectorAll('code.language-mermaid');
 
     if (codeBlocks.length === 0) return;
+
+    // Load the mermaid engine on demand (this is the only place — plus the theme
+    // re-render — that needs it, so documents without diagrams never pay for it).
+    const mermaid = await loadMermaid();
 
     // Process each mermaid diagram
     for (let i = 0; i < codeBlocks.length; i++) {
@@ -492,11 +495,15 @@ export function cleanupPanzoomInstances() {
 // Re-render Mermaid (for theme change)
 // ===========================
 export async function reRenderMermaidDiagrams() {
-    // Update mermaid theme
-    mermaid.initialize(getMermaidConfig());
-
     // Get all diagram containers
     const containers = el('markdown-content').querySelectorAll('.diagram-container');
+
+    // Nothing to re-theme means no need to pull in the mermaid engine.
+    if (containers.length === 0) return;
+
+    // Update mermaid theme (the engine is already loaded if diagrams exist)
+    const mermaid = await loadMermaid();
+    mermaid.initialize(getMermaidConfig());
 
     for (const container of containers) {
         const wrapper = container.querySelector('.diagram-wrapper');

--- a/markdown-viewer/src/main.js
+++ b/markdown-viewer/src/main.js
@@ -1,15 +1,12 @@
 // SpecDown — shared viewer entry point.
 //
-// Phase 1 (modernization roadmap): the formerly-vendored browser globals are
-// now real ES-module imports bundled by Vite. They are bound to the same
-// identifiers (`marked`, `mermaid`, `Panzoom`, `hljs`, `DOMPurify`) the rest of
-// this file already used, so the app logic below is unchanged. The internal
-// split into core/features/platform modules is a subsequent slice; for now the
-// logic remains in this single module to keep the migration behavior-preserving.
+// Phase 1 (modernization roadmap): the viewer is an ES-module graph bundled by
+// Vite, split into core/features/platform modules. This entry keeps the render
+// core (`renderMarkdown`), the event-wiring hub, and the init() DI wiring; the
+// cohesive features live in their own modules. `marked` and `DOMPurify` are used
+// directly by the render core here; the heavy `mermaid` engine is loaded on
+// demand by the diagram module (see core/render-config.js `loadMermaid`).
 import { marked } from 'marked';
-import mermaid from 'mermaid';
-import Panzoom from '@panzoom/panzoom';
-import hljs from 'highlight.js';
 import DOMPurify from 'dompurify';
 import 'highlight.js/styles/github-dark.css';
 
@@ -21,11 +18,7 @@ import {
   getSvgNaturalDimensions,
   revealHtmlComments,
 } from './core/utils.js';
-import {
-  configureMarked,
-  configureMermaid,
-  getMermaidConfig,
-} from './core/render-config.js';
+import { configureMarked } from './core/render-config.js';
 import {
   handleFile,
   handleFileSelect,
@@ -177,7 +170,6 @@ function init() {
     setupTheme();
     setupIOSNativeUI();
     setupEventListeners();
-    configureMermaid();
     configureMarked();
     checkForUpdates();
     checkForDiagramLink();

--- a/tests/integration/mermaid.test.js
+++ b/tests/integration/mermaid.test.js
@@ -13,14 +13,18 @@ describe('Mermaid Diagram Processing', () => {
     loadHTML(document);
     loadApp(document);
     mermaid.render.mockClear();
+    mermaid.initialize.mockClear();
     Panzoom.mockClear();
   });
 
-  describe('configureMermaid', () => {
-    it('should configure mermaid with correct theme for light mode', () => {
+  // Mermaid is loaded (and initialized once) on demand via loadMermaid rather
+  // than eagerly at startup, so these assert the lazy loader applies the right
+  // config the first time it runs.
+  describe('loadMermaid', () => {
+    it('should configure mermaid with correct theme for light mode', async () => {
       localStorage.getItem.mockReturnValue('light');
 
-      configureMermaid();
+      await loadMermaid();
 
       expect(mermaid.initialize).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -29,12 +33,12 @@ describe('Mermaid Diagram Processing', () => {
       );
     });
 
-    it('should configure mermaid with correct theme for dark mode', () => {
+    it('should configure mermaid with correct theme for dark mode', async () => {
       // Reset and configure for dark mode
       document.documentElement.setAttribute('data-theme', 'dark');
       state.currentTheme = 'dark';
 
-      configureMermaid();
+      await loadMermaid();
 
       expect(mermaid.initialize).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -43,8 +47,8 @@ describe('Mermaid Diagram Processing', () => {
       );
     });
 
-    it('should set security level to strict', () => {
-      configureMermaid();
+    it('should set security level to strict', async () => {
+      await loadMermaid();
 
       expect(mermaid.initialize).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -53,8 +57,8 @@ describe('Mermaid Diagram Processing', () => {
       );
     });
 
-    it('should configure font family', () => {
-      configureMermaid();
+    it('should configure font family', async () => {
+      await loadMermaid();
 
       expect(mermaid.initialize).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/vite.config.js
+++ b/vite.config.js
@@ -31,15 +31,12 @@ export default defineConfig({
     outDir: 'dist',
     emptyOutDir: true,
     modulepreload: { polyfill: false },
-    rollupOptions: {
-      output: {
-        // Split the heavy Mermaid engine into its own chunk so it can be
-        // cached independently of the app shell (and lazy-loaded in a later
-        // slice). Highlight.js + DOMPurify stay with the app for now.
-        manualChunks: {
-          mermaid: ['mermaid'],
-        },
-      },
-    },
+    // The heavy Mermaid engine is loaded on demand via a dynamic import (see
+    // core/render-config.js `loadMermaid`), so Rollup automatically code-splits
+    // it — and its diagram-type sub-modules — into async chunks that the app
+    // shell never loads until a document actually contains a diagram. We do NOT
+    // force a manualChunk for mermaid: doing so pulls mermaid's *shared* deps
+    // into that chunk, which the eager entry then has to import statically,
+    // defeating the lazy-load. Highlight.js + DOMPurify stay with the app shell.
   },
 });


### PR DESCRIPTION
Lazy-loads the Mermaid engine so the app shell no longer downloads it (or its cytoscape/katex/wardley ecosystem) until a document actually contains a diagram.

## The problem
Mermaid was statically imported in **three** places — `main.js`, `core/render-config.js`, and `features/diagrams.js` — so it was pulled into the eager graph and downloaded on every page load, even for diagram-less documents. The existing `manualChunks: { mermaid: ['mermaid'] }` put it in a *named* chunk, but the chunk was still **statically linked** from the entry (`import{…}from"./mermaid-…js"`), so the browser fetched it eagerly anyway.

## The fix
- A single cached dynamic import behind **`loadMermaid()`** in `render-config.js`, awaited on demand by `processMermaidDiagrams()` and the theme re-render (`reRenderMermaidDiagrams()`, which now early-returns when there are no diagrams).
- Removed all three static `import … 'mermaid'` lines, the startup `configureMermaid()` call, and the dead `mermaid`/`Panzoom`/`hljs` imports from `main.js`.
- **Removed `manualChunks: { mermaid }` from `vite.config.js`.** Forcing mermaid into a named chunk dragged its *shared* deps into that chunk, which the eager entry then imported statically — defeating the split. With a real dynamic import, Rollup code-splits mermaid (and each diagram type) into async chunks automatically.

## Test-harness compatibility
The Jest harness flattens the module graph to globals and mocks bare imports, so `loadMermaid()` prefers a `globalThis.mermaid` (the mock) and only falls back to `import('mermaid')` in production — the dynamic branch is never taken under test. The mermaid integration test now exercises `loadMermaid()` (async, initializes once) instead of the removed `configureMermaid()`.

## Verified against the built output
- Entry references mermaid **only** via `import("./mermaid.core-…js")` — no static `from"./mermaid…"`.
- `index.html` has **no** modulepreload for mermaid.
- Deferred until first diagram: `mermaid.core` (592 kB) + `cytoscape` (443 kB) + `katex` (261 kB) + `wardley` (615 kB) + ~40 per-diagram-type chunks.
- `npm run build` ✓, `npm run lint` ✓, `npm test` → **297 passed**.

## Note / next
The app-shell entry is still ~1.07 MB, dominated by **highlight.js** (full language set). Lazy-loading hljs (or trimming to a language subset) is the natural follow-on but is out of scope here. After that: gradual TypeScript (`checkJs`).

https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA)_