### PR TITLE
Phase 2: auto/system theme (light/dark/auto) + global reduced motion

### DIFF
--- a/docs/project-modernization/2026-06-14-tasks-session-07-phase2-theme-motion.md
+++ b/docs/project-modernization/2026-06-14-tasks-session-07-phase2-theme-motion.md
@@ -1,0 +1,62 @@
+# Tasks — Session 07: Phase 2 (auto/system theme + reduced motion, slice 2)
+
+**Date:** 2026-06-14
+**Type:** tasks (session-level implementation checklist)
+**Phase:** 2 — Design system & UX modernization
+**Source plan:** [2026-06-13-brainstorm-modernization-evaluation.md](2026-06-13-brainstorm-modernization-evaluation.md) §Phase 2
+
+Slice 2 of Phase 2. Delivers the **auto/light/dark theme** and **motion polish**
+parts of the roadmap's "token overhaul + auto/light/dark theme + motion" line.
+Picked the theme + motion work (logic-testable, low blind-risk) and **deferred
+the bulk CSS token mass-replacement** to a later slice that warrants a visual
+pass — those ~50 hard-coded hexes aren't unit-testable and rewriting them blind
+is pure risk for little verifiable gain.
+
+---
+
+## Auto / system theme
+
+The theme model went from a 2-way light↔dark flip to a 3-way preference with an
+OS-following mode:
+
+- **`state.themePreference`** (`'light' | 'dark' | 'auto'`) is the persisted
+  user choice; **`state.currentTheme`** (`'light' | 'dark'`) is the resolved
+  theme actually applied (and read by the mermaid config). `data-theme` always
+  carries the resolved value, so all existing CSS is unchanged.
+- **`auto`** resolves via `window.matchMedia('(prefers-color-scheme: dark)')`
+  and **live-updates** when the OS flips while in auto mode (a `change` listener
+  re-applies; it's a no-op once an explicit light/dark is chosen).
+- The toggle button now **cycles light → dark → auto → light**, with the icon
+  (🌙 / ☀️ / 🌗) and the `aria-label`/`title` updating to name the current mode
+  and the next.
+- **Default is now `auto`** for first-run users (follow the OS); anyone with a
+  stored `light`/`dark` keeps it. `window.setTheme(...)` (iOS bridge) accepts
+  all three values.
+
+## Motion polish
+
+- Global **`@media (prefers-reduced-motion: reduce)`** reset that neutralizes
+  animations, transitions, and smooth scrolling app-wide (replaces the narrower
+  toast-only guard from slice 1, which it subsumes).
+
+## Verification (automated)
+
+- `tests/unit/theme.test.js`: rewrote the toggle tests for the 3-way cycle and
+  added an **auto/system** describe with a `matchMedia` mock — auto→dark/light
+  resolution, default-to-auto, live OS-change updates, and "stops following the
+  OS once an explicit choice is made."
+- **build ✓, lint ✓, typecheck ✓, 324 tests ✓** (was 319; `state.js` typedef
+  gained `themePreference`).
+
+## Manual check (the only blind spot)
+
+Pure-visual: confirm the 🌗 auto state and the cycle read correctly in the UI on
+web/desktop/iOS — but the logic (which theme actually applies) is fully gated by
+Jest.
+
+## Remaining Phase 2
+
+- **Design-token overhaul** (spacing/radius/typography scales, replace the ~50
+  stray hard-coded hexes) — deferred here; best done with a visual pass.
+- **Command palette (Cmd+K)** + toolbar consolidation/overflow + keyboard
+  shortcut sheet (slice 3).

--- a/docs/project-modernization/README.md
+++ b/docs/project-modernization/README.md
@@ -15,6 +15,7 @@ three-lens evaluation of the app at v0.0.82 and a phased roadmap.
 | 2026-06-14 | [tasks-session-04-phase1-bundle-deps](2026-06-14-tasks-session-04-phase1-bundle-deps.md) | Phase 1 slice 3: heavy-dep loading — lazy-load Mermaid (~2 MB deferred, PR #119) + trim highlight.js to a curated language set (app-shell entry 1.07 MB → 261 kB) |
 | 2026-06-14 | [tasks-session-05-phase1-typescript](2026-06-14-tasks-session-05-phase1-typescript.md) | Phase 1 slice 4: gradual TypeScript foundation — `checkJs` toolchain, per-file `// @ts-check` opt-in (leaf modules), native-bridge `globals.d.ts`, `typecheck` enforced in CI |
 | 2026-06-14 | [tasks-session-06-phase2-toasts-a11y](2026-06-14-tasks-session-06-phase2-toasts-a11y.md) | Phase 2 slice 1: accessible toast system replaces all `alert()` calls + accessibility pass (skip link, aria-labels on icon-only controls, decorative-icon hiding, reduced-motion); +22 tests |
+| 2026-06-14 | [tasks-session-07-phase2-theme-motion](2026-06-14-tasks-session-07-phase2-theme-motion.md) | Phase 2 slice 2: auto/system theme (3-way light→dark→auto cycle, `prefers-color-scheme` with live OS updates) + global reduced-motion; +5 tests |
 
 ## Current Status
 
@@ -37,12 +38,15 @@ a `checkJs` toolchain with per-file `// @ts-check` opt-in, a native-bridge
 are checked and the rest opt in incrementally. **Phase 1 (Architecture) is
 functionally complete.**
 
-**Phase 2 (Design system & UX) is underway**, sliced into three reviewable PRs:
+**Phase 2 (Design system & UX) is underway**, sliced into reviewable PRs:
 (1) **toasts + accessibility** — done (session 06): an accessible toast system
 replaces every `alert()`, plus a skip link, `aria-label`s on icon-only controls,
-decorative-icon hiding, and reduced-motion support; (2) design tokens +
-auto/light/dark + motion polish (next); (3) command palette + toolbar overflow +
-shortcut sheet.
+decorative-icon hiding, and reduced-motion; (2) **auto/system theme + motion** —
+done (session 07): a 3-way light→dark→auto cycle that follows the OS via
+`prefers-color-scheme` (with live updates) and a global reduced-motion reset;
+(3) the design-token overhaul (spacing/radius/typography scales + retiring the
+stray hard-coded hexes) and the command palette (Cmd+K) + toolbar overflow +
+shortcut sheet remain.
 
 The open questions below (iOS investment, Apple Developer membership for
 signing, Electron vs Tauri spike) still gate **Phases 2–4**, not Phase 1.

--- a/markdown-viewer/src/core/state.js
+++ b/markdown-viewer/src/core/state.js
@@ -31,7 +31,8 @@
 /**
  * @typedef {object} AppState
  * @property {any[]} currentPanzoomInstances Active panzoom instances to clean up.
- * @property {string} currentTheme 'light' or 'dark'.
+ * @property {'light' | 'dark'} currentTheme The resolved, applied theme.
+ * @property {'light' | 'dark' | 'auto'} themePreference User choice; 'auto' follows the OS.
  * @property {string} currentRawMarkdown Raw source of the active document.
  * @property {'preview' | 'raw'} currentViewMode
  * @property {Tab[]} tabs Open file tabs.
@@ -48,7 +49,13 @@
 export const state = {
   // Render / view
   currentPanzoomInstances: [],
-  currentTheme: localStorage.getItem('theme') || 'light',
+  // `themePreference` is the persisted user choice (light/dark/auto);
+  // `currentTheme` is the resolved theme that's actually applied, set by
+  // setupTheme() at init (an 'auto' preference resolves via prefers-color-scheme).
+  currentTheme: 'light',
+  themePreference: /** @type {'light' | 'dark' | 'auto'} */ (
+    localStorage.getItem('theme') || 'auto'
+  ),
   currentRawMarkdown: '',
   currentViewMode: 'preview', // 'preview' or 'raw'
 

--- a/markdown-viewer/src/features/theme.js
+++ b/markdown-viewer/src/features/theme.js
@@ -1,10 +1,19 @@
-// Light/dark theme. The mermaid re-render on theme change lives in the render
-// core (main.js), so it's supplied via configureTheme to avoid a back-import.
+// Theme: light / dark / auto (system). The mermaid re-render on theme change
+// lives in the render core (main.js), so it's supplied via configureTheme to
+// avoid a back-import.
+//
+// `state.themePreference` is the persisted user choice ('light' | 'dark' |
+// 'auto'); `state.currentTheme` is the resolved theme actually applied. An
+// 'auto' preference follows the OS via `prefers-color-scheme` and live-updates
+// when the system switches while in auto mode.
 
 import { state } from '../core/state.js';
 import { syncIOSChrome } from '../platform/ios-chrome.js';
 
 const el = (id) => document.getElementById(id);
+
+// Click order for the toggle button: light → dark → auto → light.
+const THEME_ORDER = ['light', 'dark', 'auto'];
 
 let reRenderDiagrams = () => {};
 
@@ -15,21 +24,50 @@ export function configureTheme(deps) {
   }
 }
 
-export function setupTheme() {
-  document.documentElement.setAttribute('data-theme', state.currentTheme);
-  updateThemeIcon();
+function systemPrefersDark() {
+  return !!(
+    window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
+  );
+}
+
+/** Resolve a preference to the concrete theme to apply. */
+function resolveTheme(preference) {
+  if (preference === 'auto') return systemPrefersDark() ? 'dark' : 'light';
+  return preference === 'dark' ? 'dark' : 'light';
 }
 
 function updateThemeIcon() {
   const themeToggle = el('theme-toggle');
   if (!themeToggle) return;
+  const preference = state.themePreference;
+
   const icon = themeToggle.querySelector('.theme-icon');
-  if (icon) icon.textContent = state.currentTheme === 'light' ? '🌙' : '☀️';
+  if (icon) {
+    icon.textContent =
+      preference === 'auto' ? '🌗' : preference === 'dark' ? '☀️' : '🌙';
+  }
+
+  // Keep the accessible name + tooltip in step with the 3-way cycle, naming
+  // both the current mode and what a click switches to next.
+  const label =
+    preference === 'auto'
+      ? 'Theme: system (click for light)'
+      : preference === 'dark'
+        ? 'Theme: dark (click for system)'
+        : 'Theme: light (click for dark)';
+  themeToggle.setAttribute('aria-label', label);
+  themeToggle.setAttribute('title', label);
 }
 
-function applyTheme() {
+/**
+ * Resolve + apply the current preference: set the data-theme attribute, refresh
+ * the icon, sync iOS chrome, and re-render visible diagrams.
+ * @param {boolean} persist Whether to write the preference to localStorage.
+ */
+function applyTheme(persist) {
+  state.currentTheme = resolveTheme(state.themePreference);
   document.documentElement.setAttribute('data-theme', state.currentTheme);
-  localStorage.setItem('theme', state.currentTheme);
+  if (persist) localStorage.setItem('theme', state.themePreference);
   updateThemeIcon();
   syncIOSChrome();
   // Re-render mermaid diagrams with the new theme
@@ -39,13 +77,32 @@ function applyTheme() {
   }
 }
 
+export function setupTheme() {
+  applyTheme(false);
+
+  // While in auto mode, follow live OS scheme changes.
+  if (window.matchMedia) {
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    const onChange = () => {
+      if (state.themePreference === 'auto') applyTheme(false);
+    };
+    if (mq.addEventListener) {
+      mq.addEventListener('change', onChange);
+    } else if (mq.addListener) {
+      // Safari < 14 fallback
+      mq.addListener(onChange);
+    }
+  }
+}
+
 export function toggleTheme() {
-  state.currentTheme = state.currentTheme === 'light' ? 'dark' : 'light';
-  applyTheme();
+  const idx = THEME_ORDER.indexOf(state.themePreference);
+  state.themePreference = THEME_ORDER[(idx + 1) % THEME_ORDER.length];
+  applyTheme(true);
 }
 
 // iOS API: called by the Swift shell to set the theme externally.
 window.setTheme = function (theme) {
-  state.currentTheme = theme;
-  applyTheme();
+  state.themePreference = THEME_ORDER.includes(theme) ? theme : 'light';
+  applyTheme(true);
 };

--- a/markdown-viewer/styles.css
+++ b/markdown-viewer/styles.css
@@ -46,6 +46,20 @@
     box-sizing: border-box;
 }
 
+/* Respect users who ask the OS to minimize motion: neutralize animations,
+   transitions, and smooth scrolling app-wide. Individual components may still
+   opt into essential motion, but the default is near-instant. */
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+    }
+}
+
 body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
     background-color: var(--bg-secondary);
@@ -1435,18 +1449,6 @@ mark.search-highlight-current {
     top: 0.5rem;
     outline: 2px solid #fff;
     outline-offset: 2px;
-}
-
-/* Respect users who prefer reduced motion: drop the non-essential entrance
-   and skip-link slide animations. */
-@media (prefers-reduced-motion: reduce) {
-    .toast,
-    .share-toast {
-        animation: none;
-    }
-    .skip-link {
-        transition: none;
-    }
 }
 
 /* ===========================

--- a/tests/unit/theme.test.js
+++ b/tests/unit/theme.test.js
@@ -65,16 +65,21 @@ describe('Theme Management', () => {
       expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
     });
 
-    it('should toggle from dark to light', () => {
-      // First toggle to dark
-      toggleTheme();
-      // Then toggle back to light
-      toggleTheme();
+    it('cycles light → dark → auto → light', () => {
+      toggleTheme(); // → dark
+      expect(state.themePreference).toBe('dark');
+      expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
 
+      toggleTheme(); // → auto (resolves to light with no matchMedia in jsdom)
+      expect(state.themePreference).toBe('auto');
+      expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+
+      toggleTheme(); // → light
+      expect(state.themePreference).toBe('light');
       expect(document.documentElement.getAttribute('data-theme')).toBe('light');
     });
 
-    it('should persist theme to localStorage', () => {
+    it('should persist the preference to localStorage', () => {
       toggleTheme();
 
       expect(localStorage.setItem).toHaveBeenCalledWith('theme', 'dark');
@@ -86,7 +91,7 @@ describe('Theme Management', () => {
       expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
     });
 
-    it('should update theme icon when toggling', () => {
+    it('should update theme icon across the cycle', () => {
       const icon = document.querySelector('.theme-icon');
 
       // Initially light (moon icon)
@@ -95,6 +100,10 @@ describe('Theme Management', () => {
       // Toggle to dark (sun icon)
       toggleTheme();
       expect(icon.textContent).toBe('☀️');
+
+      // Toggle to auto (half-moon icon)
+      toggleTheme();
+      expect(icon.textContent).toBe('🌗');
 
       // Toggle back to light (moon icon)
       toggleTheme();
@@ -146,6 +155,89 @@ describe('Theme Management', () => {
 
       const icon = document.querySelector('.theme-icon');
       expect(icon.textContent).toBe('☀️');
+    });
+  });
+
+  describe('auto / system theme', () => {
+    let changeHandler;
+
+    function mockMatchMedia(prefersDark) {
+      changeHandler = null;
+      window.matchMedia = jest.fn().mockImplementation((query) => ({
+        matches: prefersDark,
+        media: query,
+        addEventListener: (_evt, cb) => {
+          changeHandler = cb;
+        },
+        removeEventListener: () => {},
+        addListener: (cb) => {
+          changeHandler = cb;
+        },
+        removeListener: () => {},
+      }));
+    }
+
+    afterEach(() => {
+      delete window.matchMedia;
+    });
+
+    it('resolves an "auto" preference to dark when the OS prefers dark', () => {
+      mockMatchMedia(true);
+      localStorage.getItem.mockReturnValue('auto');
+      loadApp(document);
+
+      expect(state.themePreference).toBe('auto');
+      expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+    });
+
+    it('resolves an "auto" preference to light when the OS prefers light', () => {
+      mockMatchMedia(false);
+      localStorage.getItem.mockReturnValue('auto');
+      loadApp(document);
+
+      expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+    });
+
+    it('defaults to "auto" when no preference is stored', () => {
+      mockMatchMedia(true);
+      localStorage.getItem.mockReturnValue(null);
+      loadApp(document);
+
+      expect(state.themePreference).toBe('auto');
+      expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+    });
+
+    it('live-updates when the OS scheme changes while in auto mode', () => {
+      mockMatchMedia(false);
+      localStorage.getItem.mockReturnValue('auto');
+      loadApp(document);
+      expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+
+      // The OS switches to dark; the registered listener re-resolves.
+      window.matchMedia = jest
+        .fn()
+        .mockReturnValue({ matches: true, addEventListener() {}, addListener() {} });
+      expect(typeof changeHandler).toBe('function');
+      changeHandler();
+      expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+    });
+
+    it('stops following the OS once an explicit preference is chosen', () => {
+      mockMatchMedia(false);
+      localStorage.getItem.mockReturnValue('auto');
+      loadApp(document);
+
+      toggleTheme(); // auto → light
+      toggleTheme(); // light → dark
+      expect(state.themePreference).toBe('dark');
+
+      // OS flips to dark-preference; because we're no longer in auto, the
+      // listener is a no-op and the explicit dark choice stands.
+      window.matchMedia = jest
+        .fn()
+        .mockReturnValue({ matches: true, addEventListener() {}, addListener() {} });
+      if (changeHandler) changeHandler();
+      expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
     });
   });
 });


### PR DESCRIPTION
Slice 2 of **Phase 2** — the auto/light/dark + motion parts of the roadmap's "token overhaul + auto/light/dark theme + motion" line. I **deferred the bulk CSS token mass-replacement** (the ~50 stray hard-coded hexes) to a later slice that warrants a visual pass — it isn't unit-testable and rewriting it blind is risk for little verifiable gain. This PR is the logic-testable part.

## Auto / system theme
The theme model goes from a 2-way light↔dark flip to a 3-way preference with an OS-following mode:
- **`state.themePreference`** (`light` | `dark` | `auto`) = persisted choice; **`state.currentTheme`** (`light` | `dark`) = resolved applied theme (what mermaid reads). `data-theme` always carries the resolved value, so **all existing CSS is unchanged**.
- **`auto`** resolves via `matchMedia('(prefers-color-scheme: dark)')` and **live-updates** when the OS flips while in auto mode (the listener is a no-op once an explicit theme is chosen).
- Toggle button now **cycles light → dark → auto → light**; the icon (🌙 / ☀️ / 🌗) and `aria-label`/`title` name the current mode and the next.
- **Default is now `auto`** for first-run users (follow the OS); anyone with a stored `light`/`dark` keeps it. `window.setTheme(...)` (iOS bridge) accepts all three.

## Motion
- Global **`@media (prefers-reduced-motion: reduce)`** reset neutralizing animations, transitions, and smooth scroll app-wide (subsumes the toast-only guard from slice 1).

## Verification (automated)
- Rewrote `theme.test.js` toggle tests for the 3-way cycle + new **auto/system** describe with a `matchMedia` mock: auto→dark/light resolution, default-to-auto, **live OS-change** updates, and "stops following the OS once an explicit choice is made."
- **build ✓, lint ✓, typecheck ✓, 324 tests ✓** (was 319; `state.js` typedef gained `themePreference`).

## The one manual check
Pure-visual: confirm the 🌗 auto state + cycle read right on web/desktop/iOS. The logic (which theme actually applies, and OS-follow behavior) is fully Jest-gated.

## Remaining Phase 2
Design-token overhaul (scales + retiring stray hexes) and the command palette (Cmd+K) + toolbar overflow + shortcut sheet.

https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA)_