### PR TITLE
Phase 2: accessible toast system (kill alert) + accessibility pass

### DIFF
--- a/docs/project-modernization/2026-06-14-tasks-session-06-phase2-toasts-a11y.md
+++ b/docs/project-modernization/2026-06-14-tasks-session-06-phase2-toasts-a11y.md
@@ -1,0 +1,67 @@
+# Tasks — Session 06: Phase 2 (toasts + accessibility, slice 1)
+
+**Date:** 2026-06-14
+**Type:** tasks (session-level implementation checklist)
+**Phase:** 2 — Design system & UX modernization
+**Source plan:** [2026-06-13-brainstorm-modernization-evaluation.md](2026-06-13-brainstorm-modernization-evaluation.md) §Phase 2
+
+Phase 2 splits into three reviewable slices: **(1) toasts + accessibility**,
+(2) design tokens + theming (auto/light/dark + motion), (3) command palette +
+toolbar overflow + shortcut sheet. This session ships **slice 1** — chosen first
+because it's the most logic-heavy / least visual, so it's gated by Jest rather
+than by manual eyeballing.
+
+---
+
+## Toast notifications (kill `alert()`)
+
+- New **`features/toast.js`** (`// @ts-check`): an accessible, auto-dismissing,
+  click-to-dismiss notification system. A shared `#toast-region` holds stacked
+  toasts; each toast carries **`role="alert"`** (assertive, errors) or
+  **`role="status"`** (polite, everything else) so assistive tech announces it
+  without the focus-trap / execution-halt of `alert()`. Type-specific durations
+  (errors linger longest); `duration: 0` makes a toast sticky.
+- Replaced **all four `alert()` call sites** with typed toasts:
+  - `features/file-loading.js` — invalid file type (warning), read error (error)
+  - `features/tabs.js` — max-tabs reached (warning)
+  - `main.js` `renderMarkdown` — render failure (error)
+- CSS: `.toast-region` / `.toast` + type variants (success/info/warning/error
+  accent bars), reusing the existing `fadeIn` and shadow tokens. The existing
+  bespoke `#share-toast` is left as-is (it's already a toast, not an alert, and
+  its tests assert it) — unifying it is future cleanup.
+
+## Accessibility pass (testable subset)
+
+- **Skip link:** `<a class="skip-link" href="#markdown-content">` as the first
+  body element, visually hidden until focused; `#markdown-content` gets
+  `tabindex="-1"` + `role="main"` so focus lands there.
+- **Accessible names on icon-only controls:** `aria-label` on `theme-toggle`,
+  the four content-header toggles whose text labels are `display:none` on narrow
+  screens (toc/split/print/annotate — otherwise *nameless* there), plus
+  `view-toggle`, `watch-toggle`, and the three search buttons. Labels **contain
+  the visible word** (WCAG 2.5.3 Label-in-Name).
+- **Decorative icons** (emoji/glyph spans) marked `aria-hidden="true"` so screen
+  readers don't read "broom"/"hamburger" as the button name.
+- **Generated tab controls:** the close (`×`) button is labelled
+  `Close <filename>` and the new-tab (`+`) button `Open new file`.
+- **Reduced motion:** `@media (prefers-reduced-motion: reduce)` drops the toast /
+  share-toast entrance animations and the skip-link slide.
+
+## Verification (automated)
+
+- New **`tests/unit/toast.test.js`** (region reuse, role mapping, type class,
+  auto-dismiss via fake timers, sticky `duration:0`, click-dismiss).
+- New **`tests/unit/accessibility.test.js`** (skip link + target, `aria-label`
+  on every icon-only control, label-in-name containment, decorative-icon
+  hiding, generated tab-button names).
+- Updated the former `alert`-asserting tests (`fileHandling`, `markdown`
+  integration) to assert the toast DOM + role instead.
+- **build ✓, lint ✓, typecheck ✓, 319 tests ✓** (was 297; +22).
+
+## Notes / next
+
+- This slice is logic-first by design; the **pure-visual** review (does the
+  toast look right in light + dark, on web/desktop/iOS) is the only manual
+  check, and the dark chip matches the pre-existing share toast.
+- Slice 2 (**design tokens + auto/light/dark + motion**) is the next pick — it's
+  CSS-heavy and wants a visual pass. Slice 3 (command palette + toolbar) last.

--- a/docs/project-modernization/README.md
+++ b/docs/project-modernization/README.md
@@ -14,6 +14,7 @@ three-lens evaluation of the app at v0.0.82 and a phased roadmap.
 | 2026-06-14 | [tasks-session-03-phase1-module-split](2026-06-14-tasks-session-03-phase1-module-split.md) | Phase 1 slice 2: internal split of the ~2,800-line `src/main.js` into `core/`/`features/`/`platform/` modules (main.js → 588 lines), pure refactor, 297 tests green |
 | 2026-06-14 | [tasks-session-04-phase1-bundle-deps](2026-06-14-tasks-session-04-phase1-bundle-deps.md) | Phase 1 slice 3: heavy-dep loading — lazy-load Mermaid (~2 MB deferred, PR #119) + trim highlight.js to a curated language set (app-shell entry 1.07 MB → 261 kB) |
 | 2026-06-14 | [tasks-session-05-phase1-typescript](2026-06-14-tasks-session-05-phase1-typescript.md) | Phase 1 slice 4: gradual TypeScript foundation — `checkJs` toolchain, per-file `// @ts-check` opt-in (leaf modules), native-bridge `globals.d.ts`, `typecheck` enforced in CI |
+| 2026-06-14 | [tasks-session-06-phase2-toasts-a11y](2026-06-14-tasks-session-06-phase2-toasts-a11y.md) | Phase 2 slice 1: accessible toast system replaces all `alert()` calls + accessibility pass (skip link, aria-labels on icon-only controls, decorative-icon hiding, reduced-motion); +22 tests |
 
 ## Current Status
 
@@ -34,7 +35,14 @@ highlight.js is trimmed to a curated language set (app-shell entry 1.07 MB →
 a `checkJs` toolchain with per-file `// @ts-check` opt-in, a native-bridge
 `globals.d.ts`, and a `typecheck` gate enforced in CI — the first leaf modules
 are checked and the rest opt in incrementally. **Phase 1 (Architecture) is
-functionally complete**; next is **Phase 2** (design system / accessibility).
+functionally complete.**
+
+**Phase 2 (Design system & UX) is underway**, sliced into three reviewable PRs:
+(1) **toasts + accessibility** — done (session 06): an accessible toast system
+replaces every `alert()`, plus a skip link, `aria-label`s on icon-only controls,
+decorative-icon hiding, and reduced-motion support; (2) design tokens +
+auto/light/dark + motion polish (next); (3) command palette + toolbar overflow +
+shortcut sheet.
 
 The open questions below (iOS investment, Apple Developer membership for
 signing, Electron vs Tauri spike) still gate **Phases 2–4**, not Phase 1.

--- a/markdown-viewer/index.html
+++ b/markdown-viewer/index.html
@@ -26,6 +26,7 @@
     <script type="module" src="/src/main.js"></script>
 </head>
 <body>
+    <a class="skip-link" href="#markdown-content">Skip to content</a>
     <div class="app-container">
         <!-- Header -->
         <header class="app-header">
@@ -42,8 +43,8 @@
                 </div>
             </div>
             <div class="header-controls">
-                <button id="theme-toggle" class="theme-toggle" title="Toggle theme">
-                    <span class="theme-icon">🌙</span>
+                <button id="theme-toggle" class="theme-toggle" title="Toggle theme" aria-label="Toggle light/dark theme">
+                    <span class="theme-icon" aria-hidden="true">🌙</span>
                 </button>
             </div>
         </header>
@@ -93,28 +94,28 @@
                     <span id="file-name" class="file-name"></span>
                 </div>
                 <div class="content-header-actions">
-                    <button id="watch-toggle" class="watch-toggle-button" title="Auto-reload when file changes on disk" style="display: none;">
-                        <span class="watch-toggle-icon">⟳</span>
+                    <button id="watch-toggle" class="watch-toggle-button" title="Auto-reload when file changes on disk" aria-label="Watch file for changes" style="display: none;">
+                        <span class="watch-toggle-icon" aria-hidden="true">⟳</span>
                         <span class="watch-toggle-label">Watch</span>
                     </button>
-                    <button id="toc-toggle" class="toc-toggle-button" title="Toggle table of contents">
-                        <span class="toc-toggle-icon">☰</span>
+                    <button id="toc-toggle" class="toc-toggle-button" title="Toggle table of contents" aria-label="Toggle contents">
+                        <span class="toc-toggle-icon" aria-hidden="true">☰</span>
                         <span class="toc-toggle-label">Contents</span>
                     </button>
-                    <button id="split-toggle" class="split-toggle-button" title="Toggle split view (preview + raw)">
-                        <span class="split-toggle-icon">⊟</span>
+                    <button id="split-toggle" class="split-toggle-button" title="Toggle split view (preview + raw)" aria-label="Toggle split view">
+                        <span class="split-toggle-icon" aria-hidden="true">⊟</span>
                         <span class="split-toggle-label">Split</span>
                     </button>
-                    <button id="annotation-toggle" class="annotation-toggle-button" title="Toggle annotation mode (double-click text to add notes)">
-                        <span class="annotation-toggle-icon">✎</span>
+                    <button id="annotation-toggle" class="annotation-toggle-button" title="Toggle annotation mode (double-click text to add notes)" aria-label="Toggle annotate mode">
+                        <span class="annotation-toggle-icon" aria-hidden="true">✎</span>
                         <span class="annotation-toggle-label">Annotate</span>
                     </button>
-                    <button id="print-button" class="print-button" title="Print / Save as PDF (Cmd+P)">
-                        <span class="print-button-icon">⎙</span>
+                    <button id="print-button" class="print-button" title="Print / Save as PDF (Cmd+P)" aria-label="Print or save as PDF">
+                        <span class="print-button-icon" aria-hidden="true">⎙</span>
                         <span class="print-button-label">Print</span>
                     </button>
-                    <button id="view-toggle" class="view-toggle-button" title="Toggle between preview and raw markdown">
-                        <span class="view-toggle-icon">&lt;/&gt;</span>
+                    <button id="view-toggle" class="view-toggle-button" title="Toggle between preview and raw markdown" aria-label="Toggle raw markdown view">
+                        <span class="view-toggle-icon" aria-hidden="true">&lt;/&gt;</span>
                         <span class="view-toggle-label">Raw</span>
                     </button>
                 </div>
@@ -124,9 +125,9 @@
             <div id="search-bar" class="search-bar" style="display: none;">
                 <input type="text" id="search-input" class="search-input" placeholder="Search..." autocomplete="off" spellcheck="false">
                 <span id="search-count" class="search-count"></span>
-                <button id="search-prev" class="search-nav-btn" title="Previous match">&#8593;</button>
-                <button id="search-next" class="search-nav-btn" title="Next match">&#8595;</button>
-                <button id="search-close" class="search-close-btn" title="Close search (Esc)">&#10005;</button>
+                <button id="search-prev" class="search-nav-btn" title="Previous match" aria-label="Previous match">&#8593;</button>
+                <button id="search-next" class="search-nav-btn" title="Next match" aria-label="Next match">&#8595;</button>
+                <button id="search-close" class="search-close-btn" title="Close search (Esc)" aria-label="Close search">&#10005;</button>
             </div>
 
             <!-- Body with TOC sidebar + main content -->
@@ -139,7 +140,7 @@
 
                 <!-- Main content pane (preview + optional raw split) -->
                 <div id="content-main" class="content-main">
-                    <div id="markdown-content" class="markdown-content"></div>
+                    <div id="markdown-content" class="markdown-content" tabindex="-1" role="main"></div>
                     <div id="split-raw-pane" class="split-raw-pane" style="display: none;">
                         <pre id="split-raw-content" class="raw-markdown split-raw-content"></pre>
                     </div>

--- a/markdown-viewer/src/features/file-loading.js
+++ b/markdown-viewer/src/features/file-loading.js
@@ -4,6 +4,7 @@
 
 import { normalizeMarkdownUrl } from '../core/utils.js';
 import { handleRepoUrl } from './repo-browser.js';
+import { showToast } from './toast.js';
 
 const VALID_EXTENSIONS = ['.md', '.markdown'];
 const el = (id) => document.getElementById(id);
@@ -30,7 +31,7 @@ export function handleFile(file) {
   const fileExtension = file.name.substring(file.name.lastIndexOf('.')).toLowerCase();
 
   if (!VALID_EXTENSIONS.includes(fileExtension)) {
-    alert('Please select a valid Markdown file (.md or .markdown)');
+    showToast('Please select a valid Markdown file (.md or .markdown)', { type: 'warning' });
     return;
   }
 
@@ -41,7 +42,7 @@ export function handleFile(file) {
     openTab(file.name, content, file.path || null);
   };
   reader.onerror = () => {
-    alert('Error reading file. Please try again.');
+    showToast('Error reading file. Please try again.', { type: 'error' });
   };
   reader.readAsText(file);
 }

--- a/markdown-viewer/src/features/tabs.js
+++ b/markdown-viewer/src/features/tabs.js
@@ -16,6 +16,7 @@ import { closeSearch } from './search.js';
 import { toggleToc } from './toc.js';
 import { toggleSplitView } from './split-view.js';
 import { updateViewToggleButton } from './view-mode.js';
+import { showToast } from './toast.js';
 import {
   requestNativeOpenIfAvailable,
   syncIOSChrome,
@@ -76,10 +77,10 @@ export function renderTabBar() {
       html += `<span class="tab-watching-dot" title="${dotTitle}"></span>`;
     }
     html += `<span class="tab-filename">${escapeHtml(tab.filename)}</span>`;
-    html += `<button class="tab-close" data-close-id="${tab.id}" title="Close tab">×</button>`;
+    html += `<button class="tab-close" data-close-id="${tab.id}" title="Close tab" aria-label="Close ${escapeHtml(tab.filename)}">×</button>`;
     html += `</div>`;
   }
-  html += `<button class="tab-new" title="Open new file">+</button>`;
+  html += `<button class="tab-new" title="Open new file" aria-label="Open new file">+</button>`;
 
   tabBar.innerHTML = html;
 
@@ -111,7 +112,9 @@ export function renderTabBar() {
 
 export function createTab(filename, content, filePath) {
   if (state.tabs.length >= MAX_TABS) {
-    alert('Maximum of ' + MAX_TABS + ' tabs reached. Close a tab to open another file.');
+    showToast('Maximum of ' + MAX_TABS + ' tabs reached. Close a tab to open another file.', {
+      type: 'warning',
+    });
     return;
   }
 

--- a/markdown-viewer/src/features/toast.js
+++ b/markdown-viewer/src/features/toast.js
@@ -1,0 +1,70 @@
+// @ts-check
+// Accessible, auto-dismissing toast notifications.
+//
+// Replaces blocking `alert()` calls: alert() steals focus, halts execution,
+// can't be styled or themed, and is announced inconsistently by screen readers.
+// Each toast is appended to a shared region and carries `role="status"` (polite)
+// or, for errors, `role="alert"` (assertive) so assistive tech announces it
+// without trapping focus. Toasts auto-dismiss and are click-to-dismiss.
+
+/** @typedef {'info' | 'success' | 'warning' | 'error'} ToastType */
+
+/** Default visible durations (ms) per type; errors linger longest. */
+const DEFAULT_DURATIONS = /** @type {Record<ToastType, number>} */ ({
+  info: 3000,
+  success: 2500,
+  warning: 4000,
+  error: 5000,
+});
+
+/**
+ * Get (or lazily create) the shared toast region appended to <body>.
+ * @returns {HTMLElement}
+ */
+function getRegion() {
+  let region = document.getElementById('toast-region');
+  if (!region) {
+    region = document.createElement('div');
+    region.id = 'toast-region';
+    region.className = 'toast-region';
+    document.body.appendChild(region);
+  }
+  return region;
+}
+
+/**
+ * Show a toast notification.
+ * @param {string} message
+ * @param {{ type?: ToastType, duration?: number }} [options]
+ * @returns {HTMLElement} the created toast element
+ */
+export function showToast(message, options = {}) {
+  const type = options.type || 'info';
+  const region = getRegion();
+
+  const toast = document.createElement('div');
+  toast.className = 'toast toast-' + type;
+  // role="alert" is assertive (interrupts); role="status" is polite. Errors
+  // warrant an immediate announcement, everything else stays polite.
+  toast.setAttribute('role', type === 'error' ? 'alert' : 'status');
+  toast.textContent = message;
+  toast.addEventListener('click', () => dismissToast(toast));
+  region.appendChild(toast);
+
+  const duration = options.duration != null ? options.duration : DEFAULT_DURATIONS[type];
+  if (duration > 0) {
+    setTimeout(() => dismissToast(toast), duration);
+  }
+
+  return toast;
+}
+
+/**
+ * Remove a toast from the DOM.
+ * @param {HTMLElement} toast
+ */
+export function dismissToast(toast) {
+  if (toast && toast.parentNode) {
+    toast.parentNode.removeChild(toast);
+  }
+}

--- a/markdown-viewer/src/main.js
+++ b/markdown-viewer/src/main.js
@@ -85,6 +85,7 @@ import {
   configureShareLinks,
 } from './features/share-links.js';
 import { createTab, configureTabs } from './features/tabs.js';
+import { showToast } from './features/toast.js';
 import {
   setupDesktopIPC,
   updateWatchToggle,
@@ -563,7 +564,7 @@ async function renderMarkdown(content, filename) {
 
     } catch (error) {
         console.error('Error rendering markdown:', error);
-        alert('Error rendering markdown content. Please check the file format.');
+        showToast('Error rendering markdown content. Please check the file format.', { type: 'error' });
     }
 }
 

--- a/markdown-viewer/styles.css
+++ b/markdown-viewer/styles.css
@@ -1364,6 +1364,92 @@ mark.search-highlight-current {
 }
 
 /* ===========================
+   Toast Notifications
+   =========================== */
+.toast-region {
+    position: fixed;
+    bottom: 2rem;
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+    max-width: min(90vw, 32rem);
+    z-index: 10000;
+    /* The region itself doesn't intercept clicks; individual toasts do. */
+    pointer-events: none;
+}
+
+.toast {
+    pointer-events: auto;
+    cursor: pointer;
+    /* Dark chip in both themes (matches the existing share toast) for a
+       consistent, high-contrast notification surface. */
+    background-color: #323232;
+    color: #fff;
+    padding: 0.6rem 1.4rem;
+    border-radius: 8px;
+    border-left: 4px solid transparent;
+    font-size: 0.9rem;
+    line-height: 1.4;
+    text-align: center;
+    box-shadow: var(--shadow-lg);
+    animation: fadeIn 0.2s ease;
+}
+
+.toast-success {
+    border-left-color: var(--success-color);
+}
+
+.toast-info {
+    border-left-color: var(--accent-color);
+}
+
+.toast-warning {
+    border-left-color: #e0a800;
+}
+
+.toast-error {
+    border-left-color: #e0533f;
+}
+
+/* ===========================
+   Skip Link (accessibility)
+   =========================== */
+.skip-link {
+    position: absolute;
+    left: 0.5rem;
+    top: -3rem;
+    z-index: 10001;
+    padding: 0.5rem 1rem;
+    background-color: var(--accent-color);
+    color: #fff;
+    border-radius: 6px;
+    text-decoration: none;
+    box-shadow: var(--shadow-md);
+    transition: top 0.15s ease;
+}
+
+.skip-link:focus {
+    top: 0.5rem;
+    outline: 2px solid #fff;
+    outline-offset: 2px;
+}
+
+/* Respect users who prefer reduced motion: drop the non-essential entrance
+   and skip-link slide animations. */
+@media (prefers-reduced-motion: reduce) {
+    .toast,
+    .share-toast {
+        animation: none;
+    }
+    .skip-link {
+        transition: none;
+    }
+}
+
+/* ===========================
    iOS Native Shell
    =========================== */
 .ios-native {

--- a/tests/integration/markdown.test.js
+++ b/tests/integration/markdown.test.js
@@ -106,16 +106,20 @@ describe('Markdown Rendering', () => {
       expect(processSpy).toHaveBeenCalled();
     });
 
-    it('should handle parsing errors with alert', async () => {
+    it('should handle parsing errors with an error toast', async () => {
       marked.parse.mockImplementation(() => {
         throw new Error('Parse error');
       });
 
       await renderMarkdown('# Test', 'test.md');
 
-      expect(global.alert).toHaveBeenCalledWith(
+      const toast = document.querySelector('.toast');
+      expect(toast).not.toBeNull();
+      expect(toast.textContent).toBe(
         'Error rendering markdown content. Please check the file format.'
       );
+      expect(toast.classList.contains('toast-error')).toBe(true);
+      expect(toast.getAttribute('role')).toBe('alert');
     });
 
     it('should reset scroll position', async () => {

--- a/tests/unit/accessibility.test.js
+++ b/tests/unit/accessibility.test.js
@@ -1,0 +1,97 @@
+/**
+ * Accessibility regression tests for the static markup and generated controls:
+ * skip link, accessible names on icon-only buttons, and decorative-icon hiding.
+ */
+
+const { loadHTML, loadApp } = require('../helpers/loadApp');
+require('../mocks/marked');
+require('../mocks/mermaid');
+require('../mocks/panzoom');
+require('../mocks/highlightjs');
+
+describe('Accessibility', () => {
+  beforeEach(() => {
+    loadHTML(document);
+    loadApp(document);
+  });
+
+  describe('skip link', () => {
+    it('is the first focusable element and targets the main content', () => {
+      const skip = document.querySelector('.skip-link');
+      expect(skip).not.toBeNull();
+      expect(skip.getAttribute('href')).toBe('#markdown-content');
+      expect(skip.textContent).toMatch(/skip/i);
+    });
+
+    it('points at a focusable main content region', () => {
+      const target = document.getElementById('markdown-content');
+      expect(target).not.toBeNull();
+      expect(target.getAttribute('tabindex')).toBe('-1');
+      expect(target.getAttribute('role')).toBe('main');
+    });
+  });
+
+  describe('icon-only controls have accessible names', () => {
+    const ids = [
+      'theme-toggle',
+      'watch-toggle',
+      'toc-toggle',
+      'split-toggle',
+      'annotation-toggle',
+      'print-button',
+      'view-toggle',
+      'search-prev',
+      'search-next',
+      'search-close',
+    ];
+
+    it.each(ids)('%s has a non-empty aria-label', (id) => {
+      const el = document.getElementById(id);
+      expect(el).not.toBeNull();
+      const label = el.getAttribute('aria-label');
+      expect(label).toBeTruthy();
+      expect(label.trim().length).toBeGreaterThan(0);
+    });
+
+    it('satisfies WCAG "label in name" where a visible label exists', () => {
+      // The visible label text must be contained in the accessible name so
+      // voice-control users can activate by the visible word.
+      const cases = [
+        ['toc-toggle', 'toc-toggle-label'],
+        ['split-toggle', 'split-toggle-label'],
+        ['print-button', 'print-button-label'],
+        ['annotation-toggle', 'annotation-toggle-label'],
+      ];
+      for (const [btnId, labelClass] of cases) {
+        const btn = document.getElementById(btnId);
+        const visible = btn.querySelector('.' + labelClass).textContent.trim().toLowerCase();
+        const accessible = btn.getAttribute('aria-label').toLowerCase();
+        expect(accessible).toContain(visible);
+      }
+    });
+
+    it('hides decorative icon glyphs from assistive tech', () => {
+      const icons = document.querySelectorAll(
+        '.theme-icon, .toc-toggle-icon, .split-toggle-icon, .print-button-icon, .view-toggle-icon'
+      );
+      expect(icons.length).toBeGreaterThan(0);
+      icons.forEach((icon) => {
+        expect(icon.getAttribute('aria-hidden')).toBe('true');
+      });
+    });
+  });
+
+  describe('generated tab controls have accessible names', () => {
+    it('labels the close button with the filename and the new-tab button', () => {
+      createTab('notes.md', '# Notes');
+
+      const closeBtn = document.querySelector('.tab-close');
+      expect(closeBtn).not.toBeNull();
+      expect(closeBtn.getAttribute('aria-label')).toBe('Close notes.md');
+
+      const newBtn = document.querySelector('.tab-new');
+      expect(newBtn).not.toBeNull();
+      expect(newBtn.getAttribute('aria-label')).toBeTruthy();
+    });
+  });
+});

--- a/tests/unit/fileHandling.test.js
+++ b/tests/unit/fileHandling.test.js
@@ -74,14 +74,19 @@ describe('File Handling', () => {
       }, 10);
     });
 
-    it('should reject .txt files with alert', () => {
+    it('should reject .txt files with a warning toast', () => {
       const file = new File(['Test content'], 'test.txt', { type: 'text/plain' });
 
       handleFile(file);
 
-      expect(global.alert).toHaveBeenCalledWith(
+      expect(global.alert).not.toHaveBeenCalled();
+      const toast = document.querySelector('.toast');
+      expect(toast).not.toBeNull();
+      expect(toast.textContent).toBe(
         'Please select a valid Markdown file (.md or .markdown)'
       );
+      expect(toast.classList.contains('toast-warning')).toBe(true);
+      expect(toast.getAttribute('role')).toBe('status');
     });
 
     it('should reject files without extensions', () => {
@@ -89,12 +94,14 @@ describe('File Handling', () => {
 
       handleFile(file);
 
-      expect(global.alert).toHaveBeenCalledWith(
+      const toast = document.querySelector('.toast');
+      expect(toast).not.toBeNull();
+      expect(toast.textContent).toBe(
         'Please select a valid Markdown file (.md or .markdown)'
       );
     });
 
-    it('should handle file read errors with alert', (done) => {
+    it('should handle file read errors with an error toast', (done) => {
       const file = new File(['# Test'], 'test.md', { type: 'text/markdown' });
 
       const originalFileReader = global.FileReader;
@@ -107,9 +114,11 @@ describe('File Handling', () => {
                 this.onerror(new Error('Read failed'));
               }
 
-              expect(global.alert).toHaveBeenCalledWith(
-                'Error reading file. Please try again.'
-              );
+              const toast = document.querySelector('.toast');
+              expect(toast).not.toBeNull();
+              expect(toast.textContent).toBe('Error reading file. Please try again.');
+              expect(toast.classList.contains('toast-error')).toBe(true);
+              expect(toast.getAttribute('role')).toBe('alert');
               done();
             }, 0);
           });

--- a/tests/unit/toast.test.js
+++ b/tests/unit/toast.test.js
@@ -1,0 +1,81 @@
+/**
+ * Unit tests for the accessible toast notification system.
+ */
+
+const { loadHTML, loadApp } = require('../helpers/loadApp');
+require('../mocks/marked');
+require('../mocks/mermaid');
+require('../mocks/panzoom');
+require('../mocks/highlightjs');
+
+describe('Toast notifications', () => {
+  beforeEach(() => {
+    loadHTML(document);
+    loadApp(document);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('creates a toast in a shared #toast-region with the message text', () => {
+    showToast('Hello world');
+
+    const region = document.getElementById('toast-region');
+    expect(region).not.toBeNull();
+    const toast = region.querySelector('.toast');
+    expect(toast).not.toBeNull();
+    expect(toast.textContent).toBe('Hello world');
+  });
+
+  it('reuses a single region for multiple toasts', () => {
+    showToast('one');
+    showToast('two');
+
+    const regions = document.querySelectorAll('#toast-region');
+    expect(regions.length).toBe(1);
+    expect(regions[0].querySelectorAll('.toast').length).toBe(2);
+  });
+
+  it('uses role="alert" for errors and role="status" otherwise', () => {
+    showToast('boom', { type: 'error' });
+    showToast('ok', { type: 'success' });
+    showToast('fyi', { type: 'info' });
+    showToast('careful', { type: 'warning' });
+
+    const toasts = document.querySelectorAll('.toast');
+    expect(toasts[0].getAttribute('role')).toBe('alert');
+    expect(toasts[1].getAttribute('role')).toBe('status');
+    expect(toasts[2].getAttribute('role')).toBe('status');
+    expect(toasts[3].getAttribute('role')).toBe('status');
+  });
+
+  it('applies a type-specific class', () => {
+    showToast('careful', { type: 'warning' });
+    expect(document.querySelector('.toast').classList.contains('toast-warning')).toBe(true);
+  });
+
+  it('auto-dismisses after the duration elapses', () => {
+    jest.useFakeTimers();
+    showToast('temporary', { type: 'info', duration: 1000 });
+
+    expect(document.querySelector('.toast')).not.toBeNull();
+    jest.advanceTimersByTime(1000);
+    expect(document.querySelector('.toast')).toBeNull();
+  });
+
+  it('does not auto-dismiss when duration is 0', () => {
+    jest.useFakeTimers();
+    showToast('sticky', { duration: 0 });
+
+    jest.advanceTimersByTime(60000);
+    expect(document.querySelector('.toast')).not.toBeNull();
+  });
+
+  it('dismisses on click', () => {
+    showToast('click me');
+    const toast = document.querySelector('.toast');
+    toast.dispatchEvent(new Event('click', { bubbles: true }));
+    expect(document.querySelector('.toast')).toBeNull();
+  });
+});


### PR DESCRIPTION
First slice of **Phase 2 (Design system & UX)**. Phase 2 splits into three reviewable PRs — I led with this one because it's the most logic-heavy and least visual, so it's gated by Jest rather than by manual eyeballing (per your "least attention / automate where possible" steer).

## Toasts — kill `alert()`
- New **`features/toast.js`** (`// @ts-check`): accessible, auto-dismissing, click-to-dismiss notifications in a shared `#toast-region`. Errors get **`role="alert"`** (assertive); everything else **`role="status"`** (polite) — so assistive tech announces them, with none of `alert()`'s focus-trap / execution-halt. Type-specific durations; `duration: 0` = sticky.
- Replaced **all four** `alert()` call sites with typed toasts:
  - `file-loading.js` — invalid file type (warning), read error (error)
  - `tabs.js` — max-tabs reached (warning)
  - `main.js` `renderMarkdown` — render failure (error)
- CSS: `.toast-region` / `.toast` + success/info/warning/error accent bars, reusing the existing `fadeIn` + shadow tokens. The bespoke `#share-toast` is left as-is (already a toast, not an alert; its tests assert it).

## Accessibility pass (testable subset)
- **Skip link** → `#markdown-content` (`tabindex="-1"` + `role="main"`), visually hidden until focused.
- **`aria-label` on icon-only controls** — including the content-header toggles whose text labels are `display:none` on narrow screens (toc/split/print/annotate were **nameless** there). Labels **contain the visible word** (WCAG 2.5.3 Label-in-Name).
- **Decorative glyphs** marked `aria-hidden="true"`.
- **Generated tab buttons** labelled (`Close <filename>` / `Open new file`).
- **`prefers-reduced-motion`** drops the toast / share-toast entrance + skip-link slide.

## Verification (automated)
- New `tests/unit/toast.test.js` (region reuse, role mapping, type class, auto-dismiss via fake timers, sticky `duration:0`, click-dismiss).
- New `tests/unit/accessibility.test.js` (skip link + target, `aria-label` on every icon-only control, label-in-name containment, decorative-icon hiding, generated tab names).
- Updated the former `alert`-asserting tests (`fileHandling`, `markdown` integration) to assert the toast DOM + role.
- **build ✓, lint ✓, typecheck ✓, 319 tests ✓** (was 297; +22).

## The one manual check
Pure-visual: does the toast look right in **light + dark** on web/desktop/iOS? The chip is the same dark style as the pre-existing share toast, so it should match — but that's the only thing Jest can't confirm.

## Next
Slice 2 — **design tokens + auto/light/dark + motion polish** (CSS-heavy, wants a visual pass). Slice 3 — command palette + toolbar overflow + shortcut sheet.

https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA)_