### PR TITLE
Phase 3: fix macOS notarize flag (boolean, not nested teamId)

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -50,11 +50,12 @@ jobs:
         run: npm install
 
       # Signed + notarized build (Developer ID). electron-builder imports the
-      # cert from CSC_LINK/CSC_KEY_PASSWORD; `-c.mac.notarize.teamId` enables
-      # notarization via notarytool using the APPLE_ID app-specific password.
+      # cert from CSC_LINK/CSC_KEY_PASSWORD; `-c.mac.notarize=true` enables
+      # notarization via notarytool, which reads the APPLE_ID app-specific
+      # password and APPLE_TEAM_ID from the env below.
       - name: Build DMG (signed + notarized)
         if: env.HAS_SIGNING == 'true'
-        run: npm run desktop:build -- --mac dmg -c.mac.notarize.teamId=${{ secrets.APPLE_TEAM_ID }}
+        run: npm run desktop:build -- --mac dmg -c.mac.notarize=true
         env:
           CSC_LINK: ${{ secrets.MAC_CERT_P12 }}
           CSC_KEY_PASSWORD: ${{ secrets.MAC_CERT_PASSWORD }}

--- a/docs/project-modernization/2026-06-15-spec-macos-signing.md
+++ b/docs/project-modernization/2026-06-15-spec-macos-signing.md
@@ -87,10 +87,11 @@ Or just: download → open → it launches without the "damaged" dialog.
   config follows electron-builder 26's documented signing/notarization patterns;
   please do one release and confirm with the checks above.
 - The signed path uses the **apple-id + app-specific-password** notarization
-  method (simplest). If you'd rather use an **App Store Connect API key**, swap the
-  `APPLE_ID`/`APPLE_APP_SPECIFIC_PASSWORD` env for `APPLE_API_KEY` (path to the
-  `.p8`), `APPLE_API_KEY_ID`, `APPLE_API_ISSUER` and drop the `notarize.teamId`
-  override — say the word and I'll switch it.
+  method (simplest): the workflow passes `-c.mac.notarize=true` and notarytool
+  reads `APPLE_ID` / `APPLE_APP_SPECIFIC_PASSWORD` / `APPLE_TEAM_ID` from the env.
+  If you'd rather use an **App Store Connect API key**, swap those env vars for
+  `APPLE_API_KEY` (path to the `.p8`), `APPLE_API_KEY_ID`, `APPLE_API_ISSUER` —
+  say the word and I'll switch it.
 - Apple's **arm64 + x64**: this builds a single-arch DMG for the runner's arch
   (Apple Silicon on `macos-latest`). If you want a universal DMG, add
   `"target": { "target": "dmg", "arch": ["universal"] }` — separate change.


### PR DESCRIPTION
Fixes the macOS build failure from #129 (my bug, **not** your secrets).

## What broke
```
Invalid configuration object. … configuration.mac.notarize should be a boolean
```
In electron-builder 26, `mac.notarize` must be a **boolean**. My workflow passed `-c.mac.notarize.teamId=<id>`, which the CLI parsed into an **object** `{ teamId: … }` → schema rejected it before the build even started.

## The fix
One line: `-c.mac.notarize.teamId=${{ secrets.APPLE_TEAM_ID }}` → **`-c.mac.notarize=true`**. The team ID still flows in — notarytool reads `APPLE_ID` / `APPLE_APP_SPECIFIC_PASSWORD` / `APPLE_TEAM_ID` from the step's env (all already set). Also updated the workflow comment + the signing spec doc.

## Verified
Ran electron-builder locally with the corrected flag: it **passes config validation** now (proceeds to "building target=DMG" and only stops on `sips`, a macOS-only tool absent on this Linux box — expected and unrelated). YAML re-validated.

## Next
Merge this, then re-run the release (or re-trigger the **Build Desktop App** workflow). With your 5 secrets in place, the `build-macos` job should now sign + notarize. If it fails again, paste the new log and I'll iterate — notarization sometimes surfaces credential/identity mismatches only at runtime, which I can't reproduce here.

https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA)_