### PR TITLE
Phase 1: trim highlight.js to a curated language set — app shell 1.07 MB → 261 kB

### DIFF
--- a/docs/project-modernization/2026-06-14-tasks-session-04-phase1-bundle-deps.md
+++ b/docs/project-modernization/2026-06-14-tasks-session-04-phase1-bundle-deps.md
@@ -1,0 +1,89 @@
+# Tasks — Session 04: Phase 1 (heavy-dependency loading / bundle size)
+
+**Date:** 2026-06-14
+**Type:** tasks (session-level implementation checklist)
+**Phase:** 1 — Architecture (the "lazy-load heavy deps" roadmap item)
+**Source plan:** [2026-06-13-brainstorm-modernization-evaluation.md](2026-06-13-brainstorm-modernization-evaluation.md) §6
+
+With the internal module split done (session 03), this session attacks the
+**app-shell download size**. Two heavy dependencies dominated the eager bundle:
+**Mermaid** (+ its cytoscape/katex/wardley ecosystem) and **highlight.js** (its
+full ~190-language grammar set). The gate is unchanged: `npm run build` +
+`npm run lint` + the **297 Jest tests**, green at every commit.
+
+---
+
+## 1. Lazy-load Mermaid — defer ~2 MB until a diagram renders (PR #119, merged)
+
+Mermaid was statically imported in three places (`main.js`,
+`core/render-config.js`, `features/diagrams.js`), so it sat in the eager graph
+and downloaded on every page load even for diagram-less docs. The existing
+`manualChunks: { mermaid }` put it in a *named* chunk, but the entry still
+linked that chunk **statically**, so the browser fetched it anyway.
+
+- A single cached dynamic import behind **`loadMermaid()`** in
+  `render-config.js`, awaited on demand by `processMermaidDiagrams()` and the
+  theme re-render (`reRenderMermaidDiagrams()`, which now early-returns when
+  there are no diagrams).
+- Removed all three static `import … 'mermaid'` lines, the startup
+  `configureMermaid()` call, and dead `mermaid`/`Panzoom`/`hljs` imports.
+- **Removed `manualChunks: { mermaid }` from `vite.config.js`** — forcing the
+  named chunk dragged mermaid's shared deps into it, which the eager entry then
+  imported statically, defeating the split. With a real dynamic import Rollup
+  code-splits mermaid (and each diagram type) into async chunks automatically.
+- **Test-harness compat:** `loadMermaid()` prefers a `globalThis.mermaid` (the
+  Jest mock) and only falls back to `import('mermaid')` in production, so the
+  dynamic branch is never taken under test.
+- **Verified:** entry references mermaid only via `import("./mermaid.core-…")`;
+  no modulepreload; `mermaid.core` (592 kB) + `cytoscape` (443 kB) + `katex`
+  (261 kB) + `wardley` (615 kB) + ~40 per-diagram chunks all deferred.
+- Confirmed rendering still works on the **desktop build** post-merge.
+
+## 2. Trim highlight.js to a curated language set
+
+highlight.js can't be lazy-loaded the same way: the marked `code()` renderer is
+**synchronous**, and unlike diagrams, code blocks are common, so deferring the
+engine wouldn't help most documents. The lever is instead **trimming** — every
+page load pays for hljs, so shrinking it is an unconditional win.
+
+- New **`core/highlight.js`**: starts from `highlight.js/lib/core` and
+  `registerLanguage`s a curated ~29-language set (js/ts, python, bash/shell,
+  json, yaml, markdown, xml, css/scss, sql, java, kotlin, swift, go, rust,
+  c/cpp/csharp, ruby, php, objectivec, diff, dockerfile, ini, makefile,
+  graphql, plaintext). `registerLanguage` wires each grammar's **aliases**, so
+  short forms come free (`js`, `ts`, `html`/`svg`, `sh`, `md`, `yml`, `toml`, …).
+- `render-config.js` now imports `hljs` from `./highlight.js` instead of the
+  full `highlight.js` package. Languages outside the set still render — just as
+  an escaped plain code block via the renderer's existing fallback.
+- **Test-harness compat:** `core/highlight.js` imports the core engine + grammar
+  modules as bare imports, which the eval harness strips — leaving the language
+  bindings dangling. Since the engine is a global `hljs` mock under test, the
+  harness (`tests/helpers/loadApp.js`) now **skips inlining** any relative
+  `…/highlight.js` import, treating it like the bare `highlight.js` dependency it
+  replaces (the `import hljs from './highlight.js'` line is stripped as before).
+- **Result:** app-shell entry **1,098,692 → 261,494 bytes** (~837 kB / 76%
+  smaller). Real-hljs smoke test confirms python highlights, `js`/`toml` aliases
+  resolve, and unknown languages fall back to plain. `npm run build` ✓,
+  `npm run lint` ✓, `npm test` → **297 passed**.
+
+## Patterns / gotchas
+
+- **Eval-harness + bare imports:** any identifier that comes from a *stripped*
+  bare import and is then *referenced* (not just `typeof`-guarded) throws
+  `ReferenceError` under the harness — the harness's contract is "every
+  bare-imported binding you reference is provided as a global mock." A config
+  module like `core/highlight.js` references 29 such bindings, so it can't be
+  inlined; it's skipped and the global mock stands in. (Mermaid sidesteps this
+  by `globalThis.mermaid`-checking inside `loadMermaid()`.)
+- **Named manualChunks ≠ lazy:** a manual chunk is still statically linked
+  unless the only path to it is a dynamic `import()`. Removing the manualChunk
+  and adding a real dynamic import is what actually defers the download.
+
+## Remaining / next
+
+- Phase 1's "lazy-load heavy deps" item is now substantially done (Mermaid
+  deferred, hljs trimmed). Next Phase 1 step: **gradual TypeScript** (`checkJs`
+  + JSDoc types across the new `core/`/`features/`/`platform/` modules).
+- Possible later refinement: lazy-load hljs via a post-render DOM pass (render
+  code blocks unhighlighted, then highlight asynchronously) to defer it for
+  diagram/prose-only docs — lower value than the trim, deferred.

