### PR TITLE
Phase 2 slice 4: design tokens + focus-visible + toolbar overflow menu

### DIFF
--- a/docs/project-modernization/2026-06-15-tasks-session-11-phase2-design-tokens.md
+++ b/docs/project-modernization/2026-06-15-tasks-session-11-phase2-design-tokens.md
@@ -1,0 +1,55 @@
+# Tasks — Session 11: Phase 2 (design tokens + focus-visible, slice 4a)
+
+**Date:** 2026-06-15
+**Type:** tasks (session-level implementation checklist)
+**Phase:** 2 — Design system & UX modernization
+**Source plan:** [2026-06-13-brainstorm-modernization-evaluation.md](2026-06-13-brainstorm-modernization-evaluation.md) §Phase 2
+
+The design-token half of Phase 2 slice 4. Establishes a proper token system and
+a keyboard focus treatment. **Color output is value-preserving** — every
+substitution maps to a token whose value equals the prior inline value, so the
+already-tested light/dark appearance is unchanged. The one *visible* addition is
+keyboard focus rings.
+
+---
+
+## Token system (added to `:root`)
+
+- **Radius scale** — `--radius-sm` 4px / `--radius-md` 6px / `--radius-lg` 8px /
+  `--radius-xl` 12px / `--radius-pill` 999px. The 41 single-value
+  `border-radius` declarations using those sizes now reference the tokens
+  (sed-substituted with a trailing-`;` anchor so multi-value shorthands like
+  `8px 8px 0 0` were left untouched). Odd one-offs (2/3/5/16/20px, 50%) left as-is.
+- **Spacing scale** — `--space-1`…`--space-6` (4px base rhythm), defined for
+  adoption by new components.
+- **Motion** — added `--transition-fast` alongside the existing `--transition`.
+- **Typography** — `--font-sans` (the repeated system stack, now referenced by
+  `body`) and `--font-mono`.
+- **Semantic status palette** — `--color-success` / `--color-info` /
+  `--color-warning` / `--color-danger` / `--text-on-accent`. The toast accent
+  bars now reference these (value-identical), so status colors are defined once
+  by intent rather than as scattered inline hex.
+
+## Accessibility: keyboard focus
+
+- A global **`:focus-visible`** rule gives keyboard users a consistent
+  accent-colored outline (`outline-offset: 2px`). `:focus-visible` matches only
+  keyboard focus, so mouse clicks stay clean. Low specificity, so the handful of
+  inputs with their own `:focus` border/box-shadow treatment keep it; plain
+  buttons/links — which previously had **no** focus indicator — now get one.
+
+## Verification
+
+- `npm run build` ✓ (Vite processes/validates the CSS), `npm run lint` ✓,
+  `npm run typecheck` ✓, `npm test` → **345 passed**.
+- CSS isn't exercised by the jsdom suite, so the **visual check is the focus
+  rings** + confirming light/dark is unchanged (it is — value-preserving).
+
+## Deliberately out of scope (left for a visual pass)
+
+- Consolidating the remaining scattered colors (annotation status hexes, the
+  GitHub code-block theme `#0d1117`/`#30363d`/`#e6edf3`) into tokens would change
+  values if unified, so it's deferred — not worth a contrast regression.
+- The **toolbar consolidation / overflow menu** is the other half of slice 4;
+  the command palette (Cmd/Ctrl+K) already covers action discovery, so the
+  overflow menu is lower priority.

--- a/docs/project-modernization/2026-06-15-tasks-session-11-phase2-design-tokens.md
+++ b/docs/project-modernization/2026-06-15-tasks-session-11-phase2-design-tokens.md
@@ -45,11 +45,24 @@ keyboard focus rings.
 - CSS isn't exercised by the jsdom suite, so the **visual check is the focus
   rings** + confirming light/dark is unchanged (it is — value-preserving).
 
