### PR TITLE
Gradual TypeScript batch 2: opt in 15 more modules to checkJs (21/~25)

### DIFF
--- a/docs/project-modernization/2026-06-14-tasks-session-09-typescript-batch2.md
+++ b/docs/project-modernization/2026-06-14-tasks-session-09-typescript-batch2.md
@@ -1,0 +1,52 @@
+# Tasks — Session 09: gradual TypeScript rollout (batch 2)
+
+**Date:** 2026-06-14
+**Type:** tasks (session-level implementation checklist)
+**Phase:** 1 follow-on — gradual TypeScript (`checkJs`)
+
+Continues the per-file `// @ts-check` opt-in started in session 05. A safe,
+fully-gated, zero-visual-risk batch — good autonomous work between the
+visual-review Phase 2 slices.
+
+---
+
+## Modules opted in (leaf / near-leaf)
+
+| Module | Notes |
+|---|---|
+| `features/custom-css.js` | typed the lazily-created `<style>` element |
+| `features/split-view.js` | typed the `el()` helper param |
+| `features/share-links.js` | typed the `openTab` DI callback signature (so 2-arg calls check) |
+| `features/view-mode.js` | typed the `renderPreview`/`cleanupPanzoom` DI callbacks; null-guard on `markdown-content` |
+| `features/diagram-export.js` | cast the complex-selector `querySelector` to `SVGElement`; null-guards on the 2D context and `toBlob` result |
+| `features/minimap.js` | cast `getElementById` to `HTMLCanvasElement`; null-guard on the 2D context |
+
+That's **9 of ~25 source modules** now type-checked (core/platform, core/state,
+core/utils, toast, command-palette, shortcuts from before, plus these six).
+
+## Patterns established for the DOM-heavy modules
+
+- The shared `const el = (id) => document.getElementById(id)` helper needs its
+  param annotated: `const el = (/** @type {string} */ id) => …`.
+- `getElementById` returns `HTMLElement | null`; when code uses element-specific
+  members (`canvas.width`, `.value`) cast at the call site:
+  `/** @type {HTMLCanvasElement | null} */ (document.getElementById('…'))`.
+- `getContext('2d')` and `canvas.toBlob(cb)` hand back nullable values — guard
+  before use (these are the only "new" runtime guards, and they're unreachable
+  for valid inputs, so behavior is unchanged).
+- DI callback vars (`openTab`, `renderPreview`, …) need an explicit function-type
+  JSDoc so call sites with real arguments are checked rather than inferred as
+  `() => void`.
+
+## Verification
+
+- **build ✓, lint ✓, typecheck ✓, 345 tests ✓** — no behavior change (the added
+  guards are defensive early-returns on otherwise-throwing null paths).
+
+## Remaining
+
+- Still unchecked: `render-config.js` (marked/mermaid type friction — wants a
+  careful pass), `annotations.js`, `repo-browser.js`, `search.js`, `toc.js`,
+  `file-loading.js`, `tabs.js`, `theme.js`, `diagrams.js`, `platform/*`, and the
+  `main.js` wiring hub. These have more DOM-nullability and external-lib typing
+  to work through; they opt in over subsequent batches.

--- a/docs/project-modernization/2026-06-14-tasks-session-09-typescript-batch2.md
+++ b/docs/project-modernization/2026-06-14-tasks-session-09-typescript-batch2.md
@@ -24,9 +24,17 @@ visual-review Phase 2 slices.
 | `features/file-loading.js` | typed the `openTab` DI callback + `FileReader` result; cast the file input / url input to `HTMLInputElement` |
 | `features/toc.js` | null-guards on `markdown-content`; `HTMLElement` cast for `offsetTop`; typed `activeId` |
 | `features/search.js` | typed the match/highlight node arrays; `textContent || ''` for the regex/walker paths; `HTMLInputElement` cast |
+| `features/annotations.js` | typed the localStorage record + DOM-handler params; `String(idx)` for `setAttribute`; `e.currentTarget`/`e.target` casts |
+| `features/repo-browser.js` | fixed the malformed `@returns` typedef into a `RepoFile` type; guarded/cast the modal query results |
+| `core/render-config.js` | typed the cached `loadMermaid` promise; the marked renderer's `string \| false` return type-checks cleanly |
+| `features/tabs.js` | typed the 5 DI callbacks + the `Tab` literal; null-safe `setText`/`setHtml`/`setDisplay` DOM helpers; `parseInt(... \|\| '')` |
+| `core/highlight.js` | trivial — the curated grammar registry checks as-is |
 
-That's **13 of ~25 source modules** now type-checked (core/platform, core/state,
-core/utils, toast, command-palette, shortcuts from before, plus these ten).
+That's **21 of ~25 source modules** now type-checked (core/platform, core/state,
+core/utils, toast, command-palette, shortcuts from before, plus these fifteen).
+The only holdouts are the four heaviest — `features/diagrams.js` (the
+panzoom/fullscreen engine), `platform/desktop.js`, `platform/ios-chrome.js`, and
+the `main.js` wiring hub — left for a later, careful batch.
 
 ## Patterns established for the DOM-heavy modules
 

--- a/docs/project-modernization/2026-06-14-tasks-session-09-typescript-batch2.md
+++ b/docs/project-modernization/2026-06-14-tasks-session-09-typescript-batch2.md
@@ -20,9 +20,13 @@ visual-review Phase 2 slices.
 | `features/view-mode.js` | typed the `renderPreview`/`cleanupPanzoom` DI callbacks; null-guard on `markdown-content` |
 | `features/diagram-export.js` | cast the complex-selector `querySelector` to `SVGElement`; null-guards on the 2D context and `toBlob` result |
 | `features/minimap.js` | cast `getElementById` to `HTMLCanvasElement`; null-guard on the 2D context |
+| `features/theme.js` | typed `THEME_ORDER` as the preference union; `setTheme` narrows the incoming string via `.find` |
+| `features/file-loading.js` | typed the `openTab` DI callback + `FileReader` result; cast the file input / url input to `HTMLInputElement` |
+| `features/toc.js` | null-guards on `markdown-content`; `HTMLElement` cast for `offsetTop`; typed `activeId` |
+| `features/search.js` | typed the match/highlight node arrays; `textContent || ''` for the regex/walker paths; `HTMLInputElement` cast |
 
-That's **9 of ~25 source modules** now type-checked (core/platform, core/state,
-core/utils, toast, command-palette, shortcuts from before, plus these six).
+That's **13 of ~25 source modules** now type-checked (core/platform, core/state,
+core/utils, toast, command-palette, shortcuts from before, plus these ten).
 
 ## Patterns established for the DOM-heavy modules
 

--- a/docs/project-modernization/README.md
+++ b/docs/project-modernization/README.md
@@ -17,7 +17,7 @@ three-lens evaluation of the app at v0.0.82 and a phased roadmap.
 | 2026-06-14 | [tasks-session-06-phase2-toasts-a11y](2026-06-14-tasks-session-06-phase2-toasts-a11y.md) | Phase 2 slice 1: accessible toast system replaces all `alert()` calls + accessibility pass (skip link, aria-labels on icon-only controls, decorative-icon hiding, reduced-motion); +22 tests |
 | 2026-06-14 | [tasks-session-07-phase2-theme-motion](2026-06-14-tasks-session-07-phase2-theme-motion.md) | Phase 2 slice 2: auto/system theme (3-way light→dark→auto cycle, `prefers-color-scheme` with live OS updates) + global reduced-motion; +5 tests |
 | 2026-06-14 | [tasks-session-08-phase2-command-palette](2026-06-14-tasks-session-08-phase2-command-palette.md) | Phase 2 slice 3: command palette (Cmd/Ctrl+K, fuzzy filter, keyboard nav, ARIA combobox/listbox) + keyboard shortcut sheet (`?`); +21 tests |
-| 2026-06-14 | [tasks-session-09-typescript-batch2](2026-06-14-tasks-session-09-typescript-batch2.md) | Gradual TypeScript batch 2: `// @ts-check` opt-in for 10 more modules — custom-css, split-view, share-links, view-mode, diagram-export, minimap, theme, file-loading, toc, search (13/~25 checked); no behavior change |
+| 2026-06-14 | [tasks-session-09-typescript-batch2](2026-06-14-tasks-session-09-typescript-batch2.md) | Gradual TypeScript batch 2: `// @ts-check` opt-in for 15 more modules (custom-css, split-view, share-links, view-mode, diagram-export, minimap, theme, file-loading, toc, search, annotations, repo-browser, render-config, tabs, highlight) — 21/~25 checked; no behavior change |
 
 ## Current Status
 

--- a/docs/project-modernization/README.md
+++ b/docs/project-modernization/README.md
@@ -17,6 +17,7 @@ three-lens evaluation of the app at v0.0.82 and a phased roadmap.
 | 2026-06-14 | [tasks-session-06-phase2-toasts-a11y](2026-06-14-tasks-session-06-phase2-toasts-a11y.md) | Phase 2 slice 1: accessible toast system replaces all `alert()` calls + accessibility pass (skip link, aria-labels on icon-only controls, decorative-icon hiding, reduced-motion); +22 tests |
 | 2026-06-14 | [tasks-session-07-phase2-theme-motion](2026-06-14-tasks-session-07-phase2-theme-motion.md) | Phase 2 slice 2: auto/system theme (3-way light→dark→auto cycle, `prefers-color-scheme` with live OS updates) + global reduced-motion; +5 tests |
 | 2026-06-14 | [tasks-session-08-phase2-command-palette](2026-06-14-tasks-session-08-phase2-command-palette.md) | Phase 2 slice 3: command palette (Cmd/Ctrl+K, fuzzy filter, keyboard nav, ARIA combobox/listbox) + keyboard shortcut sheet (`?`); +21 tests |
+| 2026-06-14 | [tasks-session-09-typescript-batch2](2026-06-14-tasks-session-09-typescript-batch2.md) | Gradual TypeScript batch 2: `// @ts-check` opt-in for custom-css, split-view, share-links, view-mode, diagram-export, minimap (9/~25 modules checked); no behavior change |
 
 ## Current Status
 

--- a/docs/project-modernization/README.md
+++ b/docs/project-modernization/README.md
@@ -17,7 +17,7 @@ three-lens evaluation of the app at v0.0.82 and a phased roadmap.
 | 2026-06-14 | [tasks-session-06-phase2-toasts-a11y](2026-06-14-tasks-session-06-phase2-toasts-a11y.md) | Phase 2 slice 1: accessible toast system replaces all `alert()` calls + accessibility pass (skip link, aria-labels on icon-only controls, decorative-icon hiding, reduced-motion); +22 tests |
 | 2026-06-14 | [tasks-session-07-phase2-theme-motion](2026-06-14-tasks-session-07-phase2-theme-motion.md) | Phase 2 slice 2: auto/system theme (3-way light→dark→auto cycle, `prefers-color-scheme` with live OS updates) + global reduced-motion; +5 tests |
 | 2026-06-14 | [tasks-session-08-phase2-command-palette](2026-06-14-tasks-session-08-phase2-command-palette.md) | Phase 2 slice 3: command palette (Cmd/Ctrl+K, fuzzy filter, keyboard nav, ARIA combobox/listbox) + keyboard shortcut sheet (`?`); +21 tests |
-| 2026-06-14 | [tasks-session-09-typescript-batch2](2026-06-14-tasks-session-09-typescript-batch2.md) | Gradual TypeScript batch 2: `// @ts-check` opt-in for custom-css, split-view, share-links, view-mode, diagram-export, minimap (9/~25 modules checked); no behavior change |
+| 2026-06-14 | [tasks-session-09-typescript-batch2](2026-06-14-tasks-session-09-typescript-batch2.md) | Gradual TypeScript batch 2: `// @ts-check` opt-in for 10 more modules — custom-css, split-view, share-links, view-mode, diagram-export, minimap, theme, file-loading, toc, search (13/~25 checked); no behavior change |
 
 ## Current Status
 

--- a/markdown-viewer/src/core/highlight.js
+++ b/markdown-viewer/src/core/highlight.js
@@ -1,3 +1,4 @@
+// @ts-check
 // Curated highlight.js build.
 //
 // The full `highlight.js` package bundles ~190 language grammars (~900 kB) and

--- a/markdown-viewer/src/core/render-config.js
+++ b/markdown-viewer/src/core/render-config.js
@@ -1,3 +1,4 @@
+// @ts-check
 // marked configuration + the lazy mermaid loader. Pure setup — no callbacks
 // back into the app.
 