--- a/docs/project-modernization/README.md
+++ b/docs/project-modernization/README.md
@@ -11,6 +11,8 @@ three-lens evaluation of the app at v0.0.82 and a phased roadmap.
 | 2026-06-13 | [brainstorm-modernization-evaluation](2026-06-13-brainstorm-modernization-evaluation.md) | PM/UX/engineering evaluation of v0.0.82, north-star vision, phased roadmap (Phases 0–4) |
 | 2026-06-13 | [tasks-session-01-phase0-hygiene](2026-06-13-tasks-session-01-phase0-hygiene.md) | Phase 0 implementation: desktop external-link fix, iOS CI honesty, lockfile + ESLint/Prettier + CI lane + Dependabot + CSP, docs reconciliation |
 | 2026-06-13 | [tasks-session-02-phase1-vite-foundation](2026-06-13-tasks-session-02-phase1-vite-foundation.md) | Phase 1 slice 1: Vite + ES-module build foundation, real npm deps replace `vendor/`, all surfaces load `dist/`, harness migrated, sync-version regression fixed |
+| 2026-06-14 | [tasks-session-03-phase1-module-split](2026-06-14-tasks-session-03-phase1-module-split.md) | Phase 1 slice 2: internal split of the ~2,800-line `src/main.js` into `core/`/`features/`/`platform/` modules (main.js → 588 lines), pure refactor, 297 tests green |
+| 2026-06-14 | [tasks-session-04-phase1-bundle-deps](2026-06-14-tasks-session-04-phase1-bundle-deps.md) | Phase 1 slice 3: heavy-dep loading — lazy-load Mermaid (~2 MB deferred, PR #119) + trim highlight.js to a curated language set (app-shell entry 1.07 MB → 261 kB) |
 
 ## Current Status
 
@@ -22,9 +24,12 @@ slice; lint + 297 tests are green and the web build is verified headlessly.
 **Desktop (Electron) and iOS load `file://` and need a manual smoke-test on the
 branch before merge** (see the session 02 verification checklist).
 
-Remaining Phase 1 work (next slices): split `src/main.js` into
-core/features/platform modules (no file > 500 lines), lazy-load the Mermaid
-engine, begin gradual TypeScript.
+The `src/main.js` monolith has since been **split** into
+core/features/platform modules (session 03, main.js → 588 lines), and the
+**heavy-dependency loading** work is substantially done (session 04): Mermaid
+is lazy-loaded (~2 MB deferred until a diagram renders, PR #119) and
+highlight.js is trimmed to a curated language set (app-shell entry 1.07 MB →
+261 kB). Remaining Phase 1 work: begin **gradual TypeScript** (`checkJs`).
 
 The open questions below (iOS investment, Apple Developer membership for
 signing, Electron vs Tauri spike) still gate **Phases 2–4**, not Phase 1.

--- a/markdown-viewer/src/core/highlight.js
+++ b/markdown-viewer/src/core/highlight.js
@@ -1,0 +1,81 @@
+// Curated highlight.js build.
+//
+// The full `highlight.js` package bundles ~190 language grammars (~900 kB) and
+// was the single largest contributor to the eager app-shell bundle. Code blocks
+// — unlike Mermaid diagrams — are common enough that lazy-loading the engine
+// wouldn't help most documents, so instead we trim: start from the core engine
+// and register only a curated set of languages that cover the overwhelming
+// majority of real-world technical docs.
+//
+// `registerLanguage` also wires up each grammar's aliases, so the common short
+// forms come for free (js/jsx/ts/tsx, sh, html/svg, md, yml, toml, …). Anything
+// not in this list still renders as an escaped plain code block via the marked
+// renderer's fallback — it just isn't syntax-highlighted.
+//
+// Under the Jest harness the bare imports below are stripped and a global
+// `hljs` mock stands in (registerLanguage is a no-op there), so this module is
+// inert under test and the renderer exercises the mock.
+import hljs from 'highlight.js/lib/core';
+
+import bash from 'highlight.js/lib/languages/bash';
+import c from 'highlight.js/lib/languages/c';
+import cpp from 'highlight.js/lib/languages/cpp';
+import csharp from 'highlight.js/lib/languages/csharp';
+import css from 'highlight.js/lib/languages/css';
+import diff from 'highlight.js/lib/languages/diff';
+import dockerfile from 'highlight.js/lib/languages/dockerfile';
+import go from 'highlight.js/lib/languages/go';
+import graphql from 'highlight.js/lib/languages/graphql';
+import ini from 'highlight.js/lib/languages/ini';
+import java from 'highlight.js/lib/languages/java';
+import javascript from 'highlight.js/lib/languages/javascript';
+import json from 'highlight.js/lib/languages/json';
+import kotlin from 'highlight.js/lib/languages/kotlin';
+import makefile from 'highlight.js/lib/languages/makefile';
+import markdown from 'highlight.js/lib/languages/markdown';
+import objectivec from 'highlight.js/lib/languages/objectivec';
+import php from 'highlight.js/lib/languages/php';
+import plaintext from 'highlight.js/lib/languages/plaintext';
+import python from 'highlight.js/lib/languages/python';
+import ruby from 'highlight.js/lib/languages/ruby';
+import rust from 'highlight.js/lib/languages/rust';
+import scss from 'highlight.js/lib/languages/scss';
+import shell from 'highlight.js/lib/languages/shell';
+import sql from 'highlight.js/lib/languages/sql';
+import swift from 'highlight.js/lib/languages/swift';
+import typescript from 'highlight.js/lib/languages/typescript';
+import xml from 'highlight.js/lib/languages/xml';
+import yaml from 'highlight.js/lib/languages/yaml';
+
+// Registration order is irrelevant; aliases are derived from each grammar.
+hljs.registerLanguage('bash', bash);
+hljs.registerLanguage('c', c);
+hljs.registerLanguage('cpp', cpp);
+hljs.registerLanguage('csharp', csharp);
+hljs.registerLanguage('css', css);
+hljs.registerLanguage('diff', diff);
+hljs.registerLanguage('dockerfile', dockerfile);
+hljs.registerLanguage('go', go);
+hljs.registerLanguage('graphql', graphql);
+hljs.registerLanguage('ini', ini);
+hljs.registerLanguage('java', java);
+hljs.registerLanguage('javascript', javascript);
+hljs.registerLanguage('json', json);
+hljs.registerLanguage('kotlin', kotlin);
+hljs.registerLanguage('makefile', makefile);
+hljs.registerLanguage('markdown', markdown);
+hljs.registerLanguage('objectivec', objectivec);
+hljs.registerLanguage('php', php);
+hljs.registerLanguage('plaintext', plaintext);
+hljs.registerLanguage('python', python);
+hljs.registerLanguage('ruby', ruby);
+hljs.registerLanguage('rust', rust);
+hljs.registerLanguage('scss', scss);
+hljs.registerLanguage('shell', shell);
+hljs.registerLanguage('sql', sql);
+hljs.registerLanguage('swift', swift);
+hljs.registerLanguage('typescript', typescript);
+hljs.registerLanguage('xml', xml);
+hljs.registerLanguage('yaml', yaml);
+
+export default hljs;

--- a/markdown-viewer/src/core/render-config.js
+++ b/markdown-viewer/src/core/render-config.js
@@ -2,7 +2,7 @@
 // back into the app.
 
 import { marked } from 'marked';
-import hljs from 'highlight.js';
+import hljs from './highlight.js';
 import { state } from './state.js';
 
 const FONT_FAMILY =

--- a/tests/helpers/loadApp.js
+++ b/tests/helpers/loadApp.js
@@ -47,6 +47,13 @@ function inlineModule(filePath, visited, chunks) {
   const deps = [];
   while ((match = RELATIVE_IMPORT_RE.exec(code)) !== null) {
     if (match[1].endsWith('.css')) continue;
+    // core/highlight.js configures the real highlight.js engine by importing the
+    // core build plus individual language grammars. Those are bare imports that
+    // get stripped, so inlining the module would leave the language bindings
+    // dangling. Under test the engine is provided as a global `hljs` mock, so we
+    // treat this module like the bare `highlight.js` dependency it replaces and
+    // skip it — the `import hljs from './highlight.js'` line is stripped below.
+    if (/(^|\/)highlight\.js$/.test(match[1])) continue;
     deps.push(path.resolve(dir, match[1]));
   }
   for (const dep of deps) inlineModule(dep, visited, chunks);


### PR DESCRIPTION
Trims highlight.js to a curated language set, cutting the eager app-shell entry by ~837 kB. Follows #119 (lazy Mermaid) as the second half of Phase 1's "lazy-load heavy deps" item.

## Why trim instead of lazy-load
highlight.js can't be deferred the way Mermaid was: the marked `code()` renderer is **synchronous**, and unlike diagrams, code blocks are common — so deferring the engine wouldn't help most documents. Every page load pays for hljs, so shrinking it unconditionally is the win. The full package bundles ~190 language grammars; this keeps the engine and a curated subset.

## Changes
- **New `core/highlight.js`** — builds on `highlight.js/lib/core` and `registerLanguage()`s a curated ~29-language set (js/ts, python, bash/shell, json, yaml, markdown, xml, css/scss, sql, java, kotlin, swift, go, rust, c/cpp/csharp, ruby, php, objectivec, diff, dockerfile, ini, makefile, graphql, plaintext). `registerLanguage` wires each grammar's **aliases**, so short forms come free (`js`, `ts`, `html`/`svg`, `sh`, `md`, `yml`, `toml`, …). Languages outside the set still render — as an escaped plain code block via the renderer's existing fallback.
- **`core/render-config.js`** imports `hljs` from `./highlight.js` instead of the full `highlight.js` package.
- **`tests/helpers/loadApp.js`** — `core/highlight.js` references many bindings that come from bare imports (stripped by the eval harness), and the engine is a global `hljs` mock under test, so the harness now **skips inlining** any relative `…/highlight.js` import, treating it like the bare `highlight.js` dependency it replaces.

## Result
- App-shell entry: **1,098,692 → 261,494 bytes** (~837 kB / **76%** smaller).
- Real-hljs smoke test: python highlights, `js`/`toml` aliases resolve, unknown languages fall back to plain.
- `npm run build` ✓, `npm run lint` ✓ (0 errors), `npm test` → **297 passed**.

## Note
Branch is off current `main` (matching #118/#119), not the stale `claude/roadmap-implementation-phases-atcg6q` branch, which is ~35 commits behind and predates the module split + lazy-Mermaid work.

## Next
Phase 1's heavy-dep work is now substantially done. Remaining Phase 1 item: gradual TypeScript (`checkJs`).

https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA)_