+## Toolbar overflow menu (slice 4b, same PR)
+
+On narrow viewports the secondary content-header actions (Contents / Split /
+Annotate / Print) now collapse behind a single **"⋮" overflow button** instead
+of just dropping their labels. `view-toggle` and `watch-toggle` stay inline.
+
+- New **`features/toolbar-overflow.js`** (`// @ts-check`): builds a `role="menu"`
+  dropdown on open; each `menuitem` is a **thin proxy** that `.click()`s the real
+  toolbar button — so there's **no duplicated action logic** (whatever a button
+  does, the menu does). Open/close/toggle, outside-click + Esc close, and
+  `aria-expanded` sync on the toggle.
+- CSS uses the new radius/shadow/transition tokens; the `max-width: 768px` block
+  now hides those four buttons and reveals `#overflow-toggle`.
+- Tests: `tests/unit/toolbarOverflow.test.js` (menu/ARIA, open-via-toggle,
+  **proxy-to-real-button** effect, close/toggle, outside-click). **+6 tests.**
+
 ## Deliberately out of scope (left for a visual pass)
 
 - Consolidating the remaining scattered colors (annotation status hexes, the
   GitHub code-block theme `#0d1117`/`#30363d`/`#e6edf3`) into tokens would change
   values if unified, so it's deferred — not worth a contrast regression.
-- The **toolbar consolidation / overflow menu** is the other half of slice 4;
-  the command palette (Cmd/Ctrl+K) already covers action discovery, so the
-  overflow menu is lower priority.

--- a/docs/project-modernization/README.md
+++ b/docs/project-modernization/README.md
@@ -19,6 +19,7 @@ three-lens evaluation of the app at v0.0.82 and a phased roadmap.
 | 2026-06-14 | [tasks-session-08-phase2-command-palette](2026-06-14-tasks-session-08-phase2-command-palette.md) | Phase 2 slice 3: command palette (Cmd/Ctrl+K, fuzzy filter, keyboard nav, ARIA combobox/listbox) + keyboard shortcut sheet (`?`); +21 tests |
 | 2026-06-14 | [tasks-session-09-typescript-batch2](2026-06-14-tasks-session-09-typescript-batch2.md) | Gradual TypeScript batch 2: `// @ts-check` opt-in for 15 more modules (custom-css, split-view, share-links, view-mode, diagram-export, minimap, theme, file-loading, toc, search, annotations, repo-browser, render-config, tabs, highlight) — 21/~25 checked; no behavior change |
 | 2026-06-15 | [tasks-session-10-typescript-complete](2026-06-15-tasks-session-10-typescript-complete.md) | Gradual TypeScript **complete**: final 4 modules (desktop, ios-chrome, diagrams, main) — **25/25 checked**, `checkJs: true` flipped on globally; no behavior change |
+| 2026-06-15 | [tasks-session-11-phase2-design-tokens](2026-06-15-tasks-session-11-phase2-design-tokens.md) | Phase 2 slice 4a: design-token system (radius/spacing/motion/type scales + semantic status palette, value-preserving) + global `:focus-visible` keyboard focus rings |
 
 ## Current Status
 

--- a/markdown-viewer/index.html
+++ b/markdown-viewer/index.html
@@ -118,6 +118,9 @@
                         <span class="view-toggle-icon" aria-hidden="true">&lt;/&gt;</span>
                         <span class="view-toggle-label">Raw</span>
                     </button>
+                    <button id="overflow-toggle" class="overflow-toggle-button" title="More actions" aria-label="More actions" aria-haspopup="true" aria-expanded="false" style="display: none;">
+                        <span aria-hidden="true">⋮</span>
+                    </button>
                 </div>
             </div>
 

--- a/markdown-viewer/src/features/toolbar-overflow.js
+++ b/markdown-viewer/src/features/toolbar-overflow.js
@@ -1,0 +1,91 @@
+// @ts-check
+// Toolbar overflow menu: on narrow viewports the content-header action buttons
+// collapse behind a single "⋮" button (shown via a CSS media query). The menu
+// items are thin proxies that `.click()` the real toolbar buttons, so there is
+// no duplicated action logic — whatever the buttons do, the menu does.
+
+const el = (/** @type {string} */ id) => document.getElementById(id);
+
+/** @type {Array<{ targetId: string, label: string }>} */
+const OVERFLOW_ACTIONS = [
+  { targetId: 'toc-toggle', label: 'Table of contents' },
+  { targetId: 'split-toggle', label: 'Split view' },
+  { targetId: 'annotation-toggle', label: 'Annotate' },
+  { targetId: 'print-button', label: 'Print / Save as PDF' },
+  { targetId: 'view-toggle', label: 'Toggle raw / preview' },
+];
+
+/** @type {HTMLElement | null} */
+let menu = null;
+
+export function isOverflowMenuOpen() {
+  return menu !== null;
+}
+
+export function openOverflowMenu() {
+  if (menu) return;
+  const toggle = el('overflow-toggle');
+  if (!toggle) return;
+
+  const built = document.createElement('div');
+  built.className = 'overflow-menu';
+  built.setAttribute('role', 'menu');
+
+  for (const action of OVERFLOW_ACTIONS) {
+    const target = el(action.targetId);
+    if (!target) continue;
+    const item = document.createElement('button');
+    item.className = 'overflow-menu-item';
+    item.setAttribute('role', 'menuitem');
+    item.textContent = action.label;
+    item.addEventListener('click', () => {
+      closeOverflowMenu();
+      const proxied = el(action.targetId);
+      if (proxied) proxied.click();
+    });
+    built.appendChild(item);
+  }
+
+  // Anchor inside the toolbar so it positions under the toggle.
+  (toggle.parentElement || document.body).appendChild(built);
+  menu = built;
+  toggle.setAttribute('aria-expanded', 'true');
+
+  // Defer so the opening click doesn't immediately close it.
+  setTimeout(() => document.addEventListener('click', onOutsideClick), 0);
+}
+
+export function closeOverflowMenu() {
+  if (!menu) return;
+  if (menu.parentNode) menu.parentNode.removeChild(menu);
+  menu = null;
+  const toggle = el('overflow-toggle');
+  if (toggle) toggle.setAttribute('aria-expanded', 'false');
+  document.removeEventListener('click', onOutsideClick);
+}
+
+export function toggleOverflowMenu() {
+  if (menu) {
+    closeOverflowMenu();
+  } else {
+    openOverflowMenu();
+  }
+}
+
+/** @param {Event} e */
+function onOutsideClick(e) {
+  const toggle = el('overflow-toggle');
+  const target = /** @type {Node} */ (e.target);
+  if (menu && !menu.contains(target) && toggle && !toggle.contains(target)) {
+    closeOverflowMenu();
+  }
+}
+
+export function setupToolbarOverflow() {
+  const toggle = el('overflow-toggle');
+  if (!toggle) return;
+  toggle.addEventListener('click', (e) => {
+    e.stopPropagation();
+    toggleOverflowMenu();
+  });
+}

--- a/markdown-viewer/src/main.js
+++ b/markdown-viewer/src/main.js
@@ -99,6 +99,11 @@ import {
   isShortcutsSheetOpen,
 } from './features/shortcuts.js';
 import {
+  setupToolbarOverflow,
+  closeOverflowMenu,
+  isOverflowMenuOpen,
+} from './features/toolbar-overflow.js';
+import {
   setupDesktopIPC,
   updateWatchToggle,
   saveDesktopSession,
@@ -199,6 +204,7 @@ function init() {
     setupVersionInfo();
     setupTheme();
     setupIOSNativeUI();
+    setupToolbarOverflow();
     setupEventListeners();
     configureMarked();
     checkForUpdates();
@@ -534,6 +540,8 @@ function setupEventListeners() {
                 closeCommandPalette();
             } else if (isShortcutsSheetOpen()) {
                 closeShortcutsSheet();
+            } else if (isOverflowMenuOpen()) {
+                closeOverflowMenu();
             } else if (fullscreenOverlay.style.display !== 'none') {
                 closeFullscreen();
             } else if (searchBar && searchBar.style.display !== 'none') {

--- a/markdown-viewer/styles.css
+++ b/markdown-viewer/styles.css
@@ -17,6 +17,35 @@
     --shadow-md: 0 4px 8px rgba(0, 0, 0, 0.15);
     --shadow-lg: 0 8px 16px rgba(0, 0, 0, 0.2);
     --transition: all 0.3s ease;
+    --transition-fast: all 0.15s ease;
+
+    /* Semantic status palette (the toast/badge/status colors). Defined once so
+       components reference intent, not raw hex. Values match the prior inline
+       colors, so light/dark output is unchanged. */
+    --color-success: var(--success-color);
+    --color-info: var(--accent-color);
+    --color-warning: #e0a800;
+    --color-danger: #e0533f;
+    --text-on-accent: #ffffff;
+
+    /* Radius scale */
+    --radius-sm: 4px;
+    --radius-md: 6px;
+    --radius-lg: 8px;
+    --radius-xl: 12px;
+    --radius-pill: 999px;
+
+    /* Spacing scale (4px base rhythm) */
+    --space-1: 0.25rem;
+    --space-2: 0.5rem;
+    --space-3: 0.75rem;
+    --space-4: 1rem;
+    --space-5: 1.5rem;
+    --space-6: 2rem;
+
+    /* Typography */
+    --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+    --font-mono: 'SFMono-Regular', SFMono-Regular, ui-monospace, Menlo, Consolas, monospace;
 }
 
 [data-theme="dark"] {
@@ -60,8 +89,16 @@
     }
 }
 
+/* Keyboard focus indicator: a consistent accent outline for keyboard users.
+   :focus-visible only matches keyboard (not mouse) focus, so clicks stay clean.
+   Components with their own :focus treatment keep it via higher specificity. */
+:focus-visible {
+    outline: 2px solid var(--accent-color);
+    outline-offset: 2px;
+}
+
 body {
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+    font-family: var(--font-sans);
     background-color: var(--bg-secondary);
     color: var(--text-primary);
     line-height: 1.6;
@@ -170,7 +207,7 @@ body {
 .theme-toggle {
     background: var(--bg-tertiary);
     border: 1px solid var(--border-color);
-    border-radius: 8px;
+    border-radius: var(--radius-lg);
     padding: 0.5rem 1rem;
     cursor: pointer;
     font-size: 1.2rem;
@@ -240,7 +277,7 @@ body {
     color: white;
     border: none;
     padding: 0.75rem 2rem;
-    border-radius: 8px;
+    border-radius: var(--radius-lg);
     font-size: 1rem;
     font-weight: 500;
     cursor: pointer;
@@ -273,7 +310,7 @@ body {
     color: var(--text-primary);
     border: 1px solid var(--border-color);
     padding: 0.7rem 1.1rem;
-    border-radius: 8px;
+    border-radius: var(--radius-lg);
     font-size: 0.95rem;
     font-weight: 500;
     cursor: pointer;
@@ -315,7 +352,7 @@ body {
     flex: 1;
     padding: 0.55rem 0.85rem;
     border: 1px solid var(--border-color);
-    border-radius: 6px;
+    border-radius: var(--radius-md);
     background-color: var(--bg-primary);
     color: var(--text-primary);
     font-size: 0.9rem;
@@ -332,7 +369,7 @@ body {
     background-color: var(--accent-color);
     color: white;
     border: none;
-    border-radius: 6px;
+    border-radius: var(--radius-md);
     font-size: 0.9rem;
     font-weight: 500;
     cursor: pointer;
@@ -425,7 +462,7 @@ body {
     color: var(--text-primary);
     border: 1px solid var(--border-color);
     padding: 0.5rem 1rem;
-    border-radius: 6px;
+    border-radius: var(--radius-md);
     font-size: 0.9rem;
     cursor: pointer;
     transition: var(--transition);
@@ -497,7 +534,7 @@ body {
     color: var(--text-primary);
     border: 1px solid var(--border-color);
     padding: 0.5rem 1rem;
-    border-radius: 6px;
+    border-radius: var(--radius-md);
     font-size: 0.9rem;
     cursor: pointer;
     transition: var(--transition);
@@ -529,7 +566,7 @@ body {
     color: var(--text-primary);
     border: 1px solid var(--border-color);
     padding: 0.5rem 1rem;
-    border-radius: 6px;
+    border-radius: var(--radius-md);
     font-size: 0.9rem;
     cursor: pointer;
     transition: var(--transition);
@@ -609,7 +646,7 @@ body {
        readable in both app themes. */
     background-color: #0d1117;
     border: 1px solid #30363d;
-    border-radius: 6px;
+    border-radius: var(--radius-md);
     padding: 1em;
     overflow-x: auto;
     margin-bottom: 1em;
@@ -671,7 +708,7 @@ body {
 .raw-markdown {
     background-color: var(--bg-secondary);
     border: 1px solid var(--border-color);
-    border-radius: 6px;
+    border-radius: var(--radius-md);
     padding: 1.5em;
     margin: 0;
     overflow-x: auto;
@@ -697,7 +734,7 @@ body {
     position: relative;
     margin: 2em 0;
     border: 1px solid var(--border-color);
-    border-radius: 8px;
+    border-radius: var(--radius-lg);
     background-color: var(--bg-secondary);
     overflow: hidden;
     box-shadow: var(--shadow-md);
@@ -712,7 +749,7 @@ body {
     z-index: 10;
     background-color: var(--bg-primary);
     padding: 5px;
-    border-radius: 6px;
+    border-radius: var(--radius-md);
     box-shadow: var(--shadow-md);
 }
 
@@ -721,7 +758,7 @@ body {
     color: var(--text-primary);
     border: 1px solid var(--border-color);
     padding: 0.5rem 0.75rem;
-    border-radius: 4px;
+    border-radius: var(--radius-sm);
     font-size: 1rem;
     cursor: pointer;
     transition: var(--transition);
@@ -796,7 +833,7 @@ body {
     background-color: var(--bg-primary);
     border: 2px solid var(--border-color);
     padding: 10px;
-    border-radius: 8px;
+    border-radius: var(--radius-lg);
     box-shadow: var(--shadow-lg);
 }
 
@@ -805,7 +842,7 @@ body {
     color: var(--text-primary);
     border: 1px solid var(--border-color);
     padding: 0.75rem 1rem;
-    border-radius: 6px;
+    border-radius: var(--radius-md);
     font-size: 1.2rem;
     cursor: pointer;
     transition: var(--transition);
@@ -820,7 +857,7 @@ body {
     gap: 0.4rem;
     background-color: var(--bg-tertiary);
     border: 1px solid var(--border-color);
-    border-radius: 6px;
+    border-radius: var(--radius-md);
     padding: 0.2rem 0.5rem;
 }
 
@@ -858,7 +895,7 @@ body {
     overflow: hidden;
     cursor: grab;
     background-color: var(--bg-primary);
-    border-radius: 8px;
+    border-radius: var(--radius-lg);
     position: relative;
 }
 
@@ -1026,7 +1063,7 @@ body {
     cursor: pointer;
     font-size: 1.2rem;
     padding: 0.35rem 0.65rem;
-    border-radius: 4px;
+    border-radius: var(--radius-sm);
     flex-shrink: 0;
     margin-left: 0.25rem;
     transition: background-color 0.15s ease, color 0.15s ease;
@@ -1156,7 +1193,7 @@ body {
     color: var(--text-primary);
     border: 1px solid var(--border-color);
     padding: 0.5rem 1rem;
-    border-radius: 6px;
+    border-radius: var(--radius-md);
     font-size: 0.9rem;
     cursor: pointer;
     transition: var(--transition);
@@ -1220,7 +1257,7 @@ body {
     color: var(--text-primary);
     border: 1px solid var(--border-color);
     padding: 0.5rem 1rem;
-    border-radius: 6px;
+    border-radius: var(--radius-md);
     font-size: 0.9rem;
     cursor: pointer;
     transition: var(--transition);
@@ -1249,7 +1286,7 @@ body {
     color: var(--text-primary);
     border: 1px solid var(--border-color);
     padding: 0.5rem 1rem;
-    border-radius: 6px;
+    border-radius: var(--radius-md);
     font-size: 0.9rem;
     cursor: pointer;
     transition: var(--transition);
@@ -1282,7 +1319,7 @@ body {
     max-width: 320px;
     padding: 0.4rem 0.75rem;
     border: 1px solid var(--border-color);
-    border-radius: 6px;
+    border-radius: var(--radius-md);
     background-color: var(--bg-secondary);
     color: var(--text-primary);
     font-size: 0.9rem;
@@ -1304,7 +1341,7 @@ body {
 .search-nav-btn {
     background: var(--bg-tertiary);
     border: 1px solid var(--border-color);
-    border-radius: 4px;
+    border-radius: var(--radius-sm);
     padding: 0.3rem 0.6rem;
     cursor: pointer;
     color: var(--text-primary);
@@ -1325,7 +1362,7 @@ body {
     cursor: pointer;
     font-size: 1rem;
     padding: 0.2rem 0.5rem;
-    border-radius: 4px;
+    border-radius: var(--radius-sm);
     transition: color 0.15s ease, background-color 0.15s ease;
 }
 
@@ -1369,7 +1406,7 @@ mark.search-highlight-current {
     background-color: #323232;
     color: #fff;
     padding: 0.6rem 1.4rem;
-    border-radius: 8px;
+    border-radius: var(--radius-lg);
     font-size: 0.9rem;
     z-index: 9999;
     box-shadow: var(--shadow-lg);
@@ -1403,7 +1440,7 @@ mark.search-highlight-current {
     background-color: #323232;
     color: #fff;
     padding: 0.6rem 1.4rem;
-    border-radius: 8px;
+    border-radius: var(--radius-lg);
     border-left: 4px solid transparent;
     font-size: 0.9rem;
     line-height: 1.4;
@@ -1413,19 +1450,19 @@ mark.search-highlight-current {
 }
 
 .toast-success {
-    border-left-color: var(--success-color);
+    border-left-color: var(--color-success);
 }
 
 .toast-info {
-    border-left-color: var(--accent-color);
+    border-left-color: var(--color-info);
 }
 
 .toast-warning {
-    border-left-color: #e0a800;
+    border-left-color: var(--color-warning);
 }
 
 .toast-error {
-    border-left-color: #e0533f;
+    border-left-color: var(--color-danger);
 }
 
 /* ===========================
@@ -1439,7 +1476,7 @@ mark.search-highlight-current {
     padding: 0.5rem 1rem;
     background-color: var(--accent-color);
     color: #fff;
-    border-radius: 6px;
+    border-radius: var(--radius-md);
     text-decoration: none;
     box-shadow: var(--shadow-md);
     transition: top 0.15s ease;
@@ -1473,7 +1510,7 @@ mark.search-highlight-current {
     background-color: var(--bg-primary);
     color: var(--text-primary);
     border: 1px solid var(--border-color);
-    border-radius: 12px;
+    border-radius: var(--radius-xl);
     box-shadow: var(--shadow-lg);
     overflow: hidden;
 }
@@ -1502,7 +1539,7 @@ mark.search-highlight-current {
     align-items: center;
     gap: 1rem;
     padding: 0.55rem 0.85rem;
-    border-radius: 8px;
+    border-radius: var(--radius-lg);
     cursor: pointer;
 }
 
@@ -1545,7 +1582,7 @@ mark.search-highlight-current {
     background-color: var(--bg-primary);
     color: var(--text-primary);
     border: 1px solid var(--border-color);
-    border-radius: 12px;
+    border-radius: var(--radius-xl);
     box-shadow: var(--shadow-lg);
     padding: 1.25rem 1.5rem;
     outline: none;
@@ -1581,7 +1618,7 @@ mark.search-highlight-current {
     padding: 0.15rem 0.5rem;
     background-color: var(--bg-tertiary);
     border: 1px solid var(--border-color);
-    border-radius: 6px;
+    border-radius: var(--radius-md);
     font-family: inherit;
     font-size: 0.85rem;
 }
@@ -1690,7 +1727,7 @@ mark.search-highlight-current {
     gap: 0.2rem;
     min-height: 52px;
     border: 1px solid var(--border-color);
-    border-radius: 12px;
+    border-radius: var(--radius-xl);
     background: var(--bg-primary);
     color: var(--text-primary);
     font-size: 0.78rem;
@@ -1751,7 +1788,7 @@ mark.search-highlight-current {
     border: 1px solid var(--border-color);
     background: var(--bg-secondary);
     color: var(--text-primary);
-    border-radius: 999px;
+    border-radius: var(--radius-pill);
     width: 34px;
     height: 34px;
     font-size: 0.95rem;
@@ -1768,7 +1805,7 @@ mark.search-highlight-current {
     min-height: 48px;
     padding: 0.85rem 1rem;
     border: 1px solid var(--border-color);
-    border-radius: 12px;
+    border-radius: var(--radius-xl);
     background: var(--bg-secondary);
     color: var(--text-primary);
     font-size: 0.95rem;
@@ -1805,7 +1842,7 @@ mark.search-highlight-current {
     left: 20px;
     background-color: var(--bg-primary);
     border: 1px solid var(--border-color);
-    border-radius: 6px;
+    border-radius: var(--radius-md);
     padding: 4px;
     box-shadow: var(--shadow-md);
     z-index: 1002;
@@ -1814,7 +1851,7 @@ mark.search-highlight-current {
 
 .minimap-canvas {
     display: block;
-    border-radius: 4px;
+    border-radius: var(--radius-sm);
     opacity: 0.85;
 }
 
@@ -1835,7 +1872,7 @@ mark.search-highlight-current {
     color: var(--text-primary);
     border: 1px solid var(--border-color);
     padding: 0.5rem 1rem;
-    border-radius: 6px;
+    border-radius: var(--radius-md);
     font-size: 0.9rem;
     cursor: pointer;
     transition: var(--transition);
@@ -1898,7 +1935,7 @@ mark.search-highlight-current {
     position: fixed;
     background-color: var(--bg-primary);
     border: 1px solid var(--border-color);
-    border-radius: 6px;
+    border-radius: var(--radius-md);
     padding: 0.6rem 0.9rem;
     font-size: 0.85rem;
     color: var(--text-primary);
@@ -1929,7 +1966,7 @@ mark.search-highlight-current {
 .repo-browser-content {
     background-color: var(--bg-primary);
     border: 1px solid var(--border-color);
-    border-radius: 12px;
+    border-radius: var(--radius-xl);
     width: 520px;
     max-width: 95vw;
     max-height: 70vh;
@@ -1964,7 +2001,7 @@ mark.search-highlight-current {
     cursor: pointer;
     font-size: 1rem;
     padding: 0.2rem 0.4rem;
-    border-radius: 4px;
+    border-radius: var(--radius-sm);
     flex-shrink: 0;
     transition: color 0.15s ease, background-color 0.15s ease;
 }
@@ -1984,7 +2021,7 @@ mark.search-highlight-current {
     width: 100%;
     padding: 0.45rem 0.75rem;
     border: 1px solid var(--border-color);
-    border-radius: 6px;
+    border-radius: var(--radius-md);
     background-color: var(--bg-secondary);
     color: var(--text-primary);
     font-size: 0.9rem;

--- a/markdown-viewer/styles.css
+++ b/markdown-viewer/styles.css
@@ -455,6 +455,59 @@ body {
     display: flex;
     align-items: center;
     gap: 0.5rem;
+    position: relative; /* anchor for the overflow menu */
+}
+
+/* ===========================
+   Toolbar Overflow Menu
+   =========================== */
+.overflow-toggle-button {
+    background-color: var(--bg-tertiary);
+    color: var(--text-primary);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    padding: 0.4rem 0.6rem;
+    font-size: 1.1rem;
+    line-height: 1;
+    cursor: pointer;
+    transition: var(--transition-fast);
+}
+
+.overflow-toggle-button:hover {
+    background-color: var(--accent-color);
+    border-color: var(--accent-color);
+    color: var(--text-on-accent);
+}
+
+.overflow-menu {
+    position: absolute;
+    top: calc(100% + 0.4rem);
+    right: 0;
+    z-index: 200;
+    min-width: 12rem;
+    display: flex;
+    flex-direction: column;
+    padding: 0.25rem;
+    background-color: var(--bg-primary);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-lg);
+}
+
+.overflow-menu-item {
+    text-align: left;
+    background: transparent;
+    border: none;
+    color: var(--text-primary);
+    font: inherit;
+    padding: 0.55rem 0.75rem;
+    border-radius: var(--radius-md);
+    cursor: pointer;
+}
+
+.overflow-menu-item:hover {
+    background-color: var(--accent-color);
+    color: var(--text-on-accent);
 }
 
 .watch-toggle-button {
@@ -2090,10 +2143,17 @@ mark.search-highlight-current {
         border-bottom: 1px solid var(--border-color);
     }
 
-    .toc-toggle-button .toc-toggle-label,
-    .split-toggle-button .split-toggle-label,
-    .print-button .print-button-label,
-    .annotation-toggle-button .annotation-toggle-label {
+    /* Collapse the secondary content-header actions behind the overflow "⋮"
+       menu on narrow viewports; the overflow menu proxies to these buttons.
+       view-toggle and watch-toggle stay inline as primary/contextual actions. */
+    .content-header-actions #toc-toggle,
+    .content-header-actions #split-toggle,
+    .content-header-actions #annotation-toggle,
+    .content-header-actions #print-button {
         display: none;
+    }
+
+    #overflow-toggle {
+        display: inline-flex !important;
     }
 }

--- a/tests/unit/toolbarOverflow.test.js
+++ b/tests/unit/toolbarOverflow.test.js
@@ -1,0 +1,91 @@
+/**
+ * Unit tests for the toolbar overflow menu (the "⋮" menu that collapses the
+ * content-header actions on narrow viewports). Menu items proxy to the real
+ * toolbar buttons.
+ */
+
+const { loadHTML, loadApp } = require('../helpers/loadApp');
+require('../mocks/marked');
+require('../mocks/mermaid');
+require('../mocks/panzoom');
+require('../mocks/highlightjs');
+
+describe('Toolbar overflow menu', () => {
+  beforeEach(() => {
+    loadHTML(document);
+    loadApp(document);
+  });
+
+  afterEach(() => {
+    if (isOverflowMenuOpen()) closeOverflowMenu();
+  });
+
+  it('opens a menu of action items anchored in the toolbar', () => {
+    openOverflowMenu();
+
+    expect(isOverflowMenuOpen()).toBe(true);
+    const menu = document.querySelector('.overflow-menu');
+    expect(menu).not.toBeNull();
+    expect(menu.getAttribute('role')).toBe('menu');
+
+    const items = menu.querySelectorAll('.overflow-menu-item');
+    expect(items.length).toBeGreaterThan(0);
+    items.forEach((item) => expect(item.getAttribute('role')).toBe('menuitem'));
+
+    // It lives inside the content-header actions container.
+    expect(menu.closest('.content-header-actions')).not.toBeNull();
+  });
+
+  it('opens via the overflow toggle button and syncs aria-expanded', () => {
+    const toggle = document.getElementById('overflow-toggle');
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+
+    toggle.dispatchEvent(new Event('click', { bubbles: true }));
+
+    expect(isOverflowMenuOpen()).toBe(true);
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('proxies a menu item to the real toolbar button and closes', () => {
+    expect(state.splitViewActive).toBe(false);
+
+    openOverflowMenu();
+    const items = Array.from(document.querySelectorAll('.overflow-menu-item'));
+    const splitItem = items.find((i) => /split/i.test(i.textContent));
+    expect(splitItem).toBeTruthy();
+
+    splitItem.dispatchEvent(new Event('click', { bubbles: true }));
+
+    // Clicking the item should have triggered #split-toggle's handler.
+    expect(state.splitViewActive).toBe(true);
+    expect(isOverflowMenuOpen()).toBe(false);
+  });
+
+  it('closes and removes the menu', () => {
+    openOverflowMenu();
+    closeOverflowMenu();
+
+    expect(isOverflowMenuOpen()).toBe(false);
+    expect(document.querySelector('.overflow-menu')).toBeNull();
+    expect(document.getElementById('overflow-toggle').getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('toggles open/closed', () => {
+    toggleOverflowMenu();
+    expect(isOverflowMenuOpen()).toBe(true);
+    toggleOverflowMenu();
+    expect(isOverflowMenuOpen()).toBe(false);
+  });
+
+  it('closes on an outside click', () => {
+    jest.useFakeTimers();
+    try {
+      openOverflowMenu();
+      jest.advanceTimersByTime(1); // register the deferred outside-click listener
+      document.body.dispatchEvent(new Event('click', { bubbles: true }));
+      expect(isOverflowMenuOpen()).toBe(false);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
Phase 2 slice 4 — the design-system finish. **Color output is value-preserving** (the light/dark you tested is unchanged); the visible additions are keyboard focus rings and the overflow menu.

## 1. Design-token system (`:root`)
- **Radius scale** (`--radius-sm/md/lg/xl/pill`) — the 41 single-value `border-radius` decls now use tokens (trailing-`;` anchored sed, so shorthands untouched).
- **Spacing scale** `--space-1…6`, **`--transition-fast`**, **`--font-sans`** (now on `body`) + **`--font-mono`**.
- **Semantic status palette** `--color-success/info/warning/danger` + `--text-on-accent`; the toast accent bars reference these (value-identical).

## 2. Keyboard focus (a11y)
A global **`:focus-visible`** accent outline — keyboard-only (clicks stay clean), low specificity so inputs keep their own `:focus`, but plain buttons/links that had **no** focus indicator now get one.

## 3. Toolbar overflow menu
On narrow viewports the secondary content-header actions (Contents / Split / Annotate / Print) collapse behind a single **"⋮"** button instead of just dropping their labels (`view-toggle`/`watch-toggle` stay inline).
- New **`features/toolbar-overflow.js`** (`// @ts-check`): a `role="menu"` dropdown whose items are **thin proxies** that `.click()` the real toolbar buttons — **no duplicated action logic**. Open/close/toggle, outside-click + Esc, `aria-expanded` sync.
- Styled with the new radius/shadow/transition tokens.

## Verification
`npm run build` ✓, `lint` ✓, `typecheck` ✓ (new module passes the now-global `checkJs`), `npm test` → **351 passed** (+6 for the overflow menu). CSS isn't exercised by jsdom, so the visual checks are: focus rings, light/dark unchanged (value-preserving), and the "⋮" menu at narrow widths.

## Out of scope
Consolidating the remaining scattered colors (annotation hexes, GitHub code-block theme) would change values if unified — deferred to avoid a contrast regression.

https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA