### PR TITLE
Gradual TypeScript complete: final 4 modules + flip checkJs global (25/25)

### DIFF
--- a/docs/project-modernization/2026-06-15-tasks-session-10-typescript-complete.md
+++ b/docs/project-modernization/2026-06-15-tasks-session-10-typescript-complete.md
@@ -1,0 +1,62 @@
+# Tasks — Session 10: gradual TypeScript complete (batch 3)
+
+**Date:** 2026-06-15
+**Type:** tasks (session-level implementation checklist)
+**Phase:** 1 — Architecture (the "gradual TypeScript" roadmap item — final batch)
+**Source plan:** [2026-06-13-brainstorm-modernization-evaluation.md](2026-06-13-brainstorm-modernization-evaluation.md) §6
+
+The last four (and heaviest) modules opt into `checkJs`, completing the
+migration. With every module under `markdown-viewer/src` checked, **`checkJs` is
+flipped on globally** so new files are type-checked by default. Fully gated, no
+behavior change.
+
+---
+
+## Modules opted in (the final four)
+
+| Module | Notes |
+|---|---|
+| `platform/desktop.js` | guarded the optional `window.specdown` bridge methods via a local `const bridge = window.specdown`; cast button handles to `HTMLButtonElement` for `.disabled` |
+| `platform/ios-chrome.js` | a single `iosHandler()` accessor for the WK message bridge; `HTMLButtonElement` casts for the action-bar buttons; guarded the print-clone (`cloneNode` → `HTMLElement`/`SVGElement`) |
+| `features/diagrams.js` | the heavy one — typed Panzoom (`PanzoomObject`), a `FullscreenOverlay` typedef for the overlay's expando properties, an `on()` null-safe `addEventListener` helper, `catch`-unknown handling, input/SVG casts |
+| `main.js` | `$`/`req` DOM-handle helpers (`req` casts non-null for the always-present elements used unguarded); typed input/button consts; annotated the lazy DI-callback arrow params (preserving call-time binding the tests rely on); `e.target`/drag-event casts |
+
+**Result: 25 of 25 source modules type-checked; `tsconfig.json` `checkJs: true`.**
+
+## Gotchas hit this batch
+
+- **Harness global collision (again):** a module-top `const overlay` in
+  `diagrams.js` clashed with the `let overlay` in command-palette.js /
+  shortcuts.js (all flatten to one global; last wins as `null`). `closeFullscreen`
+  is reached via `showDropZone`/`closeTab`, so the break cascaded across ~9
+  tests. Renamed to `getFsOverlay`. **Rule holds: never name a module-top
+  binding after another module's global.**
+- **`removeEventListener` options:** it doesn't accept `passive` (only
+  `addEventListener` does) — the old `{ passive: false }` on removal was a
+  silent no-op; dropped it (capture still matches).
+- **`marked.parse` returns `string | Promise<string>`** in the types; the
+  synchronous call site casts to `string`.
+- **Lazy DI arrows must stay arrows.** Tests swap globals (e.g.
+  `global.reRenderMermaidDiagrams = spy`) *after* `configure*()`, so the wiring
+  has to resolve the callee at call time. Passing the function by reference would
+  capture the original and break those tests — so the arrows are kept and their
+  params annotated instead (`(/** @type {string} */ content, …) => …`) to satisfy
+  `noImplicitAny`.
+- **Expando elements:** the fullscreen overlay carries `panzoomInstance` /
+  `fullscreenState`; typed as `HTMLElement & { … }` (not `any`, which would strip
+  `addEventListener`'s event typing).
+
+## Verification
+
+`npm run build` ✓, `npm run lint` ✓, `npm run typecheck` ✓ (now `checkJs: true`),
+`npm test` → **345 passed**. No behavior change.
+
+## What this closes
+
+The roadmap's **"gradual TypeScript"** item is done: 100% of the viewer source is
+type-checked over JSDoc (no `.ts` rewrite), enforced in CI, and on-by-default for
+new files. **Phase 1 (Architecture) is fully complete.**
+
+Next (needs the user): Phase 2 slice 4 (toolbar + design-token overhaul — visual
+review) and Phase 3 (macOS signing/notarization — Apple cert + CI secrets). See
+[handoff-next-wave](2026-06-14-handoff-next-wave.md).

--- a/docs/project-modernization/README.md
+++ b/docs/project-modernization/README.md
@@ -18,6 +18,7 @@ three-lens evaluation of the app at v0.0.82 and a phased roadmap.
 | 2026-06-14 | [tasks-session-07-phase2-theme-motion](2026-06-14-tasks-session-07-phase2-theme-motion.md) | Phase 2 slice 2: auto/system theme (3-way light→dark→auto cycle, `prefers-color-scheme` with live OS updates) + global reduced-motion; +5 tests |
 | 2026-06-14 | [tasks-session-08-phase2-command-palette](2026-06-14-tasks-session-08-phase2-command-palette.md) | Phase 2 slice 3: command palette (Cmd/Ctrl+K, fuzzy filter, keyboard nav, ARIA combobox/listbox) + keyboard shortcut sheet (`?`); +21 tests |
 | 2026-06-14 | [tasks-session-09-typescript-batch2](2026-06-14-tasks-session-09-typescript-batch2.md) | Gradual TypeScript batch 2: `// @ts-check` opt-in for 15 more modules (custom-css, split-view, share-links, view-mode, diagram-export, minimap, theme, file-loading, toc, search, annotations, repo-browser, render-config, tabs, highlight) — 21/~25 checked; no behavior change |
+| 2026-06-15 | [tasks-session-10-typescript-complete](2026-06-15-tasks-session-10-typescript-complete.md) | Gradual TypeScript **complete**: final 4 modules (desktop, ios-chrome, diagrams, main) — **25/25 checked**, `checkJs: true` flipped on globally; no behavior change |
 
 ## Current Status
 

--- a/markdown-viewer/src/features/diagrams.js
+++ b/markdown-viewer/src/features/diagrams.js
@@ -1,3 +1,4 @@
+// @ts-check
 import Panzoom from '@panzoom/panzoom';
 import DOMPurify from 'dompurify';
 import { state } from '../core/state.js';
@@ -8,14 +9,44 @@ import { updateMinimap, updateMinimapViewport } from './minimap.js';
 import { downloadDiagramSvg, downloadDiagramPng } from './diagram-export.js';
 import { shareDiagramLink } from './share-links.js';
 
-const el = (id) => document.getElementById(id);
+/** @typedef {import('@panzoom/panzoom').PanzoomObject} PanzoomObject */
+/** @typedef {{ scale: number, x: number, y: number }} HomeState */
+/**
+ * The fullscreen overlay carries expando properties set by this module.
+ * @typedef {HTMLElement & {
+ *   panzoomInstance?: any,
+ *   diagramId?: string | null,
+ *   fullscreenState?: { homeState: HomeState },
+ *   wheelHandler?: EventListener | null,
+ *   dblClickHandler?: EventListener | null,
+ * }} FullscreenOverlay
+ */
+
+const el = (/** @type {string} */ id) => document.getElementById(id);
+const getFsOverlay = () => /** @type {FullscreenOverlay | null} */ (el('fullscreen-overlay'));
+
+/**
+ * Null-safe addEventListener.
+ * @param {Element | Node | null} target
+ * @param {string} type
+ * @param {EventListener} handler
+ * @param {boolean | AddEventListenerOptions} [opts]
+ */
+const on = (target, type, handler, opts) => {
+  if (target) target.addEventListener(type, handler, opts);
+};
+
+/** @param {unknown} error */
+const errMessage = (error) => (error instanceof Error ? error.message : String(error));
 
 // ===========================
 // Mermaid Diagram Processing
 // ===========================
 export async function processMermaidDiagrams() {
+    const root = el('markdown-content');
+    if (!root) return;
     // Find all code blocks with mermaid language
-    const codeBlocks = el('markdown-content').querySelectorAll('code.language-mermaid');
+    const codeBlocks = root.querySelectorAll('code.language-mermaid');
 
     if (codeBlocks.length === 0) return;
 
@@ -26,7 +57,7 @@ export async function processMermaidDiagrams() {
     // Process each mermaid diagram
     for (let i = 0; i < codeBlocks.length; i++) {
         const codeBlock = codeBlocks[i];
-        const mermaidCode = codeBlock.textContent;
+        const mermaidCode = codeBlock.textContent || '';
         const preElement = codeBlock.parentElement;
 
         try {
@@ -40,7 +71,7 @@ export async function processMermaidDiagrams() {
             const container = createDiagramContainer(svg, diagramId, mermaidCode);
 
             // Replace pre/code block with diagram container
-            preElement.replaceWith(container);
+            if (preElement) preElement.replaceWith(container);
 
             // Initialize panzoom for this diagram
             initializePanzoom(diagramId);
@@ -51,12 +82,19 @@ export async function processMermaidDiagrams() {
             const errorDiv = document.createElement('div');
             errorDiv.className = 'mermaid-error';
             errorDiv.style.cssText = 'color: red; padding: 1rem; border: 1px solid red; border-radius: 4px; margin: 1rem 0;';
-            errorDiv.textContent = `Error rendering diagram: ${error.message}`;
-            preElement.parentElement.insertBefore(errorDiv, preElement);
+            errorDiv.textContent = `Error rendering diagram: ${errMessage(error)}`;
+            if (preElement && preElement.parentElement) {
+                preElement.parentElement.insertBefore(errorDiv, preElement);
+            }
         }
     }
 }
 
+/**
+ * @param {string} svg
+ * @param {string} diagramId
+ * @param {string | null} mermaidSource
+ */
 function createDiagramContainer(svg, diagramId, mermaidSource) {
     const container = document.createElement('div');
     container.className = 'diagram-container';
@@ -105,6 +143,12 @@ function createDiagramContainer(svg, diagramId, mermaidSource) {
 // ===========================
 // Diagram Fit Helpers
 // ===========================
+/**
+ * @param {HTMLElement} wrapper
+ * @param {SVGElement} svgElement
+ * @param {PanzoomObject} panzoomInstance
+ * @returns {HomeState}
+ */
 function fitDiagramToContainer(wrapper, svgElement, panzoomInstance) {
     const dims = getSvgNaturalDimensions(svgElement);
     const containerWidth = wrapper.clientWidth;
@@ -142,15 +186,23 @@ function fitDiagramToContainer(wrapper, svgElement, panzoomInstance) {
     return { scale: fitScale, x: x, y: y };
 }
 
+/**
+ * @param {PanzoomObject} panzoomInstance
+ * @param {HomeState} homeState
+ */
 export function resetToFit(panzoomInstance, homeState) {
     panzoomInstance.zoom(homeState.scale, { animate: true });
     panzoomInstance.pan(homeState.x, homeState.y, { animate: true });
 }
 
+/**
+ * @param {PanzoomObject | null} panzoomInstance
+ * @param {Element | null} controlsRoot
+ */
 export function updateZoomUI(panzoomInstance, controlsRoot) {
     if (!panzoomInstance || !controlsRoot) return;
     const percentEl = controlsRoot.querySelector('.zoom-percent');
-    const rangeEl = controlsRoot.querySelector('.zoom-range');
+    const rangeEl = /** @type {HTMLInputElement | null} */ (controlsRoot.querySelector('.zoom-range'));
     if (!percentEl || !rangeEl) return;
     const zoomPercent = Math.max(25, Math.min(400, Math.round(panzoomInstance.getScale() * 100)));
     percentEl.textContent = `${zoomPercent}%`;
@@ -160,6 +212,7 @@ export function updateZoomUI(panzoomInstance, controlsRoot) {
 // ===========================
 // Panzoom Initialization
 // ===========================
+/** @param {string} diagramId */
 function initializePanzoom(diagramId) {
     const wrapper = document.getElementById(`wrapper-${diagramId}`);
     if (!wrapper) return;
@@ -196,7 +249,9 @@ function initializePanzoom(diagramId) {
 
     // Get controls
     const container = wrapper.closest('.diagram-container');
+    if (!container) return;
     const controls = container.querySelector('.diagram-controls');
+    if (!controls) return;
     const zoomInBtn = controls.querySelector('.zoom-in');
     const zoomOutBtn = controls.querySelector('.zoom-out');
     const zoomRange = controls.querySelector('.zoom-range');
@@ -207,57 +262,50 @@ function initializePanzoom(diagramId) {
     const fullscreenBtn = controls.querySelector('.fullscreen');
 
     // Bind control events
-    zoomInBtn.addEventListener('click', (e) => {
+    on(zoomInBtn, 'click', (e) => {
         e.stopPropagation();
         panzoomInstance.zoomIn();
         updateZoomUI(panzoomInstance, controls);
     });
 
-    zoomOutBtn.addEventListener('click', (e) => {
+    on(zoomOutBtn, 'click', (e) => {
         e.stopPropagation();
         panzoomInstance.zoomOut();
         updateZoomUI(panzoomInstance, controls);
     });
 
-    if (zoomRange) {
-        zoomRange.addEventListener('input', (e) => {
-            e.stopPropagation();
-            const targetPercent = Number(e.target.value);
-            if (!isNaN(targetPercent)) {
-                panzoomInstance.zoom(targetPercent / 100);
-                updateZoomUI(panzoomInstance, controls);
-            }
-        });
-    }
+    on(zoomRange, 'input', (e) => {
+        e.stopPropagation();
+        const target = /** @type {HTMLInputElement} */ (e.target);
+        const targetPercent = Number(target.value);
+        if (!isNaN(targetPercent)) {
+            panzoomInstance.zoom(targetPercent / 100);
+            updateZoomUI(panzoomInstance, controls);
+        }
+    });
 
-    resetBtn.addEventListener('click', (e) => {
+    on(resetBtn, 'click', (e) => {
         e.stopPropagation();
         resetToFit(panzoomInstance, instanceState.homeState);
         updateZoomUI(panzoomInstance, controls);
     });
 
-    if (exportSvgBtn) {
-        exportSvgBtn.addEventListener('click', (e) => {
-            e.stopPropagation();
-            downloadDiagramSvg(diagramId);
-        });
-    }
+    on(exportSvgBtn, 'click', (e) => {
+        e.stopPropagation();
+        downloadDiagramSvg(diagramId);
+    });
 
-    if (exportPngBtn) {
-        exportPngBtn.addEventListener('click', (e) => {
-            e.stopPropagation();
-            downloadDiagramPng(diagramId);
-        });
-    }
+    on(exportPngBtn, 'click', (e) => {
+        e.stopPropagation();
+        downloadDiagramPng(diagramId);
+    });
 
-    if (shareBtn) {
-        shareBtn.addEventListener('click', (e) => {
-            e.stopPropagation();
-            shareDiagramLink(diagramId);
-        });
-    }
+    on(shareBtn, 'click', (e) => {
+        e.stopPropagation();
+        shareDiagramLink(diagramId);
+    });
 
-    fullscreenBtn.addEventListener('click', (e) => {
+    on(fullscreenBtn, 'click', (e) => {
         e.stopPropagation();
         openFullscreen(diagramId);
     });
@@ -280,6 +328,7 @@ function initializePanzoom(diagramId) {
 // ===========================
 // Fullscreen Management
 // ===========================
+/** @param {string} diagramId */
 function openFullscreen(diagramId) {
     const wrapper = document.getElementById(`wrapper-${diagramId}`);
     if (!wrapper) {
@@ -293,16 +342,22 @@ function openFullscreen(diagramId) {
         return;
     }
 
+    const fsOverlay = getFsOverlay();
+    if (!fsOverlay) return;
+
     // Clone SVG for fullscreen - use original mermaid source SVG attributes
-    const svgClone = svgElement.cloneNode(true);
+    const svgClone = /** @type {SVGSVGElement} */ (svgElement.cloneNode(true));
 
     // Setup fullscreen wrapper
-    const fullscreenWrapper = el('fullscreen-overlay').querySelector('.fullscreen-diagram-wrapper');
+    const fullscreenWrapper = /** @type {HTMLElement | null} */ (
+        fsOverlay.querySelector('.fullscreen-diagram-wrapper')
+    );
+    if (!fullscreenWrapper) return;
     fullscreenWrapper.innerHTML = '';
     fullscreenWrapper.appendChild(svgClone);
 
     // Show fullscreen first so container dimensions are available for fit calculation
-    el('fullscreen-overlay').style.display = 'flex';
+    fsOverlay.style.display = 'flex';
 
     // Initialize panzoom for fullscreen with wide scale range
     const fullscreenPanzoom = Panzoom(svgClone, {
@@ -321,9 +376,9 @@ function openFullscreen(diagramId) {
     });
 
     // Store for cleanup
-    el('fullscreen-overlay').panzoomInstance = fullscreenPanzoom;
-    el('fullscreen-overlay').diagramId = diagramId;
-    el('fullscreen-overlay').fullscreenState = fullscreenState;
+    fsOverlay.panzoomInstance = fullscreenPanzoom;
+    fsOverlay.diagramId = diagramId;
+    fsOverlay.fullscreenState = fullscreenState;
 
     // Setup fullscreen controls with fresh event listeners
     setupFullscreenControls(fullscreenPanzoom, fullscreenWrapper, fullscreenState);
@@ -342,11 +397,19 @@ function openFullscreen(diagramId) {
     }
 
     // Focus for keyboard events
-    el('fullscreen-overlay').focus();
+    fsOverlay.focus();
 }
 
+/**
+ * @param {PanzoomObject} panzoomInstance
+ * @param {HTMLElement} wrapper
+ * @param {{ homeState: HomeState }} fullscreenState
+ */
 function setupFullscreenControls(panzoomInstance, wrapper, fullscreenState) {
-    const controls = el('fullscreen-overlay').querySelector('.fullscreen-controls');
+    const fsOverlay = getFsOverlay();
+    if (!fsOverlay) return;
+    const controls = fsOverlay.querySelector('.fullscreen-controls');
+    if (!controls) return;
     const zoomInBtn = controls.querySelector('.zoom-in');
     const zoomOutBtn = controls.querySelector('.zoom-out');
     const zoomRange = controls.querySelector('.zoom-range');
@@ -354,12 +417,14 @@ function setupFullscreenControls(panzoomInstance, wrapper, fullscreenState) {
     const exportSvgBtn = controls.querySelector('.export-svg');
     const exportPngBtn = controls.querySelector('.export-png');
     const closeBtn = controls.querySelector('.close-fullscreen');
+    if (!zoomInBtn || !zoomOutBtn || !resetBtn || !closeBtn) return;
 
     // Remove old listeners by cloning
     const newZoomIn = zoomInBtn.cloneNode(true);
     const newZoomOut = zoomOutBtn.cloneNode(true);
     const newReset = resetBtn.cloneNode(true);
-    const newZoomRangeLabel = zoomRange ? zoomRange.closest('.zoom-range-label').cloneNode(true) : null;
+    const zoomRangeLabel = zoomRange ? zoomRange.closest('.zoom-range-label') : null;
+    const newZoomRangeLabel = zoomRangeLabel ? zoomRangeLabel.cloneNode(true) : null;
     const newExportSvg = exportSvgBtn ? exportSvgBtn.cloneNode(true) : null;
     const newExportPng = exportPngBtn ? exportPngBtn.cloneNode(true) : null;
     const newClose = closeBtn.cloneNode(true);
@@ -367,73 +432,70 @@ function setupFullscreenControls(panzoomInstance, wrapper, fullscreenState) {
     zoomInBtn.replaceWith(newZoomIn);
     zoomOutBtn.replaceWith(newZoomOut);
     resetBtn.replaceWith(newReset);
-    if (zoomRange && newZoomRangeLabel) zoomRange.closest('.zoom-range-label').replaceWith(newZoomRangeLabel);
+    if (zoomRangeLabel && newZoomRangeLabel) zoomRangeLabel.replaceWith(newZoomRangeLabel);
     if (exportSvgBtn && newExportSvg) exportSvgBtn.replaceWith(newExportSvg);
     if (exportPngBtn && newExportPng) exportPngBtn.replaceWith(newExportPng);
     closeBtn.replaceWith(newClose);
 
     // Add new listeners
-    newZoomIn.addEventListener('click', (e) => {
+    on(newZoomIn, 'click', (e) => {
         e.stopPropagation();
         panzoomInstance.zoomIn();
         updateZoomUI(panzoomInstance, controls);
     });
 
-    newZoomOut.addEventListener('click', (e) => {
+    on(newZoomOut, 'click', (e) => {
         e.stopPropagation();
         panzoomInstance.zoomOut();
         updateZoomUI(panzoomInstance, controls);
     });
 
-    newReset.addEventListener('click', (e) => {
+    on(newReset, 'click', (e) => {
         e.stopPropagation();
         resetToFit(panzoomInstance, fullscreenState.homeState);
         updateZoomUI(panzoomInstance, controls);
     });
 
     const newZoomRange = controls.querySelector('.zoom-range');
-    if (newZoomRange) {
-        newZoomRange.addEventListener('input', (e) => {
-            e.stopPropagation();
-            const targetPercent = Number(e.target.value);
-            if (!isNaN(targetPercent)) {
-                panzoomInstance.zoom(targetPercent / 100);
-                updateZoomUI(panzoomInstance, controls);
-            }
-        });
-    }
+    on(newZoomRange, 'input', (e) => {
+        e.stopPropagation();
+        const target = /** @type {HTMLInputElement} */ (e.target);
+        const targetPercent = Number(target.value);
+        if (!isNaN(targetPercent)) {
+            panzoomInstance.zoom(targetPercent / 100);
+            updateZoomUI(panzoomInstance, controls);
+        }
+    });
 
-    if (newExportSvg) {
-        newExportSvg.addEventListener('click', (e) => {
-            e.stopPropagation();
-            downloadDiagramSvg(el('fullscreen-overlay').diagramId);
-        });
-    }
+    on(newExportSvg, 'click', (e) => {
+        e.stopPropagation();
+        downloadDiagramSvg(fsOverlay.diagramId || '');
+    });
 
-    if (newExportPng) {
-        newExportPng.addEventListener('click', (e) => {
-            e.stopPropagation();
-            downloadDiagramPng(el('fullscreen-overlay').diagramId);
-        });
-    }
+    on(newExportPng, 'click', (e) => {
+        e.stopPropagation();
+        downloadDiagramPng(fsOverlay.diagramId || '');
+    });
 
-    newClose.addEventListener('click', (e) => {
+    on(newClose, 'click', (e) => {
         e.stopPropagation();
         closeFullscreen();
     });
 
     // Mouse wheel zoom - use passive: false to allow preventDefault
+    /** @type {EventListener} */
     const wheelHandler = (e) => {
         e.preventDefault();
         e.stopPropagation();
-        panzoomInstance.zoomWithWheel(e);
+        panzoomInstance.zoomWithWheel(/** @type {WheelEvent} */ (e));
         updateZoomUI(panzoomInstance, controls);
     };
 
     wrapper.addEventListener('wheel', wheelHandler, { passive: false });
-    el('fullscreen-overlay').wheelHandler = wheelHandler;
+    fsOverlay.wheelHandler = wheelHandler;
 
     // Double click to reset to fit
+    /** @type {EventListener} */
     const dblClickHandler = (e) => {
         e.stopPropagation();
         resetToFit(panzoomInstance, fullscreenState.homeState);
@@ -441,40 +503,43 @@ function setupFullscreenControls(panzoomInstance, wrapper, fullscreenState) {
     };
 
     wrapper.addEventListener('dblclick', dblClickHandler);
-    el('fullscreen-overlay').dblClickHandler = dblClickHandler;
+    fsOverlay.dblClickHandler = dblClickHandler;
     updateZoomUI(panzoomInstance, controls);
 }
 
 export function closeFullscreen() {
+    const fsOverlay = getFsOverlay();
+    if (!fsOverlay) return;
+
     // Cleanup panzoom instance
-    if (el('fullscreen-overlay').panzoomInstance) {
+    if (fsOverlay.panzoomInstance) {
         try {
-            el('fullscreen-overlay').panzoomInstance.destroy();
+            fsOverlay.panzoomInstance.destroy();
         } catch (error) {
             console.error('Error destroying fullscreen panzoom:', error);
         }
-        el('fullscreen-overlay').panzoomInstance = null;
+        fsOverlay.panzoomInstance = null;
     }
 
     // Remove event handlers
-    const fullscreenWrapper = el('fullscreen-overlay').querySelector('.fullscreen-diagram-wrapper');
+    const fullscreenWrapper = fsOverlay.querySelector('.fullscreen-diagram-wrapper');
 
-    if (el('fullscreen-overlay').wheelHandler) {
-        fullscreenWrapper.removeEventListener('wheel', el('fullscreen-overlay').wheelHandler, { passive: false });
-        el('fullscreen-overlay').wheelHandler = null;
+    if (fullscreenWrapper && fsOverlay.wheelHandler) {
+        fullscreenWrapper.removeEventListener('wheel', fsOverlay.wheelHandler);
+        fsOverlay.wheelHandler = null;
     }
 
-    if (el('fullscreen-overlay').dblClickHandler) {
-        fullscreenWrapper.removeEventListener('dblclick', el('fullscreen-overlay').dblClickHandler);
-        el('fullscreen-overlay').dblClickHandler = null;
+    if (fullscreenWrapper && fsOverlay.dblClickHandler) {
+        fullscreenWrapper.removeEventListener('dblclick', fsOverlay.dblClickHandler);
+        fsOverlay.dblClickHandler = null;
     }
 
     // Hide fullscreen
-    el('fullscreen-overlay').style.display = 'none';
+    fsOverlay.style.display = 'none';
 
     // Clear content
-    fullscreenWrapper.innerHTML = '';
-    el('fullscreen-overlay').diagramId = null;
+    if (fullscreenWrapper) fullscreenWrapper.innerHTML = '';
+    fsOverlay.diagramId = null;
 }
 
 // ===========================
@@ -495,8 +560,10 @@ export function cleanupPanzoomInstances() {
 // Re-render Mermaid (for theme change)
 // ===========================
 export async function reRenderMermaidDiagrams() {
+    const root = el('markdown-content');
+    if (!root) return;
     // Get all diagram containers
-    const containers = el('markdown-content').querySelectorAll('.diagram-container');
+    const containers = root.querySelectorAll('.diagram-container');
 
     // Nothing to re-theme means no need to pull in the mermaid engine.
     if (containers.length === 0) return;
@@ -524,19 +591,19 @@ export async function reRenderMermaidDiagrams() {
             const { svg } = await mermaid.render(`${diagramId}-rerender`, mermaidCode);
 
             // Clean up old panzoom
-            const oldInstance = state.currentPanzoomInstances.find(p => p.id === diagramId);
+            const oldInstance = state.currentPanzoomInstances.find((p) => p.id === diagramId);
             if (oldInstance) {
                 oldInstance.instance.destroy();
-                state.currentPanzoomInstances = state.currentPanzoomInstances.filter(p => p.id !== diagramId);
+                state.currentPanzoomInstances = state.currentPanzoomInstances.filter((p) => p.id !== diagramId);
             }
 
             // Update wrapper content
             // Preserve Mermaid's label markup: allow <foreignObject> (HTML labels for
-    // diagram types that use them) so DOMPurify does not strip the text.
-    wrapper.innerHTML = DOMPurify.sanitize(svg, {
-        ADD_TAGS: ['foreignObject'],
-        ADD_ATTR: ['xmlns'],
-    });
+            // diagram types that use them) so DOMPurify does not strip the text.
+            wrapper.innerHTML = DOMPurify.sanitize(svg, {
+                ADD_TAGS: ['foreignObject'],
+                ADD_ATTR: ['xmlns'],
+            });
 
             // Store mermaid source on new SVG element
             const newSvgElement = wrapper.querySelector('svg');

--- a/markdown-viewer/src/main.js
+++ b/markdown-viewer/src/main.js
@@ -1,3 +1,4 @@
+// @ts-check
 // SpecDown — shared viewer entry point.
 //
 // Phase 1 (modernization roadmap): the viewer is an ES-module graph bundled by
@@ -121,63 +122,79 @@ const SOURCE_REPO_URL = 'https://github.com/' + SOURCE_REPO;
 // ===========================
 // DOM Elements
 // ===========================
-const dropZone = document.getElementById('drop-zone');
-const fileInput = document.getElementById('file-input');
-const browseButton = document.getElementById('browse-button');
-const openSampleBasic = document.getElementById('open-sample-basic');
-const openSampleMermaid = document.getElementById('open-sample-mermaid');
-const contentArea = document.getElementById('content-area');
-const markdownContent = document.getElementById('markdown-content');
-const fileName = document.getElementById('file-name');
-const themeToggle = document.getElementById('theme-toggle');
-const fullscreenOverlay = document.getElementById('fullscreen-overlay');
-const viewToggle = document.getElementById('view-toggle');
-const urlInput = document.getElementById('url-input');
-const openUrlBtn = document.getElementById('open-url-btn');
-const urlError = document.getElementById('url-error');
-const tocToggle = document.getElementById('toc-toggle');
-const annotationToggle = document.getElementById('annotation-toggle');
-const splitToggle = document.getElementById('split-toggle');
-const splitRawPane = document.getElementById('split-raw-pane');
-const splitRawContent = document.getElementById('split-raw-content');
-const printButton = document.getElementById('print-button');
-const searchBar = document.getElementById('search-bar');
-const searchInput = document.getElementById('search-input');
-const searchPrev = document.getElementById('search-prev');
-const searchNext = document.getElementById('search-next');
-const searchClose = document.getElementById('search-close');
-const shareToast = document.getElementById('share-toast');
-const iosOpenButton = document.getElementById('ios-open-button');
-const iosContentsButton = document.getElementById('ios-contents-button');
-const iosViewButton = document.getElementById('ios-view-button');
-const iosMoreButton = document.getElementById('ios-more-button');
-const iosActionSheet = document.getElementById('ios-action-sheet');
-const iosActionSheetClose = document.getElementById('ios-action-sheet-close');
-const iosSplitButton = document.getElementById('ios-split-button');
-const iosPrintButton = document.getElementById('ios-print-button');
-const iosThemeButton = document.getElementById('ios-theme-button');
-const iosTocSheet = document.getElementById('ios-toc-sheet');
-const iosTocClose = document.getElementById('ios-toc-close');
+const $ = (/** @type {string} */ id) => document.getElementById(id);
+// `req` is for elements the app assumes always exist (used unguarded below); it
+// casts the null away. At runtime a missing element throws on first use, exactly
+// as before this typing pass.
+const req = (/** @type {string} */ id) => /** @type {HTMLElement} */ (document.getElementById(id));
+
+const dropZone = req('drop-zone');
+const fileInput = req('file-input');
+const browseButton = req('browse-button');
+const openSampleBasic = $('open-sample-basic');
+const openSampleMermaid = $('open-sample-mermaid');
+const contentArea = req('content-area');
+const markdownContent = req('markdown-content');
+const fileName = req('file-name');
+const themeToggle = req('theme-toggle');
+// The fullscreen overlay carries expando properties set by features/diagrams.js.
+const fullscreenOverlay = /** @type {HTMLElement & { panzoomInstance?: any, fullscreenState?: { homeState: { scale: number, x: number, y: number } } }} */ (
+    document.getElementById('fullscreen-overlay')
+);
+const viewToggle = req('view-toggle');
+const urlInput = /** @type {HTMLInputElement | null} */ ($('url-input'));
+const openUrlBtn = $('open-url-btn');
+const urlError = $('url-error');
+const tocToggle = $('toc-toggle');
+const annotationToggle = $('annotation-toggle');
+const splitToggle = $('split-toggle');
+const splitRawPane = $('split-raw-pane');
+const splitRawContent = $('split-raw-content');
+const printButton = $('print-button');
+const searchBar = $('search-bar');
+const searchInput = /** @type {HTMLInputElement | null} */ ($('search-input'));
+const searchPrev = $('search-prev');
+const searchNext = $('search-next');
+const searchClose = $('search-close');
+const shareToast = $('share-toast');
+const iosOpenButton = $('ios-open-button');
+const iosContentsButton = /** @type {HTMLButtonElement | null} */ ($('ios-contents-button'));
+const iosViewButton = /** @type {HTMLButtonElement | null} */ ($('ios-view-button'));
+const iosMoreButton = /** @type {HTMLButtonElement | null} */ ($('ios-more-button'));
+const iosActionSheet = $('ios-action-sheet');
+const iosActionSheetClose = $('ios-action-sheet-close');
+const iosSplitButton = /** @type {HTMLButtonElement | null} */ ($('ios-split-button'));
+const iosPrintButton = /** @type {HTMLButtonElement | null} */ ($('ios-print-button'));
+const iosThemeButton = $('ios-theme-button');
+const iosTocSheet = $('ios-toc-sheet');
+const iosTocClose = $('ios-toc-close');
 
 // ===========================
 // Initialization
 // ===========================
 function init() {
     configureTheme({ reRenderDiagrams: () => reRenderMermaidDiagrams() });
-    configureFileLoading({ createTab: (...a) => createTab(...a) });
-    configureShareLinks({ createTab: (filename, md) => createTab(filename, md) });
+    configureFileLoading({
+        createTab: (/** @type {string} */ filename, /** @type {string} */ content, /** @type {string | null} */ filePath) =>
+            createTab(filename, content, filePath),
+    });
+    configureShareLinks({
+        createTab: (/** @type {string} */ filename, /** @type {string} */ md) => createTab(filename, md),
+    });
     configureViewMode({
-        renderMarkdown: (content, title) => renderMarkdown(content, title),
+        renderMarkdown: (/** @type {string} */ content, /** @type {string} */ title) => renderMarkdown(content, title),
         cleanupPanzoom: () => cleanupPanzoomInstances(),
     });
     configureTabs({
-        renderMarkdown: (content, title) => renderMarkdown(content, title),
+        renderMarkdown: (/** @type {string} */ content, /** @type {string} */ title) => renderMarkdown(content, title),
         updateWatchToggle: () => updateWatchToggle(),
         saveDesktopSession: () => saveDesktopSession(),
-        startWatchingFilePath: (filePath) => startWatchingFilePath(filePath),
-        stopWatchingFilePath: (filePath) => stopWatchingFilePath(filePath),
+        startWatchingFilePath: (/** @type {string | null} */ filePath) => startWatchingFilePath(filePath),
+        stopWatchingFilePath: (/** @type {string | null} */ filePath) => stopWatchingFilePath(filePath),
     });
-    configureDesktop({ renderMarkdown: (content, title) => renderMarkdown(content, title) });
+    configureDesktop({
+        renderMarkdown: (/** @type {string} */ content, /** @type {string} */ title) => renderMarkdown(content, title),
+    });
     registerAppCommands();
     setupVersionInfo();
     setupTheme();
@@ -356,8 +373,9 @@ function setupEventListeners() {
 
     // Drag and drop
     dropZone.addEventListener('click', (e) => {
-        if (e.target.closest && e.target.closest('.url-section')) return;
-        if (e.target === dropZone || e.target.closest('.drop-zone-content')) {
+        const target = /** @type {HTMLElement | null} */ (e.target);
+        if (target && target.closest('.url-section')) return;
+        if (e.target === dropZone || (target && target.closest('.drop-zone-content'))) {
             if (requestNativeOpenIfAvailable()) return;
             fileInput.click();
         }
@@ -375,7 +393,7 @@ function setupEventListeners() {
 
     // TOC toggle
     if (tocToggle) {
-        tocToggle.addEventListener('click', toggleToc);
+        tocToggle.addEventListener('click', () => toggleToc());
     }
 
     // Annotation toggle (sync iOS chrome after toggling)
@@ -596,34 +614,40 @@ function setupEventListeners() {
 
 // True when the event target is a text-entry element, so global single-key
 // shortcuts (like "?") don't fire while the user is typing.
+/** @param {EventTarget | null} target */
 function isTypingTarget(target) {
     if (!target) return false;
-    const tag = target.tagName;
-    return tag === 'INPUT' || tag === 'TEXTAREA' || target.isContentEditable === true;
+    const element = /** @type {HTMLElement} */ (target);
+    const tag = element.tagName;
+    return tag === 'INPUT' || tag === 'TEXTAREA' || element.isContentEditable === true;
 }
 
 // ===========================
 // Drag and Drop Handlers
 // ===========================
+/** @param {DragEvent} e */
 function handleDragOver(e) {
     e.preventDefault();
     e.stopPropagation();
     dropZone.classList.add('drag-over');
 }
 
+/** @param {DragEvent} e */
 function handleDragLeave(e) {
     e.preventDefault();
     e.stopPropagation();
-    if (!dropZone.contains(e.relatedTarget)) {
+    if (!dropZone.contains(/** @type {Node | null} */ (e.relatedTarget))) {
         dropZone.classList.remove('drag-over');
     }
 }
 
+/** @param {DragEvent} e */
 function handleDrop(e) {
     e.preventDefault();
     e.stopPropagation();
     dropZone.classList.remove('drag-over');
 
+    if (!e.dataTransfer) return;
     const files = e.dataTransfer.files;
     for (let i = 0; i < files.length; i++) {
         handleFile(files[i]);
@@ -634,6 +658,10 @@ function handleDrop(e) {
 // ===========================
 // Markdown Rendering
 // ===========================
+/**
+ * @param {string} content
+ * @param {string} filename
+ */
 async function renderMarkdown(content, filename) {
     try {
         // Clean up existing panzoom instances
@@ -644,8 +672,8 @@ async function renderMarkdown(content, filename) {
         state.currentViewMode = 'preview';
         updateViewToggleButton();
 
-        // Parse markdown to HTML
-        const htmlContent = marked.parse(content);
+        // Parse markdown to HTML (synchronous: marked.parse returns a string here)
+        const htmlContent = /** @type {string} */ (marked.parse(content));
 
         // Update UI
         fileName.textContent = filename;

--- a/markdown-viewer/src/platform/desktop.js
+++ b/markdown-viewer/src/platform/desktop.js
@@ -1,3 +1,4 @@
+// @ts-check
 // Desktop (Electron) integration: the file-watch model, the watch-toggle UI,
 // session persistence, and the IPC wiring to the main process (native menus,
 // file-open / file-changed / close-tab events, custom CSS).
@@ -15,15 +16,20 @@ import { openSearch } from '../features/search.js';
 import { applyCustomCss } from '../features/custom-css.js';
 import { performPrint } from './ios-chrome.js';
 
-const el = (id) => document.getElementById(id);
+const el = (/** @type {string} */ id) => document.getElementById(id);
 
-const watchRefCounts = new Map(); // filePath -> number of watching tabs
+/** @type {Map<string, number>} filePath -> number of watching tabs */
+const watchRefCounts = new Map();
 
 // Render core (main.js), supplied via configureDesktop.
+/** @type {(content: string, filename: string) => any} */
 let reloadDoc = () => {};
 
+/** @param {{ renderMarkdown?: Function }} [deps] */
 export function configureDesktop(deps) {
-  if (deps && typeof deps.renderMarkdown === 'function') reloadDoc = deps.renderMarkdown;
+  if (deps && typeof deps.renderMarkdown === 'function') {
+    reloadDoc = /** @type {typeof reloadDoc} */ (deps.renderMarkdown);
+  }
 }
 
 export function updateWatchToggle() {
@@ -31,9 +37,8 @@ export function updateWatchToggle() {
   if (!watchToggle) return;
 
   const tab = state.activeTabId !== null ? state.tabs.find((t) => t.id === state.activeTabId) : null;
-  const canWatch = !!(tab && tab.filePath);
 
-  if (!canWatch) {
+  if (!tab || !tab.filePath) {
     watchToggle.style.display = 'none';
     return;
   }
@@ -51,6 +56,7 @@ export function updateWatchToggle() {
 // Briefly animate the watch toggle to signal that an auto-reload just
 // happened. Without this, the reload is invisible if the user happens
 // not to be looking at the content area when the disk write lands.
+/** @type {ReturnType<typeof setTimeout> | null} */
 let watchTogglePulseTimer = null;
 function pulseWatchToggle() {
   const watchToggle = el('watch-toggle');
@@ -72,24 +78,28 @@ function pulseWatchToggle() {
   }, 1200);
 }
 
+/** @param {string | null} [filePath] */
 export function startWatchingFilePath(filePath) {
-  if (!isDesktop || !filePath || !window.specdown || !window.specdown.watchFile) return;
+  const bridge = window.specdown;
+  if (!isDesktop || !filePath || !bridge || !bridge.watchFile) return;
 
   const currentCount = watchRefCounts.get(filePath) || 0;
   watchRefCounts.set(filePath, currentCount + 1);
 
   if (currentCount === 0) {
-    window.specdown.watchFile(filePath);
+    bridge.watchFile(filePath);
   }
 }
 
+/** @param {string | null} [filePath] */
 export function stopWatchingFilePath(filePath) {
-  if (!isDesktop || !filePath || !window.specdown || !window.specdown.unwatchFile) return;
+  const bridge = window.specdown;
+  if (!isDesktop || !filePath || !bridge || !bridge.unwatchFile) return;
 
   const currentCount = watchRefCounts.get(filePath) || 0;
   if (currentCount <= 1) {
     watchRefCounts.delete(filePath);
-    window.specdown.unwatchFile(filePath);
+    bridge.unwatchFile(filePath);
     return;
   }
 
@@ -114,20 +124,23 @@ function toggleWatching() {
 }
 
 export function setupDesktopIPC() {
+  const bridge = window.specdown;
+  if (!bridge) return;
+
   // Listen for files opened from the main process (Cmd+O, Finder, drag-to-dock)
-  window.specdown.onFileOpened(function (fileData) {
+  bridge.onFileOpened?.(function (fileData) {
     createTab(fileData.filename, fileData.content, fileData.filePath);
   });
 
   // Listen for close-tab command from native menu (Cmd+W)
-  window.specdown.onCloseTab(function () {
+  bridge.onCloseTab?.(function () {
     if (state.activeTabId !== null) {
       closeTab(state.activeTabId);
     }
   });
 
   // Listen for file-changed events (watched file updated on disk)
-  window.specdown.onFileChanged(async function (fileData) {
+  bridge.onFileChanged?.(async function (fileData) {
     const tab = state.tabs.find((t) => t.filePath === fileData.filePath);
     if (!tab) return;
 
@@ -138,6 +151,7 @@ export function setupDesktopIPC() {
       // Preserve scroll position across the re-render so an
       // auto-reload doesn't yank the user back to the top.
       const markdownContent = el('markdown-content');
+      if (!markdownContent) return;
       const savedScrollTop = markdownContent.scrollTop;
 
       if (tab.viewMode === 'raw') {
@@ -171,32 +185,28 @@ export function setupDesktopIPC() {
   }
 
   // Native menu: File > Print
-  if (window.specdown.onTriggerPrint) {
-    window.specdown.onTriggerPrint(function () {
-      performPrint();
-    });
-  }
+  bridge.onTriggerPrint?.(function () {
+    performPrint();
+  });
 
   // Native menu: Edit > Find
-  if (window.specdown.onTriggerSearch) {
-    window.specdown.onTriggerSearch(function () {
-      if (el('content-area').style.display !== 'none') {
-        openSearch();
-      }
-    });
-  }
+  bridge.onTriggerSearch?.(function () {
+    const contentArea = el('content-area');
+    if (contentArea && contentArea.style.display !== 'none') {
+      openSearch();
+    }
+  });
 
   // Appearance menu: apply custom CSS theme
-  if (window.specdown.onApplyCustomCss) {
-    window.specdown.onApplyCustomCss(function (cssContent) {
-      applyCustomCss(cssContent);
-    });
-  }
+  bridge.onApplyCustomCss?.(function (cssContent) {
+    applyCustomCss(cssContent);
+  });
 }
 
 export function saveDesktopSession() {
-  if (!isDesktop || !window.specdown.saveSession) return;
-  window.specdown.saveSession(
+  const bridge = window.specdown;
+  if (!isDesktop || !bridge || !bridge.saveSession) return;
+  bridge.saveSession(
     state.tabs.map((t) => ({
       filePath: t.filePath,
       filename: t.filename,

--- a/markdown-viewer/src/platform/ios-chrome.js
+++ b/markdown-viewer/src/platform/ios-chrome.js
@@ -1,3 +1,4 @@
+// @ts-check
 // iOS native chrome + print.
 //
 // The iOS shell talks to the web app through window.webkit.messageHandlers and
@@ -10,7 +11,11 @@ import { state } from '../core/state.js';
 import { isDesktop, isIOSNative } from '../core/platform.js';
 import { escapeHtml } from '../core/utils.js';
 
-const el = (id) => document.getElementById(id);
+const el = (/** @type {string} */ id) => document.getElementById(id);
+
+// The iOS WKScriptMessage bridge, present only inside the native shell.
+const iosHandler = () =>
+  window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.specdown;
 
 export function setupIOSNativeUI() {
   document.body.classList.toggle('ios-native', isIOSNative);
@@ -25,22 +30,26 @@ export function setupIOSNativeUI() {
 }
 
 export function requestNativeOpenIfAvailable() {
-  if (isDesktop && window.specdown && window.specdown.requestFileOpen) {
-    window.specdown.requestFileOpen();
+  const desktopBridge = window.specdown;
+  if (isDesktop && desktopBridge && desktopBridge.requestFileOpen) {
+    desktopBridge.requestFileOpen();
     return true;
   }
-  if (isIOSNative && window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.specdown) {
-    window.webkit.messageHandlers.specdown.postMessage({ action: 'openFilePicker' });
+  const handler = iosHandler();
+  if (isIOSNative && handler) {
+    handler.postMessage({ action: 'openFilePicker' });
     return true;
   }
   return false;
 }
 
+/** @param {string} sampleName */
 export function requestBundledSampleIfAvailable(sampleName) {
-  if (!isIOSNative || !window.webkit || !window.webkit.messageHandlers || !window.webkit.messageHandlers.specdown) {
+  const handler = iosHandler();
+  if (!isIOSNative || !handler) {
     return false;
   }
-  window.webkit.messageHandlers.specdown.postMessage({
+  handler.postMessage({
     action: 'openBundledSample',
     data: { name: sampleName },
   });
@@ -48,11 +57,12 @@ export function requestBundledSampleIfAvailable(sampleName) {
 }
 
 function requestNativePrintIfAvailable() {
-  if (!isIOSNative || !window.webkit || !window.webkit.messageHandlers || !window.webkit.messageHandlers.specdown || !hasLoadedContent()) {
+  const handler = iosHandler();
+  if (!isIOSNative || !handler || !hasLoadedContent()) {
     return false;
   }
   const fileName = el('file-name');
-  window.webkit.messageHandlers.specdown.postMessage({
+  handler.postMessage({
     action: 'printDocument',
     data: {
       title: fileName ? fileName.textContent : '',
@@ -67,6 +77,10 @@ export function hasLoadedContent() {
   return !!(contentArea && contentArea.style.display !== 'none' && state.currentRawMarkdown);
 }
 
+/**
+ * @param {HTMLElement | null} sheet
+ * @param {boolean} visible
+ */
 export function setIOSSheetVisibility(sheet, visible) {
   if (!sheet) return;
   sheet.style.display = visible ? 'flex' : 'none';
@@ -84,6 +98,10 @@ export function closeIOSTocSheet() {
   syncIOSChrome();
 }
 
+/**
+ * @param {HTMLElement | null} button
+ * @param {string} label
+ */
 function updateIOSActionButtonLabel(button, label) {
   if (!button) return;
   const labelEl = button.querySelector('.ios-action-label');
@@ -92,6 +110,11 @@ function updateIOSActionButtonLabel(button, label) {
   }
 }
 
+/**
+ * @param {HTMLElement | null} button
+ * @param {string} label
+ * @param {boolean} active
+ */
 function updateIOSSheetButton(button, label, active) {
   if (!button) return;
   button.textContent = label;
@@ -105,7 +128,7 @@ export function performPrint() {
   window.print();
 }
 
-window.setIOSLayoutMode = function (mode) {
+window.setIOSLayoutMode = function (/** @type {string} */ mode) {
   state.iosLayoutMode = mode === 'pad' ? 'pad' : 'phone';
   if (isIOSNative) {
     document.body.classList.toggle('ios-pad', state.iosLayoutMode === 'pad');
@@ -122,7 +145,8 @@ function buildPrintableDocument() {
   const fileName = el('file-name');
   const markdownContent = el('markdown-content');
   const title = fileName && fileName.textContent ? fileName.textContent : 'Specdown Document';
-  const printableContent = markdownContent.cloneNode(true);
+  if (!markdownContent) return '';
+  const printableContent = /** @type {HTMLElement} */ (markdownContent.cloneNode(true));
 
   printableContent
     .querySelectorAll('.diagram-controls, .annotation-popover, .search-highlight, .search-highlight-current')
@@ -131,11 +155,13 @@ function buildPrintableDocument() {
   printableContent.querySelectorAll('.has-annotation').forEach((element) => {
     element.classList.remove('has-annotation');
   });
-  printableContent.querySelectorAll('.diagram-wrapper').forEach((wrapper) => {
+  printableContent.querySelectorAll('.diagram-wrapper').forEach((node) => {
+    const wrapper = /** @type {HTMLElement} */ (node);
     wrapper.style.height = 'auto';
     wrapper.style.overflow = 'visible';
   });
-  printableContent.querySelectorAll('.diagram-wrapper svg').forEach((svg) => {
+  printableContent.querySelectorAll('.diagram-wrapper svg').forEach((node) => {
+    const svg = /** @type {SVGElement} */ (node);
     svg.style.maxWidth = '100%';
     svg.style.height = 'auto';
     svg.style.position = 'static';
@@ -286,20 +312,20 @@ export function syncIOSChrome() {
     iosActionBar.style.display = showActionBar ? 'grid' : 'none';
   }
 
-  const iosContentsButton = el('ios-contents-button');
+  const iosContentsButton = /** @type {HTMLButtonElement | null} */ (el('ios-contents-button'));
   if (iosContentsButton) {
     iosContentsButton.disabled = !canShowContents;
     iosContentsButton.classList.toggle('active', state.tocVisible);
   }
 
-  const iosViewButton = el('ios-view-button');
+  const iosViewButton = /** @type {HTMLButtonElement | null} */ (el('ios-view-button'));
   if (iosViewButton) {
     iosViewButton.disabled = !hasContent;
     iosViewButton.classList.toggle('active', state.currentViewMode === 'raw');
     updateIOSActionButtonLabel(iosViewButton, state.currentViewMode === 'preview' ? 'Raw' : 'Preview');
   }
 
-  const iosMoreButton = el('ios-more-button');
+  const iosMoreButton = /** @type {HTMLButtonElement | null} */ (el('ios-more-button'));
   if (iosMoreButton) {
     iosMoreButton.disabled = !hasContent;
   }
@@ -307,8 +333,8 @@ export function syncIOSChrome() {
   updateIOSSheetButton(el('ios-split-button'), state.splitViewActive ? 'Hide Split View' : 'Show Split View', state.splitViewActive);
   updateIOSSheetButton(el('ios-theme-button'), state.currentTheme === 'light' ? 'Switch to Dark Mode' : 'Switch to Light Mode', false);
 
-  const iosSplitButton = el('ios-split-button');
-  const iosPrintButton = el('ios-print-button');
+  const iosSplitButton = /** @type {HTMLButtonElement | null} */ (el('ios-split-button'));
+  const iosPrintButton = /** @type {HTMLButtonElement | null} */ (el('ios-print-button'));
   if (iosSplitButton) iosSplitButton.disabled = !hasContent;
   if (iosPrintButton) iosPrintButton.disabled = !hasContent;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,11 +5,11 @@
     "moduleResolution": "bundler",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "allowJs": true,
-    // Gradual adoption: type-checking is opt-in per file via a `// @ts-check`
-    // pragma at the top of the module. checkJs stays false so unannotated
-    // modules are parsed (for import resolution) but not yet type-checked.
-    // Modules are migrated to checked status one at a time, leaf-first.
-    "checkJs": false,
+    // The gradual adoption is complete: every module under markdown-viewer/src
+    // is type-checked. checkJs is now on globally so new files are checked by
+    // default (no `// @ts-check` pragma needed — the existing per-file pragmas
+    // are kept as harmless documentation of the migration).
+    "checkJs": true,
     "noEmit": true,
     "strict": true,
     "skipLibCheck": true,


### PR DESCRIPTION
The last four (and heaviest) modules opt into `checkJs`, **completing the migration**. Every module under `markdown-viewer/src` is now type-checked over JSDoc, so **`checkJs` is flipped on globally** (new files are checked by default). Fully gated, **no behavior change**.

## Modules opted in (the final four)
| Module | Notes |
|---|---|
| `platform/desktop.js` | guarded the optional `window.specdown` bridge methods via a local `const bridge = window.specdown`; `HTMLButtonElement` casts for `.disabled` |
| `platform/ios-chrome.js` | one `iosHandler()` accessor for the WK message bridge; button casts; guarded the print-clone (`cloneNode` → `HTMLElement`/`SVGElement`) |
| `features/diagrams.js` | the heavy one — typed Panzoom (`PanzoomObject`), a `FullscreenOverlay` typedef for the overlay's expandos, an `on()` null-safe `addEventListener` helper, `catch`-unknown handling, input/SVG casts |
| `main.js` | `$`/`req` DOM-handle helpers (`req` casts non-null for the always-present elements used unguarded); typed input/button consts; annotated the **lazy DI-callback arrow params** (kept as arrows so the tests can still swap globals at call time); `e.target`/drag-event casts |

**Result: 25 / 25 source modules type-checked; `tsconfig.json` → `checkJs: true`.**

## Gotchas hit
- **Harness global collision (again):** a module-top `const overlay` in `diagrams.js` clashed with the `let overlay` in command-palette/shortcuts (all flatten to one global; last wins as `null`). `closeFullscreen` is reached via `showDropZone`/`closeTab`, so it cascaded across ~9 tests. Renamed to `getFsOverlay`.
- **`removeEventListener`** doesn't accept `passive` (only `addEventListener` does) — the old `{ passive: false }` on removal was a silent no-op; dropped it.
- **`marked.parse` is typed `string | Promise<string>`** — the sync call site casts to `string`.
- **Lazy DI arrows stay arrows.** Tests swap globals (e.g. `global.reRenderMermaidDiagrams = spy`) *after* `configure*()`, so the wiring must resolve the callee at call time. Passing by reference would capture the original and break those tests — so the arrows are kept and their params annotated to satisfy `noImplicitAny`.

## Verification
`npm run build` ✓, `npm run lint` ✓, **`npm run typecheck` ✓ (`checkJs: true`)**, `npm test` → **345 passed**. No behavior change.

## What this closes
The roadmap's **"gradual TypeScript"** item is **done** — 100% of the viewer source type-checked over JSDoc (no `.ts` rewrite), enforced in CI, on-by-default for new files. **Phase 1 (Architecture) is fully complete.**

Builds on #126 (handoff). Remaining roadmap work needs you: Phase 2 slice 4 (toolbar + token overhaul — visual review) and Phase 3 (macOS signing — Apple cert + CI secrets).

https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA)_