### PR TITLE
Phase 2: command palette (Cmd+K) + keyboard shortcut sheet

### DIFF
--- a/docs/project-modernization/2026-06-14-tasks-session-08-phase2-command-palette.md
+++ b/docs/project-modernization/2026-06-14-tasks-session-08-phase2-command-palette.md
@@ -1,0 +1,66 @@
+# Tasks — Session 08: Phase 2 (command palette + shortcut sheet, slice 3)
+
+**Date:** 2026-06-14
+**Type:** tasks (session-level implementation checklist)
+**Phase:** 2 — Design system & UX modernization
+**Source plan:** [2026-06-13-brainstorm-modernization-evaluation.md](2026-06-13-brainstorm-modernization-evaluation.md) §Phase 2
+
+Slice 3 of Phase 2: the **command palette (Cmd/Ctrl+K)** and the **keyboard
+shortcut sheet (`?`)**. Net-new UI, but the substance — a command registry,
+fuzzy filtering, and keyboard navigation — is pure logic, so it's almost
+entirely Jest-gated; only the rendered look needs a glance.
+
+---
+
+## Command palette (`features/command-palette.js`, `// @ts-check`)
+
+- A registry of `Command` objects (`id`, `title`, optional `hint`/`keywords`,
+  `run`, optional `isAvailable`). The entry module registers the set in
+  `registerAppCommands()` so the palette stays decoupled from the features it
+  invokes (open file, toggle theme, raw/preview, TOC, split, annotate, find,
+  print, shortcuts).
+- **`filterCommands`** / **`fuzzyScore`** are pure and exported: subsequence
+  fuzzy match with consecutive- and start-of-string bonuses; commands whose
+  `isAvailable()` is false (e.g. document-only actions with no doc open) are
+  hidden.
+- Full **keyboard nav**: ↑/↓ move the selection, Enter runs + closes, Esc
+  closes; mouse hover/click work too. Opens with **Cmd/Ctrl+K** (wired in the
+  global keydown), closes on outside-click. Focus is captured on open and
+  **restored** to the prior element on close.
+- **ARIA:** combobox input + listbox/options dialog (`role="dialog"`,
+  `aria-modal`, `aria-activedescendant`, `aria-selected`). Built on open / torn
+  down on close, so there's no stale selection between invocations.
+
+## Keyboard shortcut sheet (`features/shortcuts.js`, `// @ts-check`)
+
+- A small accessible modal (`role="dialog"`, `aria-modal`) listing the app's
+  shortcuts as `<kbd>` + description rows. The modifier glyph adapts (⌘ on Apple
+  platforms, Ctrl elsewhere). Opened with **`?`** (suppressed while typing or
+  while the palette is open) and via the palette's "Keyboard shortcuts" command.
+
+## Styling
+
+- New `.command-palette*` and `.shortcuts-*` rules, all built on the theme
+  tokens (`--bg-primary`, `--text-primary`, `--border-color`, `--accent-color`,
+  `--shadow-lg`) so they track light/dark automatically.
+
+## Verification (automated)
+
+- `tests/unit/commandPalette.test.js`: `fuzzyScore` (no-match / subsequence /
+  start bonus / empty), `filterCommands` (availability, fuzzy, keywords, no
+  match), open/close/toggle, ARIA dialog wiring, arrow-key selection, Enter-runs
+  + closes, Esc, live input filtering, empty state.
+- `tests/unit/shortcutsSheet.test.js`: accessible modal + `<kbd>` rows,
+  idempotent open, close/remove, Esc-to-close.
+- **build ✓, lint ✓, typecheck ✓, 345 tests ✓** (was 324; +21).
+- (Document-level Cmd+K/`?` dispatch isn't unit-tested because `loadApp`
+  re-attaches the global keydown listener each run, which would make a
+  document-dispatch assertion order-dependent; the open/close/toggle logic those
+  keys call is covered directly.)
+
+## Remaining Phase 2
+
+- **Toolbar consolidation + overflow menu** and the broader **design-token
+  overhaul** (spacing/radius/typography scales + retiring stray hard-coded
+  hexes) — both want a visual review pass, so they're the natural
+  with-you-watching slices to close out Phase 2.

--- a/docs/project-modernization/README.md
+++ b/docs/project-modernization/README.md
@@ -16,6 +16,7 @@ three-lens evaluation of the app at v0.0.82 and a phased roadmap.
 | 2026-06-14 | [tasks-session-05-phase1-typescript](2026-06-14-tasks-session-05-phase1-typescript.md) | Phase 1 slice 4: gradual TypeScript foundation — `checkJs` toolchain, per-file `// @ts-check` opt-in (leaf modules), native-bridge `globals.d.ts`, `typecheck` enforced in CI |
 | 2026-06-14 | [tasks-session-06-phase2-toasts-a11y](2026-06-14-tasks-session-06-phase2-toasts-a11y.md) | Phase 2 slice 1: accessible toast system replaces all `alert()` calls + accessibility pass (skip link, aria-labels on icon-only controls, decorative-icon hiding, reduced-motion); +22 tests |
 | 2026-06-14 | [tasks-session-07-phase2-theme-motion](2026-06-14-tasks-session-07-phase2-theme-motion.md) | Phase 2 slice 2: auto/system theme (3-way light→dark→auto cycle, `prefers-color-scheme` with live OS updates) + global reduced-motion; +5 tests |