@@ -57,9 +58,11 @@ export function getMermaidConfig() {
 // Under the Jest harness the module graph is flattened to globals and bare
 // imports are replaced by mocks, so a global `mermaid` stands in for the real
 // dynamic import (the `import('mermaid')` branch is never taken there).
+/** @type {Promise<any> | null} */
 let mermaidPromise = null;
 export function loadMermaid() {
   if (!mermaidPromise) {
+    /** @type {Promise<any>} */
     const source =
       typeof globalThis.mermaid !== 'undefined'
         ? Promise.resolve(globalThis.mermaid)

--- a/markdown-viewer/src/features/annotations.js
+++ b/markdown-viewer/src/features/annotations.js
@@ -1,3 +1,4 @@
+// @ts-check
 // Lightweight sticky-note annotations stored in localStorage, keyed by
 // filename. Users can double-click any paragraph or heading to add/edit one.
 // State is private to this module.
@@ -9,6 +10,10 @@ let annotationKey = '';
 
 const content = () => document.getElementById('markdown-content');
 
+/**
+ * @param {string} key
+ * @returns {Record<string, string>}
+ */
 function loadAnnotations(key) {
   try {
     const raw = localStorage.getItem(ANNOTATIONS_KEY);
@@ -19,6 +24,10 @@ function loadAnnotations(key) {
   }
 }
 
+/**
+ * @param {string} key
+ * @param {Record<string, string>} annotations
+ */
 function saveAnnotations(key, annotations) {
   try {
     const raw = localStorage.getItem(ANNOTATIONS_KEY);
@@ -50,10 +59,14 @@ export function toggleAnnotationMode() {
   }
 }
 
-/** Render saved annotation badges for a document, keyed by filename. */
+/**
+ * Render saved annotation badges for a document, keyed by filename.
+ * @param {string} key
+ */
 export function renderAnnotations(key) {
   const markdownContent = content();
   annotationKey = key;
+  if (!markdownContent) return;
   // Remove old annotation badges
   markdownContent.querySelectorAll('.annotation-badge').forEach((b) => b.remove());
 
@@ -68,28 +81,31 @@ export function renderAnnotations(key) {
 }
 
 function attachAnnotationHandlers() {
+  const root = content();
+  if (!root) return;
   // Index all annotatable elements
-  const els = content().querySelectorAll('p, h1, h2, h3, h4, h5, h6, li, blockquote');
+  const els = root.querySelectorAll('p, h1, h2, h3, h4, h5, h6, li, blockquote');
   els.forEach((el, idx) => {
-    el.setAttribute('data-annot-idx', idx);
+    el.setAttribute('data-annot-idx', String(idx));
     el.classList.add('annotatable');
     el.addEventListener('dblclick', handleAnnotationDblClick);
   });
 }
 
 function detachAnnotationHandlers() {
-  content()
-    .querySelectorAll('.annotatable')
-    .forEach((el) => {
-      el.removeEventListener('dblclick', handleAnnotationDblClick);
-      el.classList.remove('annotatable');
-    });
+  const root = content();
+  if (!root) return;
+  root.querySelectorAll('.annotatable').forEach((el) => {
+    el.removeEventListener('dblclick', handleAnnotationDblClick);
+    el.classList.remove('annotatable');
+  });
 }
 
+/** @param {Event} e */
 function handleAnnotationDblClick(e) {
   if (!annotationMode) return;
-  const el = e.currentTarget;
-  const idx = parseInt(el.getAttribute('data-annot-idx'), 10);
+  const el = /** @type {HTMLElement} */ (e.currentTarget);
+  const idx = parseInt(el.getAttribute('data-annot-idx') || '', 10);
   const annotations = loadAnnotations(annotationKey);
   const existing = annotations[idx] || '';
 
@@ -107,12 +123,17 @@ function handleAnnotationDblClick(e) {
   saveAnnotations(annotationKey, annotations);
 }
 
+/**
+ * @param {Element} el
+ * @param {number} idx
+ * @param {string} text
+ */
 function attachAnnotationBadge(el, idx, text) {
   // Remove existing badge first
   const existing = el.querySelector('.annotation-badge');
   if (existing) existing.remove();
 
-  el.setAttribute('data-annot-idx', idx);
+  el.setAttribute('data-annot-idx', String(idx));
   el.classList.add('has-annotation');
 
   const badge = document.createElement('span');
@@ -126,6 +147,10 @@ function attachAnnotationBadge(el, idx, text) {
   el.appendChild(badge);
 }
 
+/**
+ * @param {HTMLElement} anchor
+ * @param {string} text
+ */
 function showAnnotationPopover(anchor, text) {
   let popover = document.getElementById('annotation-popover');
   if (!popover) {
@@ -134,15 +159,18 @@ function showAnnotationPopover(anchor, text) {
     popover.className = 'annotation-popover';
     document.body.appendChild(popover);
   }
-  popover.textContent = text;
+  const box = popover;
+  box.textContent = text;
   const rect = anchor.getBoundingClientRect();
-  popover.style.top = rect.bottom + window.scrollY + 4 + 'px';
-  popover.style.left = rect.left + window.scrollX + 'px';
-  popover.style.display = '';
+  box.style.top = rect.bottom + window.scrollY + 4 + 'px';
+  box.style.left = rect.left + window.scrollX + 'px';
+  box.style.display = '';
 
+  /** @param {Event} e */
   const hide = (e) => {
-    if (!popover.contains(e.target) && e.target !== anchor) {
-      popover.style.display = 'none';
+    const target = /** @type {Node} */ (e.target);
+    if (!box.contains(target) && e.target !== anchor) {
+      box.style.display = 'none';
       document.removeEventListener('click', hide);
     }
   };

--- a/markdown-viewer/src/features/custom-css.js
+++ b/markdown-viewer/src/features/custom-css.js
@@ -1,7 +1,10 @@
+// @ts-check
 // Custom CSS themes (desktop): inject a user-supplied stylesheet into the page.
 
+/** @type {HTMLStyleElement | null} */
 let customStyleEl = null;
 
+/** @param {string} cssContent */
 export function applyCustomCss(cssContent) {
   if (!customStyleEl) {
     customStyleEl = document.createElement('style');

--- a/markdown-viewer/src/features/diagram-export.js
+++ b/markdown-viewer/src/features/diagram-export.js
@@ -1,3 +1,4 @@
+// @ts-check
 // Diagram export: download a rendered Mermaid diagram as SVG or PNG.
 
 import { getSvgNaturalDimensions } from '../core/utils.js';
@@ -16,7 +17,9 @@ function getSvgElementForDiagram(diagramId) {
     if (inWrapper) return inWrapper;
   }
   return fullscreenOverlay
-    ? fullscreenOverlay.querySelector('.fullscreen-diagram-wrapper svg')
+    ? /** @type {SVGElement | null} */ (
+        fullscreenOverlay.querySelector('.fullscreen-diagram-wrapper svg')
+      )
     : null;
 }
 
@@ -36,7 +39,10 @@ function triggerDownload(blob, filename) {
   setTimeout(() => URL.revokeObjectURL(url), 1000);
 }
 
-/** Download the diagram as an SVG file. */
+/**
+ * Download the diagram as an SVG file.
+ * @param {string} diagramId
+ */
 export function downloadDiagramSvg(diagramId) {
   const svgEl = getSvgElementForDiagram(diagramId);
   if (!svgEl) return;
@@ -47,7 +53,10 @@ export function downloadDiagramSvg(diagramId) {
   triggerDownload(blob, (diagramId || 'diagram') + '.svg');
 }
 
-/** Download the diagram as a 2x (retina) PNG file. */
+/**
+ * Download the diagram as a 2x (retina) PNG file.
+ * @param {string} diagramId
+ */
 export function downloadDiagramPng(diagramId) {
   const svgEl = getSvgElementForDiagram(diagramId);
   if (!svgEl) return;
@@ -66,11 +75,15 @@ export function downloadDiagramPng(diagramId) {
     canvas.width = (dims ? dims.width : img.naturalWidth || 800) * scale;
     canvas.height = (dims ? dims.height : img.naturalHeight || 600) * scale;
     const ctx = canvas.getContext('2d');
+    if (!ctx) {
+      URL.revokeObjectURL(url);
+      return;
+    }
     ctx.scale(scale, scale);
     ctx.drawImage(img, 0, 0);
     URL.revokeObjectURL(url);
     canvas.toBlob((pngBlob) => {
-      triggerDownload(pngBlob, (diagramId || 'diagram') + '.png');
+      if (pngBlob) triggerDownload(pngBlob, (diagramId || 'diagram') + '.png');
     }, 'image/png');
   };
   img.onerror = () => URL.revokeObjectURL(url);

--- a/markdown-viewer/src/features/file-loading.js
+++ b/markdown-viewer/src/features/file-loading.js
@@ -1,3 +1,4 @@
+// @ts-check
 // Loading markdown from local files (browse / drop) and from URLs (incl. the
 // GitHub repo browser). Opening content creates a tab (tabs core, main.js),
 // supplied via configureFileLoading.
@@ -7,25 +8,32 @@ import { handleRepoUrl } from './repo-browser.js';
 import { showToast } from './toast.js';
 
 const VALID_EXTENSIONS = ['.md', '.markdown'];
-const el = (id) => document.getElementById(id);
+const el = (/** @type {string} */ id) => document.getElementById(id);
 
+/** @type {(filename: string, content?: string, filePath?: string | null) => void} */
 let openTab = () => {};
 
+/** @param {{ createTab?: Function }} [deps] */
 export function configureFileLoading(deps) {
-  if (deps && typeof deps.createTab === 'function') openTab = deps.createTab;
+  if (deps && typeof deps.createTab === 'function') {
+    openTab = /** @type {typeof openTab} */ (deps.createTab);
+  }
 }
 
+/** @param {Event} e */
 export function handleFileSelect(e) {
-  const files = e.target.files;
-  for (let i = 0; i < files.length; i++) {
-    handleFile(files[i]);
+  const input = /** @type {HTMLInputElement} */ (e.target);
+  const files = input.files;
+  if (files) {
+    for (let i = 0; i < files.length; i++) {
+      handleFile(files[i]);
+    }
   }
   // Reset so the same file can be re-opened in a new tab
-  if (e.target && 'value' in e.target) {
-    e.target.value = '';
-  }
+  input.value = '';
 }
 
+/** @param {File & { path?: string }} file */
 export function handleFile(file) {
   // Validate file type
   const fileExtension = file.name.substring(file.name.lastIndexOf('.')).toLowerCase();
@@ -37,8 +45,8 @@ export function handleFile(file) {
 
   // Read file and open in a new tab
   const reader = new FileReader();
-  reader.onload = (e) => {
-    const content = e.target.result;
+  reader.onload = () => {
+    const content = /** @type {string} */ (reader.result);
     openTab(file.name, content, file.path || null);
   };
   reader.onerror = () => {
@@ -47,6 +55,7 @@ export function handleFile(file) {
   reader.readAsText(file);
 }
 
+/** @param {string} url */
 function getFilenameFromUrl(url) {
   try {
     const pathname = new URL(url).pathname;
@@ -60,6 +69,7 @@ function getFilenameFromUrl(url) {
   return 'untitled.md';
 }
 
+/** @param {string} message */
 function showUrlError(message) {
   const urlError = el('url-error');
   if (!urlError) return;
@@ -74,6 +84,7 @@ function clearUrlError() {
   urlError.textContent = '';
 }
 
+/** @param {string} url */
 export async function handleUrl(url) {
   clearUrlError();
 
@@ -82,7 +93,7 @@ export async function handleUrl(url) {
     return;
   }
 
-  const urlInput = el('url-input');
+  const urlInput = /** @type {HTMLInputElement | null} */ (el('url-input'));
 
   // Check if this is a GitHub repo URL to show the file browser
   const isRepoBrowserUrl = /^https?:\/\/github\.com\/[^/]+\/[^/]+\/?$/.test(url);

--- a/markdown-viewer/src/features/minimap.js
+++ b/markdown-viewer/src/features/minimap.js
@@ -1,12 +1,18 @@
+// @ts-check
 // Diagram minimap (shown in the fullscreen overlay): a scaled-down render of
 // the diagram plus a viewport indicator reflecting the current pan/zoom.
 
 import { getSvgNaturalDimensions } from '../core/utils.js';
 
-/** Render the diagram SVG into the minimap canvas. */
+/**
+ * Render the diagram SVG into the minimap canvas.
+ * @param {SVGElement} svgElement
+ */
 export function updateMinimap(svgElement) {
   const minimapEl = document.getElementById('fullscreen-minimap');
-  const canvas = document.getElementById('minimap-canvas');
+  const canvas = /** @type {HTMLCanvasElement | null} */ (
+    document.getElementById('minimap-canvas')
+  );
   if (!minimapEl || !canvas) return;
 
   const dims = getSvgNaturalDimensions(svgElement);
@@ -32,6 +38,10 @@ export function updateMinimap(svgElement) {
   const img = new Image();
   img.onload = () => {
     const ctx = canvas.getContext('2d');
+    if (!ctx) {
+      URL.revokeObjectURL(url);
+      return;
+    }
     ctx.clearRect(0, 0, canvas.width, canvas.height);
     ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
     URL.revokeObjectURL(url);
@@ -40,10 +50,16 @@ export function updateMinimap(svgElement) {
   img.src = url;
 }
 
-/** Position the minimap viewport rectangle for the current pan/zoom. */
+/**
+ * Position the minimap viewport rectangle for the current pan/zoom.
+ * @param {any} panzoomInstance
+ * @param {HTMLElement} wrapper
+ */
 export function updateMinimapViewport(panzoomInstance, wrapper) {
   const viewportEl = document.getElementById('minimap-viewport');
-  const canvas = document.getElementById('minimap-canvas');
+  const canvas = /** @type {HTMLCanvasElement | null} */ (
+    document.getElementById('minimap-canvas')
+  );
   if (!viewportEl || !canvas || !panzoomInstance) return;
 
   const pan = panzoomInstance.getPan();

--- a/markdown-viewer/src/features/repo-browser.js
+++ b/markdown-viewer/src/features/repo-browser.js
@@ -1,3 +1,4 @@
+// @ts-check
 // GitHub repo file browser: accept a github.com/<owner>/<repo> URL and show a
 // list of the repo's markdown files to pick from.
 //
@@ -7,9 +8,17 @@
 import { escapeHtml } from '../core/utils.js';
 
 /**
+ * @typedef {object} RepoFile
+ * @property {string} path
+ * @property {string} url
+ * @property {string} rawUrl
+ */
+
+/**
  * Fetch the markdown files for a GitHub repo URL via the Search API.
- * @returns {Promise<Array<{path,url,rawUrl}>|null>} files, [] if none, or null
- *   when the URL isn't a recognized repo URL / the fetch failed.
+ * @param {string} repoUrl
+ * @returns {Promise<RepoFile[] | null>} files, [] if none, or null when the URL
+ *   isn't a recognized repo URL / the fetch failed.
  */
 export async function fetchGitHubRepoFiles(repoUrl) {
   // Match: https://github.com/<owner>/<repo>
@@ -31,7 +40,7 @@ export async function fetchGitHubRepoFiles(repoUrl) {
     const data = await resp.json();
     if (!data.items || data.items.length === 0) return [];
 
-    return data.items.map((item) => ({
+    return data.items.map((/** @type {any} */ item) => ({
       path: item.path,
       url: item.html_url,
       rawUrl: `https://raw.githubusercontent.com/${owner}/${repo}/HEAD/${item.path}`,
@@ -63,6 +72,11 @@ export async function handleRepoUrl(url, { clearError, showError, onSelectFile }
   return true;
 }
 
+/**
+ * @param {RepoFile[]} files
+ * @param {string} repoUrl
+ * @param {Function} onSelectFile
+ */
 function showRepoBrowser(files, repoUrl, onSelectFile) {
   let modal = document.getElementById('repo-browser-modal');
   if (!modal) {
@@ -71,10 +85,11 @@ function showRepoBrowser(files, repoUrl, onSelectFile) {
     modal.className = 'repo-browser-modal';
     document.body.appendChild(modal);
   }
+  const panel = modal;
 
   const repoName = repoUrl.replace(/^https?:\/\/github\.com\//, '').replace(/\/$/, '');
 
-  modal.innerHTML = `
+  panel.innerHTML = `
         <div class="repo-browser-content">
             <div class="repo-browser-header">
                 <span class="repo-browser-title">${escapeHtml(repoName)}</span>
@@ -97,30 +112,39 @@ function showRepoBrowser(files, repoUrl, onSelectFile) {
             </ul>
         </div>
     `;
-  modal.style.display = 'flex';
+  panel.style.display = 'flex';
 
-  modal.querySelector('.repo-browser-close').addEventListener('click', () => {
-    modal.style.display = 'none';
-  });
-
-  modal.addEventListener('click', (e) => {
-    if (e.target === modal) modal.style.display = 'none';
-  });
-
-  const filterInput = modal.querySelector('.repo-browser-filter');
-  filterInput.addEventListener('input', () => {
-    const q = filterInput.value.toLowerCase();
-    modal.querySelectorAll('.repo-browser-item').forEach((item) => {
-      const path = item.querySelector('.repo-file-path').textContent.toLowerCase();
-      item.style.display = path.includes(q) ? '' : 'none';
+  const closeBtn = panel.querySelector('.repo-browser-close');
+  if (closeBtn) {
+    closeBtn.addEventListener('click', () => {
+      panel.style.display = 'none';
     });
-  });
-  filterInput.focus();
+  }
 
-  modal.querySelectorAll('.repo-browser-item').forEach((item) => {
+  panel.addEventListener('click', (e) => {
+    if (e.target === panel) panel.style.display = 'none';
+  });
+
+  const filterInput = /** @type {HTMLInputElement | null} */ (
+    panel.querySelector('.repo-browser-filter')
+  );
+  if (filterInput) {
+    filterInput.addEventListener('input', () => {
+      const q = filterInput.value.toLowerCase();
+      panel.querySelectorAll('.repo-browser-item').forEach((node) => {
+        const item = /** @type {HTMLElement} */ (node);
+        const pathEl = item.querySelector('.repo-file-path');
+        const path = (pathEl?.textContent || '').toLowerCase();
+        item.style.display = path.includes(q) ? '' : 'none';
+      });
+    });
+    filterInput.focus();
+  }
+
+  panel.querySelectorAll('.repo-browser-item').forEach((item) => {
     item.addEventListener('click', () => {
       const rawUrl = item.getAttribute('data-raw-url');
-      modal.style.display = 'none';
+      panel.style.display = 'none';
       onSelectFile(rawUrl);
     });
   });

--- a/markdown-viewer/src/features/search.js
+++ b/markdown-viewer/src/features/search.js
@@ -1,12 +1,16 @@
+// @ts-check
 // In-document search: highlight matches in the rendered markdown and navigate
 // between them. State is private to this module.
 
+/** @type {HTMLElement[]} */
 let searchMatches = [];
 let searchCurrentIndex = -1;
+/** @type {HTMLElement[]} */
 let searchHighlightNodes = [];
 
-const el = (id) => document.getElementById(id);
+const el = (/** @type {string} */ id) => document.getElementById(id);
 
+/** @param {string} str */
 function escapeRegex(str) {
   return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
@@ -38,7 +42,7 @@ export function openSearch() {
   const searchBar = el('search-bar');
   if (!searchBar) return;
   searchBar.style.display = 'flex';
-  const searchInput = el('search-input');
+  const searchInput = /** @type {HTMLInputElement | null} */ (el('search-input'));
   if (searchInput) {
     searchInput.value = '';
     searchInput.focus();
@@ -57,6 +61,7 @@ export function closeSearch() {
   updateSearchCount();
 }
 
+/** @param {string} query */
 export function runSearch(query) {
   const markdownContent = el('markdown-content');
   clearSearchHighlights();
@@ -67,6 +72,7 @@ export function runSearch(query) {
     updateSearchCount();
     return;
   }
+  if (!markdownContent) return;
 
   // Walk text nodes in markdownContent, wrap matches with <mark>
   const walker = document.createTreeWalker(markdownContent, NodeFilter.SHOW_TEXT, {
@@ -85,14 +91,14 @@ export function runSearch(query) {
   const nodesToProcess = [];
   let node;
   while ((node = walker.nextNode())) {
-    if (regex.test(node.textContent)) {
+    if (regex.test(node.textContent || '')) {
       nodesToProcess.push(node);
     }
     regex.lastIndex = 0;
   }
 
   nodesToProcess.forEach((textNode) => {
-    const text = textNode.textContent;
+    const text = textNode.textContent || '';
     const parts = [];
     let lastIndex = 0;
     let match;
@@ -129,6 +135,7 @@ export function runSearch(query) {
   updateSearchCount();
 }
 
+/** @param {number} direction */
 export function navigateSearch(direction) {
   if (searchMatches.length === 0) return;
   searchCurrentIndex =
@@ -141,7 +148,7 @@ export function clearSearchHighlights() {
   // Unwrap all <mark> elements
   searchHighlightNodes.forEach((mark) => {
     if (mark.parentNode) {
-      const text = document.createTextNode(mark.textContent);
+      const text = document.createTextNode(mark.textContent || '');
       mark.parentNode.replaceChild(text, mark);
     }
   });

--- a/markdown-viewer/src/features/share-links.js
+++ b/markdown-viewer/src/features/share-links.js
@@ -1,3 +1,4 @@
+// @ts-check
 // Shareable diagram deep links: copy a link that encodes a Mermaid diagram's
 // source, and open such a link on load as a one-diagram document.
 //
@@ -6,10 +7,14 @@
 
 const MAX_DIAGRAM_URL_PARAM_LENGTH = 65536;
 
+/** @type {(filename: string, markdown?: string, filePath?: string | null) => void} */
 let openTab = () => {};
 
+/** @param {{ createTab?: Function }} [deps] */
 export function configureShareLinks(deps) {
-  if (deps && typeof deps.createTab === 'function') openTab = deps.createTab;
+  if (deps && typeof deps.createTab === 'function') {
+    openTab = /** @type {typeof openTab} */ (deps.createTab);
+  }
 }
 
 function showShareToast() {
@@ -21,6 +26,7 @@ function showShareToast() {
   }, 2500);
 }
 
+/** @param {string} diagramId */
 export function shareDiagramLink(diagramId) {
   const wrapper = document.getElementById('wrapper-' + diagramId);
   if (!wrapper) return;

--- a/markdown-viewer/src/features/split-view.js
+++ b/markdown-viewer/src/features/split-view.js
@@ -1,9 +1,10 @@
+// @ts-check
 // Split view: show the rendered preview alongside the raw markdown source.
 
 import { state } from '../core/state.js';
 import { syncIOSChrome } from '../platform/ios-chrome.js';
 
-const el = (id) => document.getElementById(id);
+const el = (/** @type {string} */ id) => document.getElementById(id);
 
 export function toggleSplitView() {
   state.splitViewActive = !state.splitViewActive;
@@ -28,6 +29,7 @@ export function toggleSplitView() {
   syncIOSChrome();
 }
 
+/** @param {string} content */
 export function updateSplitRawPane(content) {
   const splitRawContent = el('split-raw-content');
   if (!splitRawContent) return;

--- a/markdown-viewer/src/features/tabs.js
+++ b/markdown-viewer/src/features/tabs.js
@@ -1,3 +1,4 @@
+// @ts-check
 // Tab management: the open-document model (create / switch / close), the tab
 // bar UI, and the empty-state drop zone reset.
 //
@@ -24,23 +25,54 @@ import {
   closeIOSTocSheet,
 } from '../platform/ios-chrome.js';
 
+/** @typedef {import('../core/state.js').Tab} Tab */
+
 const MAX_TABS = 10;
-const el = (id) => document.getElementById(id);
+const el = (/** @type {string} */ id) => document.getElementById(id);
+
+// Small null-safe DOM setters (every getElementById is `HTMLElement | null`).
+const setText = (/** @type {string} */ id, /** @type {string} */ text) => {
+  const e = el(id);
+  if (e) e.textContent = text;
+};
+const setHtml = (/** @type {string} */ id, /** @type {string} */ html) => {
+  const e = el(id);
+  if (e) e.innerHTML = html;
+};
+const setDisplay = (/** @type {string} */ id, /** @type {string} */ value) => {
+  const e = el(id);
+  if (e) e.style.display = value;
+};
 
 // Render-core / desktop callbacks, wired by configureTabs in init().
+/** @type {(content: string, filename: string) => any} */
 let renderDoc = () => {};
+/** @type {() => void} */
 let refreshWatchUI = () => {};
+/** @type {() => void} */
 let persistSession = () => {};
+/** @type {(filePath?: string | null) => void} */
 let beginWatch = () => {};
+/** @type {(filePath?: string | null) => void} */
 let endWatch = () => {};
 
+/**
+ * @param {{ renderMarkdown?: Function, updateWatchToggle?: Function,
+ *   saveDesktopSession?: Function, startWatchingFilePath?: Function,
+ *   stopWatchingFilePath?: Function }} [deps]
+ */
 export function configureTabs(deps) {
   if (!deps) return;
-  if (typeof deps.renderMarkdown === 'function') renderDoc = deps.renderMarkdown;
-  if (typeof deps.updateWatchToggle === 'function') refreshWatchUI = deps.updateWatchToggle;
-  if (typeof deps.saveDesktopSession === 'function') persistSession = deps.saveDesktopSession;
-  if (typeof deps.startWatchingFilePath === 'function') beginWatch = deps.startWatchingFilePath;
-  if (typeof deps.stopWatchingFilePath === 'function') endWatch = deps.stopWatchingFilePath;
+  if (typeof deps.renderMarkdown === 'function')
+    renderDoc = /** @type {typeof renderDoc} */ (deps.renderMarkdown);
+  if (typeof deps.updateWatchToggle === 'function')
+    refreshWatchUI = /** @type {typeof refreshWatchUI} */ (deps.updateWatchToggle);
+  if (typeof deps.saveDesktopSession === 'function')
+    persistSession = /** @type {typeof persistSession} */ (deps.saveDesktopSession);
+  if (typeof deps.startWatchingFilePath === 'function')
+    beginWatch = /** @type {typeof beginWatch} */ (deps.startWatchingFilePath);
+  if (typeof deps.stopWatchingFilePath === 'function')
+    endWatch = /** @type {typeof endWatch} */ (deps.stopWatchingFilePath);
 }
 
 function saveActiveTabState() {
@@ -86,8 +118,9 @@ export function renderTabBar() {
 
   tabBar.querySelectorAll('.tab').forEach((tabEl) => {
     tabEl.addEventListener('click', (e) => {
-      if (e.target.classList.contains('tab-close')) return;
-      const id = parseInt(tabEl.getAttribute('data-tab-id'), 10);
+      const target = /** @type {HTMLElement} */ (e.target);
+      if (target.classList.contains('tab-close')) return;
+      const id = parseInt(tabEl.getAttribute('data-tab-id') || '', 10);
       switchTab(id);
     });
   });
@@ -95,7 +128,7 @@ export function renderTabBar() {
   tabBar.querySelectorAll('.tab-close').forEach((btn) => {
     btn.addEventListener('click', (e) => {
       e.stopPropagation();
-      const id = parseInt(btn.getAttribute('data-close-id'), 10);
+      const id = parseInt(btn.getAttribute('data-close-id') || '', 10);
       closeTab(id);
     });
   });
@@ -110,6 +143,11 @@ export function renderTabBar() {
   }
 }
 
+/**
+ * @param {string} filename
+ * @param {string} content
+ * @param {string | null} [filePath]
+ */
 export function createTab(filename, content, filePath) {
   if (state.tabs.length >= MAX_TABS) {
     showToast('Maximum of ' + MAX_TABS + ' tabs reached. Close a tab to open another file.', {
@@ -122,6 +160,7 @@ export function createTab(filename, content, filePath) {
   saveActiveTabState();
 
   const id = ++state.nextTabId;
+  /** @type {Tab} */
   const tab = {
     id,
     filename,
@@ -147,6 +186,7 @@ export function createTab(filename, content, filePath) {
   renderDoc(content, filename);
 }
 
+/** @param {number} id */
 export async function switchTab(id) {
   if (id === state.activeTabId) return;
 
@@ -163,6 +203,7 @@ export async function switchTab(id) {
   cleanupPanzoomInstances();
 
   const markdownContent = el('markdown-content');
+  if (!markdownContent) return;
 
   if (tab.viewMode === 'raw') {
     if (state.tocVisible) {
@@ -175,9 +216,9 @@ export async function switchTab(id) {
       .replace(/</g, '&lt;')
       .replace(/>/g, '&gt;');
     markdownContent.innerHTML = `<pre class="raw-markdown"><code>${escaped}</code></pre>`;
-    el('file-name').textContent = tab.filename;
-    el('drop-zone').style.display = 'none';
-    el('content-area').style.display = 'flex';
+    setText('file-name', tab.filename);
+    setDisplay('drop-zone', 'none');
+    setDisplay('content-area', 'flex');
     updateViewToggleButton();
     markdownContent.scrollTop = tab.scrollTop;
     syncIOSChrome();
@@ -187,6 +228,7 @@ export async function switchTab(id) {
   }
 }
 
+/** @param {number} id */
 export async function closeTab(id) {
   const idx = state.tabs.findIndex((t) => t.id === id);
   if (idx === -1) return;
@@ -229,10 +271,10 @@ export async function closeTab(id) {
         .replace(/&/g, '&amp;')
         .replace(/</g, '&lt;')
         .replace(/>/g, '&gt;');
-      el('markdown-content').innerHTML = `<pre class="raw-markdown"><code>${escaped}</code></pre>`;
-      el('file-name').textContent = newTab.filename;
-      el('drop-zone').style.display = 'none';
-      el('content-area').style.display = 'flex';
+      setHtml('markdown-content', `<pre class="raw-markdown"><code>${escaped}</code></pre>`);
+      setText('file-name', newTab.filename);
+      setDisplay('drop-zone', 'none');
+      setDisplay('content-area', 'flex');
       updateViewToggleButton();
       syncIOSChrome();
     } else {
@@ -252,9 +294,10 @@ export function showDropZone() {
   closeIOSTocSheet();
 
   // Clear content
-  el('markdown-content').innerHTML = '';
-  el('file-name').textContent = '';
-  el('file-input').value = '';
+  setHtml('markdown-content', '');
+  setText('file-name', '');
+  const fileInput = /** @type {HTMLInputElement | null} */ (el('file-input'));
+  if (fileInput) fileInput.value = '';
   state.currentRawMarkdown = '';
   state.currentViewMode = 'preview';
   updateViewToggleButton();
@@ -276,7 +319,7 @@ export function showDropZone() {
   if (tocSidebar) tocSidebar.style.display = 'none';
 
   // Show drop zone, hide content
-  el('content-area').style.display = 'none';
-  el('drop-zone').style.display = 'flex';
+  setDisplay('content-area', 'none');
+  setDisplay('drop-zone', 'flex');
   syncIOSChrome();
 }

--- a/markdown-viewer/src/features/theme.js
+++ b/markdown-viewer/src/features/theme.js
@@ -1,3 +1,4 @@
+// @ts-check
 // Theme: light / dark / auto (system). The mermaid re-render on theme change
 // lives in the render core (main.js), so it's supplied via configureTheme to
 // avoid a back-import.
@@ -10,17 +11,22 @@
 import { state } from '../core/state.js';
 import { syncIOSChrome } from '../platform/ios-chrome.js';
 
-const el = (id) => document.getElementById(id);
+const el = (/** @type {string} */ id) => document.getElementById(id);
 
 // Click order for the toggle button: light → dark → auto → light.
+/** @type {Array<'light' | 'dark' | 'auto'>} */
 const THEME_ORDER = ['light', 'dark', 'auto'];
 
+/** @type {() => void} */
 let reRenderDiagrams = () => {};
 
-/** Wire the render-core callback used when the theme changes. */
+/**
+ * Wire the render-core callback used when the theme changes.
+ * @param {{ reRenderDiagrams?: Function }} [deps]
+ */
 export function configureTheme(deps) {
   if (deps && typeof deps.reRenderDiagrams === 'function') {
-    reRenderDiagrams = deps.reRenderDiagrams;
+    reRenderDiagrams = /** @type {() => void} */ (deps.reRenderDiagrams);
   }
 }
 
@@ -30,7 +36,11 @@ function systemPrefersDark() {
   );
 }
 
-/** Resolve a preference to the concrete theme to apply. */
+/**
+ * Resolve a preference to the concrete theme to apply.
+ * @param {'light' | 'dark' | 'auto'} preference
+ * @returns {'light' | 'dark'}
+ */
 function resolveTheme(preference) {
   if (preference === 'auto') return systemPrefersDark() ? 'dark' : 'light';
   return preference === 'dark' ? 'dark' : 'light';
@@ -103,6 +113,6 @@ export function toggleTheme() {
 
 // iOS API: called by the Swift shell to set the theme externally.
 window.setTheme = function (theme) {
-  state.themePreference = THEME_ORDER.includes(theme) ? theme : 'light';
+  state.themePreference = THEME_ORDER.find((t) => t === theme) || 'light';
   applyTheme(true);
 };

--- a/markdown-viewer/src/features/toc.js
+++ b/markdown-viewer/src/features/toc.js
@@ -1,3 +1,4 @@
+// @ts-check
 // Table of contents: builds a heading outline, toggles the sidebar (or the iOS
 // sheet), and runs scroll-spy to highlight the active heading.
 
@@ -10,13 +11,14 @@ import {
   setIOSSheetVisibility,
 } from '../platform/ios-chrome.js';
 
-const el = (id) => document.getElementById(id);
+const el = (/** @type {string} */ id) => document.getElementById(id);
 
 export function buildToc() {
   const tocNav = el('toc-nav');
   const iosTocNav = el('ios-toc-nav');
   if (!tocNav && !iosTocNav) return;
   const markdownContent = el('markdown-content');
+  if (!markdownContent) return;
   const headings = markdownContent.querySelectorAll('h1, h2, h3, h4');
   state.tocEntries = [];
 
@@ -50,6 +52,7 @@ export function buildToc() {
   syncIOSChrome();
 }
 
+/** @param {HTMLElement | null} navElement */
 function renderTocNavigation(navElement) {
   if (!navElement) return;
   navElement.innerHTML = '';
@@ -72,6 +75,7 @@ function renderTocNavigation(navElement) {
   });
 }
 
+/** @param {boolean} [forceState] */
 export function toggleToc(forceState) {
   const nextVisible = typeof forceState === 'boolean' ? forceState : !state.tocVisible;
   if (isIOSNative && nextVisible && (state.currentViewMode !== 'preview' || state.tocEntries.length === 0)) {
@@ -108,13 +112,16 @@ export function scheduleTocActiveHeadingUpdate() {
 function updateTocActiveHeading() {
   if (!state.tocVisible) return;
   const markdownContent = el('markdown-content');
+  if (!markdownContent) return;
   const headings = markdownContent.querySelectorAll('h1, h2, h3, h4');
   const scrollTop = markdownContent.scrollTop;
+  /** @type {string | null} */
   let activeId = null;
 
   headings.forEach((h) => {
-    if (h.offsetTop - 60 <= scrollTop) {
-      activeId = h.id;
+    const heading = /** @type {HTMLElement} */ (h);
+    if (heading.offsetTop - 60 <= scrollTop) {
+      activeId = heading.id;
     }
   });
 

--- a/markdown-viewer/src/features/view-mode.js
+++ b/markdown-viewer/src/features/view-mode.js
@@ -1,3 +1,4 @@
+// @ts-check
 // Preview / raw-markdown view toggle. The preview render and panzoom cleanup
 // live in the render core (main.js) and are supplied via configureViewMode.
 
@@ -5,19 +6,27 @@ import { state } from '../core/state.js';
 import { toggleToc } from './toc.js';
 import { syncIOSChrome } from '../platform/ios-chrome.js';
 
-const el = (id) => document.getElementById(id);
+const el = (/** @type {string} */ id) => document.getElementById(id);
 
+/** @type {(content: string, title: string) => void} */
 let renderPreview = () => {};
+/** @type {() => void} */
 let cleanupPanzoom = () => {};
 
+/** @param {{ renderMarkdown?: Function, cleanupPanzoom?: Function }} [deps] */
 export function configureViewMode(deps) {
-  if (deps && typeof deps.renderMarkdown === 'function') renderPreview = deps.renderMarkdown;
-  if (deps && typeof deps.cleanupPanzoom === 'function') cleanupPanzoom = deps.cleanupPanzoom;
+  if (deps && typeof deps.renderMarkdown === 'function') {
+    renderPreview = /** @type {typeof renderPreview} */ (deps.renderMarkdown);
+  }
+  if (deps && typeof deps.cleanupPanzoom === 'function') {
+    cleanupPanzoom = /** @type {typeof cleanupPanzoom} */ (deps.cleanupPanzoom);
+  }
 }
 
 export function toggleViewMode() {
   if (!state.currentRawMarkdown) return;
   const markdownContent = el('markdown-content');
+  if (!markdownContent) return;
 
   if (state.currentViewMode === 'preview') {
     state.currentViewMode = 'raw';


### PR DESCRIPTION
Continues the per-file `// @ts-check` rollout from #121. Safe, fully-gated, **zero visual/behavior risk**. Consolidated into one PR (kept growing it rather than stacking parallel TS PRs).

## Opted in this batch (15 modules)
`custom-css`, `split-view`, `share-links`, `view-mode`, `diagram-export`, `minimap`, `theme`, `file-loading`, `toc`, `search`, `annotations`, `repo-browser`, `render-config`, `tabs`, `highlight`.

That's **21 of ~25 source modules** now type-checked. Only the four heaviest remain for a later batch: `features/diagrams.js` (panzoom/fullscreen engine), `platform/desktop.js`, `platform/ios-chrome.js`, and the `main.js` hub.

## Notables
- **`render-config.js`** — typed the cached `loadMermaid` promise; marked's `string | false` renderer return type-checks cleanly (the friction I'd flagged turned out fine).
- **`tabs.js`** — typed the 5 DI callbacks and the `Tab` object literal (via `import('../core/state.js').Tab`); added null-safe `setText`/`setHtml`/`setDisplay` helpers to replace repeated `el('x').prop` on nullable handles.
- **`repo-browser.js`** — fixed a malformed `@returns {...{path,url,rawUrl}...}` into a real `RepoFile` typedef; guarded/cast the modal query results.
- **`annotations.js`** — typed the localStorage record + DOM-handler params; `String(idx)` for `setAttribute`; `e.currentTarget`/`e.target` casts.

## Real gaps surfaced
The strict pass flagged genuine nullable-DOM paths (`markdown-content`, `getContext('2d')`, `toBlob` callback, `textContent`, modal queries). All handled with defensive early-returns / `|| ''`, so **behavior is unchanged for valid inputs** — confirmed by the suite.

## Patterns (for future batches)
- Annotate the shared `el()` helper param; cast `getElementById`/`querySelector` at the call site when using element-specific members.
- Give DI callback vars explicit function-type JSDoc so real-argument calls are checked.
- Type module-level arrays that accumulate DOM nodes (`HTMLElement[]`).
- `import('../core/state.js').Tab` resolves the shared JSDoc typedef across modules.

## Verification
**build ✓, lint ✓, typecheck ✓, 345 tests ✓** — no behavior change.

https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA