### PR TITLE
Phase 1: gradual TypeScript foundation (checkJs) + typecheck CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,5 +28,8 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: Typecheck
+        run: npm run typecheck
+
       - name: Test
         run: npm run test:ci

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,7 @@ npm run preview           # serve the production build locally
 npm test                  # run full Jest suite (required before committing)
 npm run test:coverage     # coverage report
 npm run lint              # ESLint (flat config) — must be clean before committing
+npm run typecheck         # tsc --noEmit (checkJs) — must be clean before committing
 npm run format            # Prettier — write
 npm run desktop           # build the web app, then launch Electron (macOS)
 npm run desktop:build     # build the web app + .dmg locally (macOS only)
@@ -118,9 +119,17 @@ iOS) load the build output in `markdown-viewer/dist/`, so `npm run build` must
 run before packaging the desktop or iOS app (the `desktop`/`desktop:build`
 scripts and the CI workflows do this for you).
 
-Tests and lint must pass before committing; both run in CI on every PR
-(`.github/workflows/ci.yml`). Coverage is reported by `npm run test:coverage`
-but no hard `coverageThreshold` is configured in `package.json` yet.
+Tests, lint, and typecheck must pass before committing; all three run in CI on
+every PR (`.github/workflows/ci.yml`). Coverage is reported by
+`npm run test:coverage` but no hard `coverageThreshold` is configured in
+`package.json` yet.
+
+**Gradual TypeScript:** the viewer is plain ESM JS, type-checked via
+`checkJs`. `tsconfig.json` keeps `checkJs` off globally; modules opt in one at a
+time with a `// @ts-check` pragma at the top (leaf modules first) plus JSDoc
+types. `npm run typecheck` only checks opted-in files, so the gate stays green
+while coverage grows. Native-bridge globals (`window.specdown`, `window.webkit`,
+…) are declared in `markdown-viewer/src/types/globals.d.ts`.
 
 ---
 

--- a/docs/project-modernization/2026-06-14-tasks-session-05-phase1-typescript.md
+++ b/docs/project-modernization/2026-06-14-tasks-session-05-phase1-typescript.md
@@ -1,0 +1,75 @@
+# Tasks — Session 05: Phase 1 (gradual TypeScript via checkJs)
+
+**Date:** 2026-06-14
+**Type:** tasks (session-level implementation checklist)
+**Phase:** 1 — Architecture (the "gradual TypeScript" roadmap item)
+**Source plan:** [2026-06-13-brainstorm-modernization-evaluation.md](2026-06-13-brainstorm-modernization-evaluation.md) §6
+
+The final Phase 1 item. The viewer stays **plain ESM JavaScript** — no `.ts`
+rewrite — and gains type-checking via TypeScript's `checkJs` over JSDoc. The
+adoption is **gradual**: type-checking is opt-in per module, leaf modules first,
+so the gate stays green while coverage grows session over session.
+
+---
+
+## Toolchain established
+
+- **`typescript` devDependency** (5.x) — `tsc` runs as a checker only.
+- **`tsconfig.json`** — `allowJs`, `strict`, `skipLibCheck`, `noEmit`,
+  `moduleResolution: bundler` (matches Vite), `lib: ES2022 + DOM`, `types: []`
+  (no Node globals — the viewer is browser-only). **`checkJs: false`**, so
+  unannotated modules are parsed for import resolution but not yet checked.
+- **`// @ts-check` opt-in:** a module is type-checked once it carries the pragma
+  at the top. This is the gradual lever — add the pragma + JSDoc one module at a
+  time without ever red-lighting the gate.
+- **`npm run typecheck`** = `tsc --noEmit`. Wired into **CI** (`ci.yml`) as a
+  step between Lint and Test, so it's enforced on every PR.
+- **`markdown-viewer/src/types/globals.d.ts`** — ambient declarations for the
+  native-bridge globals the shells inject (`window.specdown` desktop bridge,
+  `window.webkit` iOS message handlers, `window.iosNative`, and the app-set
+  callbacks `loadFileContent` / `setTheme` / `setIOSLayoutMode`, plus the
+  `globalThis.mermaid` test mock). Doubles as the canonical web ↔ native
+  bridge contract.
+
+## Modules checked this session (leaf-first)
+
+| Module | Notes |
+|---|---|
+| `core/platform.js` | `isDesktop` / `isIOSNative` — needed the bridge globals d.ts |
+| `core/state.js` | added `@typedef` for `Tab`, `TocEntry`, `AppState`; typed the exported `state` so future checked modules can assign `state.tabs` / `state.activeTabId` without `never[]` friction |
+| `core/utils.js` | pure helpers; surfaced + fixed two real strict-null gaps in `revealHtmlComments` (`node.nodeValue` / `node.parentNode` possibly null) |
+
+`npm run typecheck` ✓, `npm run build` ✓, `npm run lint` ✓, `npm test` →
+**297 passed**.
+
+## Patterns / gotchas
+
+- **Type the shared `state` early.** Empty array literals (`tabs: []`) infer as
+  `never[]`, so the first checked module that does `state.tabs.push(tab)` or
+  `state.activeTabId = id` would error. Giving `state` an explicit `AppState`
+  JSDoc type now unblocks every future module that touches it.
+- **Don't let `prettier --write` touch existing files.** The repo isn't
+  Prettier-clean (format:check fails on ~67 pre-existing files and is *not* a CI
+  gate), so running `--write` reflows unrelated lines and bloats the diff. Keep
+  edits in each file's existing style; only new files (the d.ts) are formatted.
+- **`strict` is on**, but only bites opted-in files. DOM-heavy modules (lots of
+  `getElementById` → `T | null`) will need null guards as they opt in — expect
+  that to be the bulk of future annotation work.
+
+## Remaining / next (future sessions)
+
+- Opt in the rest of `core/` and the `features/`/`platform/` modules one at a
+  time, leaf-first (next natural picks: `core/render-config.js`,
+  `features/diagram-export.js`, `features/custom-css.js`).
+- The DOM-heavy modules (`features/diagrams.js`, `platform/*`, the `main.js`
+  wiring hub) come last — they need the most null-guarding.
+- Optional later: flip `checkJs: true` once every module carries the pragma, and
+  drop the per-file pragmas.
+
+## Phase 1 status
+
+With this slice, **Phase 1 (Architecture) is functionally complete**: Vite + ESM
+foundation, the `src/main.js` module split, lazy-loaded Mermaid, trimmed
+highlight.js, and the gradual-TypeScript foundation are all in. Remaining TS
+coverage is incremental and rides the enforced `typecheck` gate. Next up is
+**Phase 2** (design system / accessibility / WCAG).

--- a/docs/project-modernization/README.md
+++ b/docs/project-modernization/README.md
@@ -13,6 +13,7 @@ three-lens evaluation of the app at v0.0.82 and a phased roadmap.
 | 2026-06-13 | [tasks-session-02-phase1-vite-foundation](2026-06-13-tasks-session-02-phase1-vite-foundation.md) | Phase 1 slice 1: Vite + ES-module build foundation, real npm deps replace `vendor/`, all surfaces load `dist/`, harness migrated, sync-version regression fixed |
 | 2026-06-14 | [tasks-session-03-phase1-module-split](2026-06-14-tasks-session-03-phase1-module-split.md) | Phase 1 slice 2: internal split of the ~2,800-line `src/main.js` into `core/`/`features/`/`platform/` modules (main.js → 588 lines), pure refactor, 297 tests green |
 | 2026-06-14 | [tasks-session-04-phase1-bundle-deps](2026-06-14-tasks-session-04-phase1-bundle-deps.md) | Phase 1 slice 3: heavy-dep loading — lazy-load Mermaid (~2 MB deferred, PR #119) + trim highlight.js to a curated language set (app-shell entry 1.07 MB → 261 kB) |
+| 2026-06-14 | [tasks-session-05-phase1-typescript](2026-06-14-tasks-session-05-phase1-typescript.md) | Phase 1 slice 4: gradual TypeScript foundation — `checkJs` toolchain, per-file `// @ts-check` opt-in (leaf modules), native-bridge `globals.d.ts`, `typecheck` enforced in CI |
 
 ## Current Status
 
@@ -29,7 +30,11 @@ core/features/platform modules (session 03, main.js → 588 lines), and the
 **heavy-dependency loading** work is substantially done (session 04): Mermaid
 is lazy-loaded (~2 MB deferred until a diagram renders, PR #119) and
 highlight.js is trimmed to a curated language set (app-shell entry 1.07 MB →
-261 kB). Remaining Phase 1 work: begin **gradual TypeScript** (`checkJs`).
+261 kB). The **gradual-TypeScript foundation** is now in place too (session 05):
+a `checkJs` toolchain with per-file `// @ts-check` opt-in, a native-bridge
+`globals.d.ts`, and a `typecheck` gate enforced in CI — the first leaf modules
+are checked and the rest opt in incrementally. **Phase 1 (Architecture) is
+functionally complete**; next is **Phase 2** (design system / accessibility).
 
 The open questions below (iOS investment, Apple Developer membership for
 signing, Electron vs Tauri spike) still gate **Phases 2–4**, not Phase 1.

--- a/markdown-viewer/src/core/platform.js
+++ b/markdown-viewer/src/core/platform.js
@@ -1,3 +1,4 @@
+// @ts-check
 // Platform detection. The native shells inject their flags before the bundle
 // runs — the Electron preload sets window.specdown, and the iOS WKUserScript
 // sets window.iosNative at document start — so these evaluate correctly when

--- a/markdown-viewer/src/core/state.js
+++ b/markdown-viewer/src/core/state.js
@@ -1,3 +1,4 @@
+// @ts-check
 // Shared mutable app state.
 //
 // Modules import this object and read/mutate its fields. ESM forbids
@@ -6,6 +7,44 @@
 // bare module-level `let`s. This object grows as the entry module is split
 // into feature modules that need to share state.
 
+/**
+ * An open file tab.
+ * @typedef {object} Tab
+ * @property {number} id
+ * @property {string} filename
+ * @property {string | null} filePath
+ * @property {string} rawMarkdown
+ * @property {'preview' | 'raw'} viewMode
+ * @property {number} scrollTop
+ * @property {boolean} watching
+ * @property {boolean} hasUnseenChanges
+ */
+
+/**
+ * A table-of-contents entry derived from a rendered heading.
+ * @typedef {object} TocEntry
+ * @property {string} id
+ * @property {number} level
+ * @property {string | null} text
+ */
+
+/**
+ * @typedef {object} AppState
+ * @property {any[]} currentPanzoomInstances Active panzoom instances to clean up.
+ * @property {string} currentTheme 'light' or 'dark'.
+ * @property {string} currentRawMarkdown Raw source of the active document.
+ * @property {'preview' | 'raw'} currentViewMode
+ * @property {Tab[]} tabs Open file tabs.
+ * @property {number | null} activeTabId
+ * @property {number} nextTabId Monotonic id source for new tabs.
+ * @property {boolean} tocVisible
+ * @property {TocEntry[]} tocEntries
+ * @property {boolean} tocScrollSpyScheduled
+ * @property {boolean} splitViewActive
+ * @property {string} iosLayoutMode
+ */
+
+/** @type {AppState} */
 export const state = {
   // Render / view
   currentPanzoomInstances: [],

--- a/markdown-viewer/src/core/utils.js
+++ b/markdown-viewer/src/core/utils.js
@@ -1,3 +1,4 @@
+// @ts-check
 // Pure, dependency-free helpers shared across the viewer.
 
 /**
@@ -85,12 +86,14 @@ export function revealHtmlComments(container) {
   }
 
   commentNodes.forEach((node) => {
-    const text = node.nodeValue.trim();
+    // Comment nodes always have a string value and a parent here (they came
+    // from a TreeWalker over `container`), but guard for the type-checker.
+    const text = (node.nodeValue || '').trim();
     if (!text) return;
 
     const block = document.createElement('div');
     block.className = 'html-comment-block';
     block.textContent = text;
-    node.parentNode.replaceChild(block, node);
+    node.parentNode?.replaceChild(block, node);
   });
 }

--- a/markdown-viewer/src/types/globals.d.ts
+++ b/markdown-viewer/src/types/globals.d.ts
@@ -1,0 +1,70 @@
+// Ambient declarations for the globals the native shells inject into the page.
+//
+// The Electron preload (desktop/preload.js) exposes `window.specdown`, and the
+// iOS WKWebView injects `window.iosNative` / `window.webkit` plus a set of
+// callbacks the Swift side invokes. None of these exist on the standard DOM
+// `Window`, so they are declared here for the type-checker. This file is the
+// canonical description of the web ↔ native bridge contract.
+
+export {};
+
+/** Payload delivered by the desktop shell when a file is opened or changes. */
+interface SpecdownFileData {
+  filename: string;
+  content: string;
+  filePath: string;
+}
+
+/** One persisted tab descriptor sent to the desktop shell's session store. */
+interface SpecdownSessionTab {
+  filePath: string | null;
+  filename: string;
+}
+
+/** The desktop (Electron) bridge exposed on `window.specdown` by the preload. */
+interface SpecdownDesktopBridge {
+  isDesktop?: boolean;
+  requestFileOpen?: () => void;
+  watchFile?: (filePath: string) => void;
+  unwatchFile?: (filePath: string) => void;
+  onFileOpened?: (cb: (fileData: SpecdownFileData) => void) => void;
+  onCloseTab?: (cb: () => void) => void;
+  onFileChanged?: (
+    cb: (fileData: SpecdownFileData) => void | Promise<void>
+  ) => void;
+  onTriggerPrint?: (cb: () => void) => void;
+  onTriggerSearch?: (cb: () => void) => void;
+  onApplyCustomCss?: (cb: (cssContent: string) => void) => void;
+  saveSession?: (tabs: SpecdownSessionTab[]) => void;
+}
+
+/** A single WKScriptMessageHandler bridge on the iOS side. */
+interface WebkitMessageHandler {
+  postMessage: (message: unknown) => void;
+}
+
+declare global {
+  interface Window {
+    /** Electron preload bridge (desktop only). */
+    specdown?: SpecdownDesktopBridge;
+    /** Truthy inside the iOS/iPadOS WKWebView shell. */
+    iosNative?: boolean;
+    /** WKWebView message-handler namespace (iOS only). */
+    webkit?: {
+      messageHandlers?: {
+        specdown?: WebkitMessageHandler;
+      };
+    };
+    /** Set by the app; called by the native shell to load file content. */
+    loadFileContent?: (content: string, filename: string) => void;
+    /** Set by the app; called by the iOS shell to switch theme. */
+    setTheme?: (theme: string) => void;
+    /** Set by the app; called by the iOS shell on layout-class changes. */
+    setIOSLayoutMode?: (mode: string) => void;
+  }
+
+  // Under the Jest harness a global `mermaid` mock stands in for the dynamic
+  // import; in production it is undefined until the engine is loaded.
+  // eslint-disable-next-line no-var
+  var mermaid: unknown | undefined;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "specdown",
-  "version": "0.0.86",
+  "version": "0.0.104",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "specdown",
-      "version": "0.0.86",
+      "version": "0.0.104",
       "license": "MIT",
       "dependencies": {
         "@panzoom/panzoom": "4.6.2",
@@ -28,6 +28,7 @@
         "jest": "30.4.2",
         "jest-environment-jsdom": "30.4.1",
         "prettier": "3.8.4",
+        "typescript": "^5.9.3",
         "vite": "6.4.2"
       },
       "engines": {
@@ -11323,6 +11324,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/undici": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:verbose": "jest --verbose",
     "test:ci": "jest --ci --coverage --maxWorkers=2",
     "test:report": "jest --verbose --json --outputFile=test-results.json",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
@@ -44,6 +45,7 @@
     "jest": "30.4.2",
     "jest-environment-jsdom": "30.4.1",
     "prettier": "3.8.4",
+    "typescript": "^5.9.3",
     "vite": "6.4.2"
   },
   "engines": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "allowJs": true,
+    // Gradual adoption: type-checking is opt-in per file via a `// @ts-check`
+    // pragma at the top of the module. checkJs stays false so unannotated
+    // modules are parsed (for import resolution) but not yet type-checked.
+    // Modules are migrated to checked status one at a time, leaf-first.
+    "checkJs": false,
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    // The viewer runs in the browser; don't pull in @types/node globals.
+    "types": []
+  },
+  "include": ["markdown-viewer/src/**/*.js", "markdown-viewer/src/**/*.d.ts"]
+}


### PR DESCRIPTION
The final Phase 1 item. Adds type-checking to the **plain-ESM** viewer via TypeScript's `checkJs` over JSDoc — **no `.ts` rewrite**. Adoption is **opt-in per module** so the gate never red-lights while coverage grows session over session.

## Toolchain
- **`typescript` devDependency** (checker only) + **`npm run typecheck`** (`tsc --noEmit`).
- **`tsconfig.json`** — `allowJs`, `strict`, `skipLibCheck`, `noEmit`, `moduleResolution: bundler` (matches Vite), `lib: ES2022 + DOM`, `types: []` (browser-only, no Node globals). **`checkJs: false`** globally, so unannotated modules are parsed for import resolution but not yet checked; a module opts in with a top-of-file **`// @ts-check`** pragma.
- **`markdown-viewer/src/types/globals.d.ts`** — ambient declarations for the native-bridge globals the shells inject (`window.specdown` desktop bridge, `window.webkit` iOS message handlers, `window.iosNative`, the app-set `loadFileContent`/`setTheme`/`setIOSLayoutMode` callbacks, and the `globalThis.mermaid` test mock). Doubles as the canonical web ↔ native bridge contract.
- **CI:** `typecheck` runs between Lint and Test in `ci.yml`, enforced on every PR.

## Modules checked this session (leaf-first)
| Module | Notes |
|---|---|
| `core/platform.js` | `isDesktop`/`isIOSNative` — needed the bridge-globals d.ts |
| `core/state.js` | added `@typedef` `Tab`/`TocEntry`/`AppState` and typed the exported `state`, so future checked modules can assign `state.tabs`/`state.activeTabId` without `never[]` friction |
| `core/utils.js` | pure helpers; **surfaced + fixed two real strict-null gaps** in `revealHtmlComments` (`node.nodeValue` / `node.parentNode` possibly null) |

## Verified
- `npm run build` ✓, `npm run lint` ✓, **`npm run typecheck` ✓**, `npm test` → **297 passed**.

## Notes
- Branch is off current `main` (matching #118/#119/#120).
- `format:check` is **not** touched — the repo isn't Prettier-clean (~67 pre-existing files) and it's not a CI gate; I kept edits in each file's existing style to avoid reflow noise (only the new d.ts is Prettier-formatted).

## What this closes
**Phase 1 (Architecture) is now functionally complete**: Vite + ESM foundation, the `src/main.js` module split, lazy-loaded Mermaid, trimmed highlight.js, and this gradual-TypeScript foundation. Remaining TS coverage is incremental and rides the enforced `typecheck` gate. Next up: **Phase 2** (design system / accessibility / WCAG).

https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA)_