+| 2026-06-14 | [tasks-session-08-phase2-command-palette](2026-06-14-tasks-session-08-phase2-command-palette.md) | Phase 2 slice 3: command palette (Cmd/Ctrl+K, fuzzy filter, keyboard nav, ARIA combobox/listbox) + keyboard shortcut sheet (`?`); +21 tests |
 
 ## Current Status
 
@@ -44,9 +45,11 @@ replaces every `alert()`, plus a skip link, `aria-label`s on icon-only controls,
 decorative-icon hiding, and reduced-motion; (2) **auto/system theme + motion** —
 done (session 07): a 3-way light→dark→auto cycle that follows the OS via
 `prefers-color-scheme` (with live updates) and a global reduced-motion reset;
-(3) the design-token overhaul (spacing/radius/typography scales + retiring the
-stray hard-coded hexes) and the command palette (Cmd+K) + toolbar overflow +
-shortcut sheet remain.
+(3) **command palette + shortcut sheet** — done (session 08): a Cmd/Ctrl+K
+fuzzy-filtered, keyboard-navigable command palette (ARIA combobox/listbox) and a
+`?` keyboard-shortcut sheet. Remaining: toolbar consolidation/overflow and the
+broader design-token overhaul (spacing/radius/typography scales + retiring stray
+hard-coded hexes) — both want a visual-review pass.
 
 The open questions below (iOS investment, Apple Developer membership for
 signing, Electron vs Tauri spike) still gate **Phases 2–4**, not Phase 1.

--- a/markdown-viewer/src/features/command-palette.js
+++ b/markdown-viewer/src/features/command-palette.js
@@ -1,0 +1,263 @@
+// @ts-check
+// Command palette (Cmd/Ctrl+K): a searchable list of every app action, with
+// fuzzy filtering and full keyboard navigation. Commands are registered by the
+// entry module so this stays decoupled from the features it invokes.
+//
+// The palette DOM is built on open and torn down on close, so there's no stale
+// selection state between invocations. It's an ARIA combobox + listbox dialog.
+
+/**
+ * @typedef {object} Command
+ * @property {string} id
+ * @property {string} title
+ * @property {string} [hint] Right-aligned shortcut/hint text.
+ * @property {string[]} [keywords] Extra terms the fuzzy filter also matches.
+ * @property {() => void} run
+ * @property {() => boolean} [isAvailable] Hide the command when this returns false.
+ */
+
+/** @type {Command[]} */
+let registry = [];
+
+/** @type {HTMLElement | null} */
+let overlay = null;
+/** @type {HTMLInputElement | null} */
+let input = null;
+/** @type {HTMLElement | null} */
+let listEl = null;
+/** @type {Command[]} */
+let visible = [];
+let selectedIndex = 0;
+/** @type {Element | null} */
+let previouslyFocused = null;
+
+/**
+ * Register the set of commands the palette offers. Replaces any prior set.
+ * @param {Command[]} commands
+ */
+export function registerCommands(commands) {
+  registry = Array.isArray(commands) ? commands.slice() : [];
+}
+
+/**
+ * Fuzzy subsequence score of `query` against `text`. Returns -1 for no match,
+ * otherwise a score that rewards consecutive and start-of-string matches.
+ * @param {string} query
+ * @param {string} text
+ * @returns {number}
+ */
+export function fuzzyScore(query, text) {
+  const q = query.toLowerCase();
+  const t = text.toLowerCase();
+  if (q === '') return 0;
+  let qi = 0;
+  let score = 0;
+  let lastMatch = -2;
+  for (let ti = 0; ti < t.length && qi < q.length; ti++) {
+    if (t[ti] === q[qi]) {
+      score += lastMatch === ti - 1 ? 2 : 1; // consecutive bonus
+      if (ti === 0) score += 3; // start-of-string bonus
+      lastMatch = ti;
+      qi++;
+    }
+  }
+  return qi === q.length ? score : -1;
+}
+
+/**
+ * Filter + rank the available commands for a query (pure; used by the UI and
+ * directly by tests).
+ * @param {Command[]} commands
+ * @param {string} query
+ * @returns {Command[]}
+ */
+export function filterCommands(commands, query) {
+  const available = commands.filter((c) => !c.isAvailable || c.isAvailable());
+  if (!query) return available;
+  return available
+    .map((command) => {
+      let best = fuzzyScore(query, command.title);
+      for (const kw of command.keywords || []) {
+        best = Math.max(best, fuzzyScore(query, kw));
+      }
+      return { command, score: best };
+    })
+    .filter((entry) => entry.score >= 0)
+    .sort((a, b) => b.score - a.score)
+    .map((entry) => entry.command);
+}
+
+export function isCommandPaletteOpen() {
+  return overlay !== null;
+}
+
+function renderList() {
+  if (!listEl || !input) return;
+  const list = listEl;
+  const field = input;
+  list.innerHTML = '';
+
+  if (visible.length === 0) {
+    const empty = document.createElement('li');
+    empty.className = 'command-palette-empty';
+    empty.textContent = 'No matching commands';
+    list.appendChild(empty);
+    field.removeAttribute('aria-activedescendant');
+    return;
+  }
+
+  visible.forEach((command, i) => {
+    const item = document.createElement('li');
+    item.className = 'command-palette-item' + (i === selectedIndex ? ' is-selected' : '');
+    item.id = 'command-palette-option-' + i;
+    item.setAttribute('role', 'option');
+    item.setAttribute('aria-selected', i === selectedIndex ? 'true' : 'false');
+
+    const title = document.createElement('span');
+    title.className = 'command-palette-item-title';
+    title.textContent = command.title;
+    item.appendChild(title);
+
+    if (command.hint) {
+      const hint = document.createElement('span');
+      hint.className = 'command-palette-item-hint';
+      hint.textContent = command.hint;
+      item.appendChild(hint);
+    }
+
+    item.addEventListener('mousemove', () => {
+      selectedIndex = i;
+      updateSelection();
+    });
+    item.addEventListener('click', () => runSelected());
+
+    list.appendChild(item);
+  });
+
+  updateSelection();
+}
+
+function updateSelection() {
+  if (!listEl || !input) return;
+  const field = input;
+  const items = listEl.querySelectorAll('.command-palette-item');
+  items.forEach((item, i) => {
+    const isSel = i === selectedIndex;
+    item.classList.toggle('is-selected', isSel);
+    item.setAttribute('aria-selected', isSel ? 'true' : 'false');
+    if (isSel) {
+      field.setAttribute('aria-activedescendant', item.id);
+      if (typeof (/** @type {HTMLElement} */ (item)).scrollIntoView === 'function') {
+        (/** @type {HTMLElement} */ (item)).scrollIntoView({ block: 'nearest' });
+      }
+    }
+  });
+}
+
+/** @param {number} delta */
+function moveSelection(delta) {
+  if (visible.length === 0) return;
+  selectedIndex = (selectedIndex + delta + visible.length) % visible.length;
+  updateSelection();
+}
+
+function runSelected() {
+  const command = visible[selectedIndex];
+  closeCommandPalette();
+  if (command && typeof command.run === 'function') {
+    command.run();
+  }
+}
+
+function onInput() {
+  if (!input) return;
+  visible = filterCommands(registry, input.value.trim());
+  selectedIndex = 0;
+  renderList();
+}
+
+/** @param {KeyboardEvent} e */
+function onKeydown(e) {
+  if (e.key === 'ArrowDown') {
+    e.preventDefault();
+    moveSelection(1);
+  } else if (e.key === 'ArrowUp') {
+    e.preventDefault();
+    moveSelection(-1);
+  } else if (e.key === 'Enter') {
+    e.preventDefault();
+    runSelected();
+  } else if (e.key === 'Escape') {
+    e.preventDefault();
+    closeCommandPalette();
+  }
+}
+
+export function openCommandPalette() {
+  if (overlay) return;
+  previouslyFocused = document.activeElement;
+
+  overlay = document.createElement('div');
+  overlay.className = 'command-palette-overlay';
+  overlay.addEventListener('mousedown', (e) => {
+    if (e.target === overlay) closeCommandPalette();
+  });
+
+  const dialog = document.createElement('div');
+  dialog.className = 'command-palette';
+  dialog.setAttribute('role', 'dialog');
+  dialog.setAttribute('aria-modal', 'true');
+  dialog.setAttribute('aria-label', 'Command palette');
+
+  input = document.createElement('input');
+  input.className = 'command-palette-input';
+  input.type = 'text';
+  input.setAttribute('role', 'combobox');
+  input.setAttribute('aria-expanded', 'true');
+  input.setAttribute('aria-controls', 'command-palette-list');
+  input.setAttribute('aria-autocomplete', 'list');
+  input.setAttribute('placeholder', 'Type a command…');
+  input.setAttribute('autocomplete', 'off');
+  input.setAttribute('spellcheck', 'false');
+  input.addEventListener('input', onInput);
+  input.addEventListener('keydown', onKeydown);
+
+  listEl = document.createElement('ul');
+  listEl.className = 'command-palette-list';
+  listEl.id = 'command-palette-list';
+  listEl.setAttribute('role', 'listbox');
+
+  dialog.appendChild(input);
+  dialog.appendChild(listEl);
+  overlay.appendChild(dialog);
+  document.body.appendChild(overlay);
+
+  visible = filterCommands(registry, '');
+  selectedIndex = 0;
+  renderList();
+  input.focus();
+}
+
+export function closeCommandPalette() {
+  if (!overlay) return;
+  if (overlay.parentNode) overlay.parentNode.removeChild(overlay);
+  overlay = null;
+  input = null;
+  listEl = null;
+  visible = [];
+  selectedIndex = 0;
+  // Restore focus to wherever it was before the palette opened.
+  if (previouslyFocused && typeof (/** @type {HTMLElement} */ (previouslyFocused)).focus === 'function') {
+    (/** @type {HTMLElement} */ (previouslyFocused)).focus();
+  }
+  previouslyFocused = null;
+}
+
+/** Open the palette if closed, close it if open. */
+export function toggleCommandPalette() {
+  if (overlay) {
+    closeCommandPalette();
+  } else {
+    openCommandPalette();
+  }
+}

--- a/markdown-viewer/src/features/shortcuts.js
+++ b/markdown-viewer/src/features/shortcuts.js
@@ -1,0 +1,93 @@
+// @ts-check
+// Keyboard-shortcut reference sheet: a small accessible modal listing the app's
+// shortcuts. Opened with `?` or from the command palette.
+
+const MOD = /Mac|iPhone|iPad/.test(
+  (typeof navigator !== 'undefined' && navigator.platform) || ''
+)
+  ? '⌘'
+  : 'Ctrl';
+
+/** @type {Array<{ keys: string, label: string }>} */
+const SHORTCUTS = [
+  { keys: `${MOD} K`, label: 'Open command palette' },
+  { keys: `${MOD} F`, label: 'Find in document' },
+  { keys: `${MOD} P`, label: 'Print / save as PDF' },
+  { keys: '?', label: 'Show this shortcuts sheet' },
+  { keys: 'Esc', label: 'Close dialog, search, or fullscreen' },
+];
+
+/** @type {HTMLElement | null} */
+let overlay = null;
+/** @type {Element | null} */
+let previouslyFocused = null;
+
+export function isShortcutsSheetOpen() {
+  return overlay !== null;
+}
+
+export function openShortcutsSheet() {
+  if (overlay) return;
+  previouslyFocused = document.activeElement;
+
+  overlay = document.createElement('div');
+  overlay.className = 'shortcuts-overlay';
+  overlay.addEventListener('mousedown', (e) => {
+    if (e.target === overlay) closeShortcutsSheet();
+  });
+
+  const dialog = document.createElement('div');
+  dialog.className = 'shortcuts-sheet';
+  dialog.setAttribute('role', 'dialog');
+  dialog.setAttribute('aria-modal', 'true');
+  dialog.setAttribute('aria-label', 'Keyboard shortcuts');
+  dialog.tabIndex = -1;
+  dialog.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      closeShortcutsSheet();
+    }
+  });
+
+  const heading = document.createElement('h2');
+  heading.className = 'shortcuts-title';
+  heading.textContent = 'Keyboard shortcuts';
+  dialog.appendChild(heading);
+
+  const list = document.createElement('dl');
+  list.className = 'shortcuts-list';
+  for (const { keys, label } of SHORTCUTS) {
+    const row = document.createElement('div');
+    row.className = 'shortcuts-row';
+
+    const dt = document.createElement('dt');
+    const kbd = document.createElement('kbd');
+    kbd.textContent = keys;
+    dt.appendChild(kbd);
+
+    const dd = document.createElement('dd');
+    dd.textContent = label;
+
+    row.appendChild(dt);
+    row.appendChild(dd);
+    list.appendChild(row);
+  }
+  dialog.appendChild(list);
+
+  overlay.appendChild(dialog);
+  document.body.appendChild(overlay);
+  dialog.focus();
+}
+
+export function closeShortcutsSheet() {
+  if (!overlay) return;
+  if (overlay.parentNode) overlay.parentNode.removeChild(overlay);
+  overlay = null;
+  if (
+    previouslyFocused &&
+    typeof (/** @type {HTMLElement} */ (previouslyFocused)).focus === 'function'
+  ) {
+    (/** @type {HTMLElement} */ (previouslyFocused)).focus();
+  }
+  previouslyFocused = null;
+}

--- a/markdown-viewer/src/main.js
+++ b/markdown-viewer/src/main.js
@@ -87,6 +87,17 @@ import {
 import { createTab, configureTabs } from './features/tabs.js';
 import { showToast } from './features/toast.js';
 import {
+  registerCommands,
+  toggleCommandPalette,
+  closeCommandPalette,
+  isCommandPaletteOpen,
+} from './features/command-palette.js';
+import {
+  openShortcutsSheet,
+  closeShortcutsSheet,
+  isShortcutsSheetOpen,
+} from './features/shortcuts.js';
+import {
   setupDesktopIPC,
   updateWatchToggle,
   saveDesktopSession,
@@ -167,6 +178,7 @@ function init() {
         stopWatchingFilePath: (filePath) => stopWatchingFilePath(filePath),
     });
     configureDesktop({ renderMarkdown: (content, title) => renderMarkdown(content, title) });
+    registerAppCommands();
     setupVersionInfo();
     setupTheme();
     setupIOSNativeUI();
@@ -177,6 +189,88 @@ function init() {
     if (isDesktop) {
         setupDesktopIPC();
     }
+}
+
+// ===========================
+// Command Palette registry
+// ===========================
+// The modifier glyph shown in command hints — ⌘ on Apple platforms, Ctrl else.
+const CMD_MOD = /Mac|iPhone|iPad/.test(navigator.platform || '') ? '⌘' : 'Ctrl';
+
+// Commands that act on the open document are only offered while one is visible.
+const isDocumentOpen = () => contentArea.style.display !== 'none';
+
+function registerAppCommands() {
+    registerCommands([
+        {
+            id: 'open-file',
+            title: 'Open file…',
+            keywords: ['browse', 'load', 'new'],
+            run: () => {
+                if (!requestNativeOpenIfAvailable()) fileInput.click();
+            },
+        },
+        {
+            id: 'toggle-theme',
+            title: 'Toggle theme (light / dark / system)',
+            keywords: ['dark', 'light', 'appearance', 'color'],
+            run: () => toggleTheme(),
+        },
+        {
+            id: 'toggle-view',
+            title: 'Toggle raw / preview',
+            keywords: ['markdown', 'source', 'code'],
+            run: () => toggleViewMode(),
+            isAvailable: isDocumentOpen,
+        },
+        {
+            id: 'toggle-toc',
+            title: 'Toggle table of contents',
+            keywords: ['outline', 'headings', 'contents'],
+            run: () => toggleToc(),
+            isAvailable: isDocumentOpen,
+        },
+        {
+            id: 'toggle-split',
+            title: 'Toggle split view',
+            keywords: ['preview', 'raw', 'side'],
+            run: () => toggleSplitView(),
+            isAvailable: isDocumentOpen,
+        },
+        {
+            id: 'toggle-annotate',
+            title: 'Toggle annotation mode',
+            keywords: ['notes', 'comment', 'markup'],
+            run: () => {
+                toggleAnnotationMode();
+                syncIOSChrome();
+            },
+            isAvailable: isDocumentOpen,
+        },
+        {
+            id: 'find',
+            title: 'Find in document',
+            hint: CMD_MOD + ' F',
+            keywords: ['search'],
+            run: () => openSearch(),
+            isAvailable: isDocumentOpen,
+        },
+        {
+            id: 'print',
+            title: 'Print / Save as PDF',
+            hint: CMD_MOD + ' P',
+            keywords: ['pdf', 'export', 'save'],
+            run: () => performPrint(),
+            isAvailable: isDocumentOpen,
+        },
+        {
+            id: 'shortcuts',
+            title: 'Keyboard shortcuts',
+            hint: '?',
+            keywords: ['help', 'keys', 'cheatsheet'],
+            run: () => openShortcutsSheet(),
+        },
+    ]);
 }
 
 // ===========================
@@ -404,9 +498,25 @@ function setupEventListeners() {
 
     // Global keyboard shortcuts
     document.addEventListener('keydown', (e) => {
+        // Cmd/Ctrl+K — toggle the command palette (works anywhere)
+        if ((e.metaKey || e.ctrlKey) && (e.key === 'k' || e.key === 'K')) {
+            e.preventDefault();
+            toggleCommandPalette();
+            return;
+        }
+        // "?" — open the keyboard shortcut sheet (unless typing or in a dialog)
+        if (e.key === '?' && !isTypingTarget(e.target) && !isCommandPaletteOpen()) {
+            e.preventDefault();
+            openShortcutsSheet();
+            return;
+        }
         // ESC
         if (e.key === 'Escape') {
-            if (fullscreenOverlay.style.display !== 'none') {
+            if (isCommandPaletteOpen()) {
+                closeCommandPalette();
+            } else if (isShortcutsSheetOpen()) {
+                closeShortcutsSheet();
+            } else if (fullscreenOverlay.style.display !== 'none') {
                 closeFullscreen();
             } else if (searchBar && searchBar.style.display !== 'none') {
                 closeSearch();
@@ -482,6 +592,14 @@ function setupEventListeners() {
 
     // TOC scroll spy
     markdownContent.addEventListener('scroll', scheduleTocActiveHeadingUpdate);
+}
+
+// True when the event target is a text-entry element, so global single-key
+// shortcuts (like "?") don't fire while the user is typing.
+function isTypingTarget(target) {
+    if (!target) return false;
+    const tag = target.tagName;
+    return tag === 'INPUT' || tag === 'TEXTAREA' || target.isContentEditable === true;
 }
 
 // ===========================

--- a/markdown-viewer/styles.css
+++ b/markdown-viewer/styles.css
@@ -1452,6 +1452,141 @@ mark.search-highlight-current {
 }
 
 /* ===========================
+   Command Palette
+   =========================== */
+.command-palette-overlay {
+    position: fixed;
+    inset: 0;
+    background-color: rgba(0, 0, 0, 0.4);
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding-top: 12vh;
+    z-index: 10002;
+}
+
+.command-palette {
+    width: min(92vw, 38rem);
+    max-height: 60vh;
+    display: flex;
+    flex-direction: column;
+    background-color: var(--bg-primary);
+    color: var(--text-primary);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    box-shadow: var(--shadow-lg);
+    overflow: hidden;
+}
+
+.command-palette-input {
+    border: none;
+    outline: none;
+    padding: 1rem 1.25rem;
+    font-size: 1rem;
+    font-family: inherit;
+    background-color: transparent;
+    color: var(--text-primary);
+    border-bottom: 1px solid var(--border-color);
+}
+
+.command-palette-list {
+    list-style: none;
+    margin: 0;
+    padding: 0.25rem;
+    overflow-y: auto;
+}
+
+.command-palette-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.55rem 0.85rem;
+    border-radius: 8px;
+    cursor: pointer;
+}
+
+.command-palette-item.is-selected {
+    background-color: var(--accent-color);
+    color: #fff;
+}
+
+.command-palette-item-hint {
+    font-size: 0.8rem;
+    opacity: 0.7;
+    white-space: nowrap;
+}
+
+.command-palette-item.is-selected .command-palette-item-hint {
+    opacity: 0.9;
+}
+
+.command-palette-empty {
+    padding: 0.85rem;
+    text-align: center;
+    opacity: 0.7;
+}
+
+/* ===========================
+   Keyboard Shortcuts Sheet
+   =========================== */
+.shortcuts-overlay {
+    position: fixed;
+    inset: 0;
+    background-color: rgba(0, 0, 0, 0.4);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 10002;
+}
+
+.shortcuts-sheet {
+    width: min(92vw, 26rem);
+    background-color: var(--bg-primary);
+    color: var(--text-primary);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    box-shadow: var(--shadow-lg);
+    padding: 1.25rem 1.5rem;
+    outline: none;
+}
+
+.shortcuts-title {
+    font-size: 1.1rem;
+    margin-bottom: 0.75rem;
+}
+
+.shortcuts-list {
+    margin: 0;
+}
+
+.shortcuts-row {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.35rem 0;
+}
+
+.shortcuts-row dt,
+.shortcuts-row dd {
+    margin: 0;
+}
+
+.shortcuts-row dt {
+    min-width: 4.5rem;
+}
+
+.shortcuts-row kbd {
+    display: inline-block;
+    padding: 0.15rem 0.5rem;
+    background-color: var(--bg-tertiary);
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    font-family: inherit;
+    font-size: 0.85rem;
+}
+
+/* ===========================
    iOS Native Shell
    =========================== */
 .ios-native {

--- a/tests/unit/commandPalette.test.js
+++ b/tests/unit/commandPalette.test.js
@@ -1,0 +1,174 @@
+/**
+ * Unit tests for the command palette: fuzzy filtering (pure) and the
+ * open/close/keyboard-navigation behavior.
+ */
+
+const { loadHTML, loadApp } = require('../helpers/loadApp');
+require('../mocks/marked');
+require('../mocks/mermaid');
+require('../mocks/panzoom');
+require('../mocks/highlightjs');
+
+function dispatchKey(el, key) {
+  el.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+}
+
+describe('Command palette', () => {
+  beforeEach(() => {
+    loadHTML(document);
+    loadApp(document);
+  });
+
+  afterEach(() => {
+    if (isCommandPaletteOpen()) closeCommandPalette();
+  });
+
+  describe('fuzzyScore', () => {
+    it('returns -1 when the query is not a subsequence', () => {
+      expect(fuzzyScore('xyz', 'Toggle theme')).toBe(-1);
+    });
+
+    it('matches an in-order subsequence', () => {
+      expect(fuzzyScore('tg', 'Toggle')).toBeGreaterThanOrEqual(0);
+    });
+
+    it('rewards start-of-string matches', () => {
+      expect(fuzzyScore('to', 'Toggle')).toBeGreaterThan(fuzzyScore('gl', 'Toggle'));
+    });
+
+    it('scores an empty query as 0', () => {
+      expect(fuzzyScore('', 'anything')).toBe(0);
+    });
+  });
+
+  describe('filterCommands', () => {
+    const cmds = [
+      { id: 'a', title: 'Toggle theme', run() {} },
+      { id: 'b', title: 'Find in document', run() {} },
+      { id: 'c', title: 'Print', run() {}, isAvailable: () => false },
+    ];
+
+    it('returns all available commands for an empty query', () => {
+      expect(filterCommands(cmds, '').map((c) => c.id)).toEqual(['a', 'b']);
+    });
+
+    it('filters by a fuzzy query', () => {
+      expect(filterCommands(cmds, 'find').map((c) => c.id)).toEqual(['b']);
+    });
+
+    it('matches against keywords too', () => {
+      const withKw = [{ id: 'x', title: 'Toggle theme', keywords: ['dark'], run() {} }];
+      expect(filterCommands(withKw, 'dark').map((c) => c.id)).toEqual(['x']);
+    });
+
+    it('returns nothing when no command matches', () => {
+      expect(filterCommands(cmds, 'zzzz')).toEqual([]);
+    });
+  });
+
+  describe('open / close', () => {
+    it('opens an accessible dialog with command options', () => {
+      openCommandPalette();
+
+      expect(isCommandPaletteOpen()).toBe(true);
+      const dialog = document.querySelector('.command-palette');
+      expect(dialog.getAttribute('role')).toBe('dialog');
+      expect(dialog.getAttribute('aria-modal')).toBe('true');
+
+      const input = document.querySelector('.command-palette-input');
+      expect(input.getAttribute('role')).toBe('combobox');
+      expect(document.querySelectorAll('.command-palette-item').length).toBeGreaterThan(0);
+    });
+
+    it('closes and removes the overlay', () => {
+      openCommandPalette();
+      closeCommandPalette();
+
+      expect(isCommandPaletteOpen()).toBe(false);
+      expect(document.querySelector('.command-palette-overlay')).toBeNull();
+    });
+
+    it('toggles open then closed', () => {
+      toggleCommandPalette();
+      expect(isCommandPaletteOpen()).toBe(true);
+      toggleCommandPalette();
+      expect(isCommandPaletteOpen()).toBe(false);
+    });
+
+    it('only registers available commands (doc-only commands hidden with no doc)', () => {
+      openCommandPalette();
+      const titles = Array.from(document.querySelectorAll('.command-palette-item-title')).map(
+        (el) => el.textContent
+      );
+      // "Open file…" is always available; "Find in document" needs an open doc.
+      expect(titles).toContain('Open file…');
+      expect(titles).not.toContain('Find in document');
+    });
+  });
+
+  describe('keyboard navigation', () => {
+    it('moves the selection with arrow keys', () => {
+      openCommandPalette();
+      const input = document.querySelector('.command-palette-input');
+
+      let items = document.querySelectorAll('.command-palette-item');
+      expect(items[0].getAttribute('aria-selected')).toBe('true');
+
+      dispatchKey(input, 'ArrowDown');
+      items = document.querySelectorAll('.command-palette-item');
+      expect(items[0].getAttribute('aria-selected')).toBe('false');
+      expect(items[1].getAttribute('aria-selected')).toBe('true');
+
+      dispatchKey(input, 'ArrowUp');
+      items = document.querySelectorAll('.command-palette-item');
+      expect(items[0].getAttribute('aria-selected')).toBe('true');
+    });
+
+    it('runs the selected command on Enter and closes', () => {
+      const run = jest.fn();
+      registerCommands([{ id: 'spy', title: 'Spy command', run }]);
+      openCommandPalette();
+
+      const input = document.querySelector('.command-palette-input');
+      dispatchKey(input, 'Enter');
+
+      expect(run).toHaveBeenCalledTimes(1);
+      expect(isCommandPaletteOpen()).toBe(false);
+    });
+
+    it('closes on Escape', () => {
+      openCommandPalette();
+      const input = document.querySelector('.command-palette-input');
+      dispatchKey(input, 'Escape');
+      expect(isCommandPaletteOpen()).toBe(false);
+    });
+  });
+
+  describe('filtering via the input', () => {
+    it('re-renders the list as the query changes', () => {
+      registerCommands([
+        { id: 'theme', title: 'Toggle theme', run() {} },
+        { id: 'find', title: 'Find in document', run() {} },
+      ]);
+      openCommandPalette();
+
+      const input = document.querySelector('.command-palette-input');
+      input.value = 'find';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+
+      const items = document.querySelectorAll('.command-palette-item');
+      expect(items.length).toBe(1);
+      expect(items[0].textContent).toContain('Find in document');
+    });
+
+    it('shows an empty state when nothing matches', () => {
+      openCommandPalette();
+      const input = document.querySelector('.command-palette-input');
+      input.value = 'zzzznope';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+
+      expect(document.querySelector('.command-palette-item')).toBeNull();
+      expect(document.querySelector('.command-palette-empty')).not.toBeNull();
+    });
+  });
+});

--- a/tests/unit/shortcutsSheet.test.js
+++ b/tests/unit/shortcutsSheet.test.js
@@ -1,0 +1,57 @@
+/**
+ * Unit tests for the keyboard-shortcut reference sheet.
+ */
+
+const { loadHTML, loadApp } = require('../helpers/loadApp');
+require('../mocks/marked');
+require('../mocks/mermaid');
+require('../mocks/panzoom');
+require('../mocks/highlightjs');
+
+describe('Keyboard shortcuts sheet', () => {
+  beforeEach(() => {
+    loadHTML(document);
+    loadApp(document);
+  });
+
+  afterEach(() => {
+    if (isShortcutsSheetOpen()) closeShortcutsSheet();
+  });
+
+  it('opens an accessible modal listing shortcuts', () => {
+    openShortcutsSheet();
+
+    expect(isShortcutsSheetOpen()).toBe(true);
+    const dialog = document.querySelector('.shortcuts-sheet');
+    expect(dialog).not.toBeNull();
+    expect(dialog.getAttribute('role')).toBe('dialog');
+    expect(dialog.getAttribute('aria-modal')).toBe('true');
+    expect(dialog.getAttribute('aria-label')).toBe('Keyboard shortcuts');
+
+    const rows = document.querySelectorAll('.shortcuts-row');
+    expect(rows.length).toBeGreaterThan(0);
+    // Each row pairs a <kbd> key with a description.
+    expect(document.querySelector('.shortcuts-row kbd')).not.toBeNull();
+  });
+
+  it('is idempotent — a second open does not stack overlays', () => {
+    openShortcutsSheet();
+    openShortcutsSheet();
+    expect(document.querySelectorAll('.shortcuts-overlay').length).toBe(1);
+  });
+
+  it('closes and removes the overlay', () => {
+    openShortcutsSheet();
+    closeShortcutsSheet();
+
+    expect(isShortcutsSheetOpen()).toBe(false);
+    expect(document.querySelector('.shortcuts-overlay')).toBeNull();
+  });
+
+  it('closes on Escape within the sheet', () => {
+    openShortcutsSheet();
+    const dialog = document.querySelector('.shortcuts-sheet');
+    dialog.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(isShortcutsSheetOpen()).toBe(false);
+  });
+});


### PR DESCRIPTION
Slice 3 of **Phase 2**. Net-new UI, but the substance — a command registry, fuzzy filtering, and keyboard navigation — is pure logic, so it's almost entirely Jest-gated; only the rendered look needs your glance.

## Command palette — `features/command-palette.js` (`// @ts-check`)
- **Registry** of `Command` objects (`id`, `title`, optional `hint`/`keywords`, `run`, optional `isAvailable`). The entry module registers the set (open file, toggle theme, raw/preview, TOC, split, annotate, find, print, shortcuts) via `registerAppCommands()`, keeping the palette decoupled from what it invokes.
- **Pure, exported `filterCommands` / `fuzzyScore`:** subsequence fuzzy match with consecutive- and start-of-string bonuses; commands whose `isAvailable()` is false (document-only actions with no doc open) are hidden.
- **Keyboard nav:** ↑/↓ select, Enter runs + closes, Esc closes; hover/click too. Opens with **Cmd/Ctrl+K**, closes on outside-click. Focus captured on open, **restored** on close.
- **ARIA:** combobox input + listbox/options dialog (`role="dialog"`, `aria-modal`, `aria-activedescendant`, `aria-selected`). Built on open / torn down on close — no stale state between invocations.

## Keyboard shortcut sheet — `features/shortcuts.js` (`// @ts-check`)
- Small accessible modal listing shortcuts as `<kbd>` + description rows; the modifier glyph adapts (⌘ on Apple, Ctrl elsewhere). Opened with **`?`** (suppressed while typing or when the palette is open) and via the palette's "Keyboard shortcuts" command.

## Styling
Both modals use the theme tokens (`--bg-primary`, `--text-primary`, `--border-color`, `--accent-color`, `--shadow-lg`), so they track light/dark automatically.

## Verification (automated)
- `commandPalette.test.js`: `fuzzyScore` (no-match / subsequence / start bonus / empty), `filterCommands` (availability / fuzzy / keywords / no-match), open/close/toggle, ARIA wiring, arrow-key selection, Enter-runs+closes, Esc, live input filtering, empty state.
- `shortcutsSheet.test.js`: accessible modal + `<kbd>` rows, idempotent open, close/remove, Esc-to-close.
- **build ✓, lint ✓, typecheck ✓, 345 tests ✓** (was 324; +21).
- Document-level Cmd+K/`?` dispatch isn't asserted (the test harness re-attaches the global keydown listener per `loadApp`, which would make such an assertion order-dependent); the open/close/toggle logic those keys call is covered directly.

## The manual check
Visual only: do the palette + sheet look right in light/dark? Behavior is fully tested.

## Remaining Phase 2
Toolbar consolidation/overflow + the broader design-token overhaul — both want a visual-review pass to close out Phase 2.

https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA)_