### PR TITLE
Phase 4: recent files

### DIFF
--- a/docs/project-modernization/2026-06-15-tasks-session-14-recent-files.md
+++ b/docs/project-modernization/2026-06-15-tasks-session-14-recent-files.md
@@ -1,0 +1,56 @@
+# Tasks — Session 14: Phase 4 (recent files)
+
+**Date:** 2026-06-15
+**Type:** tasks (session-level implementation checklist)
+**Phase:** 4 — differentiators (web persistence)
+
+Remembers recently-opened documents and offers one-click re-open from the
+empty-state drop zone. Persisted across sessions in localStorage.
+
+---
+
+## What shipped
+
+- **`markdown-viewer/src/features/recent-files.js`** (`// @ts-check`):
+  - storage model — `recordRecentFile()` (most-recent-first, de-duplicated by
+    ref, capped at 8), `getRecentFiles()`, `clearRecentFiles()`; persisted under
+    `specdown-recent-files`;
+  - rendering — `renderRecentFiles()` fills a drop-zone list (clickable items
+    showing the filename, the full URL as `title`), hiding the section when
+    empty; `configureRecentFiles({ onSelect })` decouples the re-open action.
+- **`index.html`** — a `#recent-files-section` in the drop zone (a "recent"
+  header + Clear button + list), hidden until there are recents.
+- **`main.js`** — wires `onSelect` to `handleUrl(entry.ref)`, renders on init,
+  and hooks the Clear button.
+- **`file-loading.js`** — records the URL + re-renders after a successful URL
+  open (this also covers GitHub repo-browser picks, which go through `handleUrl`).
+- **CSS** — `.recent-files-*` built on the design tokens.
+
+## Scope decision
+
+**URLs only.** Browser-picked local files can't be reopened by path (the File
+System Access security model), so they're intentionally not recorded — only
+things the app can actually re-fetch (URLs, including GitHub raw links). Desktop
+file-path re-open would need a new pull-style IPC method (`requestOpenPath`) in
+the Electron main process; that's a separate, desktop-only follow-up.
+
+## Verification
+
+- `tests/unit/recentFiles.test.js` (+9): order, de-dup/move-to-top, cap at 8,
+  ignore-without-ref, localStorage persistence, clear; drop-zone rendering
+  (hidden when empty, one clickable item per recent, `onSelect` invoked with the
+  entry on click).
+- `npm run build` ✓, `npm run lint` ✓, `npm run typecheck` ✓, `npm test` →
+  **371 passed**.
+
+## Manual check (visual)
+
+Open a couple of markdown URLs → close them (or reload) → the drop zone shows a
+**recent** list; click one to re-open; the Clear button empties it. Confirm in
+light + dark.
+
+## Possible follow-ups
+
+- Desktop: re-openable recent **file paths** via a new `requestOpenPath` IPC.
+- Session restore (reopen the last document(s) on launch).
+- Surface recents in the command palette too.

--- a/docs/project-modernization/README.md
+++ b/docs/project-modernization/README.md
@@ -23,6 +23,7 @@ three-lens evaluation of the app at v0.0.82 and a phased roadmap.
 | 2026-06-15 | [spec-macos-signing](2026-06-15-spec-macos-signing.md) | Phase 3: macOS code-signing + notarization — the fix for the desktop "damaged"/Gatekeeper error. Wires hardened runtime + entitlements + a signed/notarized (or unsigned-fallback) `build-macos` workflow path; **needs 5 Apple secrets from the user** (setup guide in the doc) |
 | 2026-06-15 | [tasks-session-12-pwa](2026-06-15-tasks-session-12-pwa.md) | Phase 3: PWA — installable + offline web app (manifest + icons + a conservative web-only service worker: network-first navigation, SWR assets, cross-origin never cached); +5 tests |
 | 2026-06-15 | [tasks-session-13-presentation-mode](2026-06-15-tasks-session-13-presentation-mode.md) | Phase 4: diagram presentation mode — full-screen step-through of a document’s Mermaid diagrams (prev/next, counter, keyboard nav), surfaced via a "Present diagrams" palette command; +6 tests |
+| 2026-06-15 | [tasks-session-14-recent-files](2026-06-15-tasks-session-14-recent-files.md) | Phase 4: recent files — remembers recently-opened URLs (localStorage), one-click re-open list on the drop zone with a Clear button; +9 tests |
 | 2026-06-14 | [handoff-next-wave](2026-06-14-handoff-next-wave.md) | **Resume point** — aggregated status, the remaining Phase 3/4 options, and the project gotchas. Start here after a break. |
 
 > **Resuming after a break?** Read **[handoff-next-wave](2026-06-14-handoff-next-wave.md)** first — it's the durable index of what's done, what's next, and the gotchas.

--- a/markdown-viewer/index.html
+++ b/markdown-viewer/index.html
@@ -86,6 +86,13 @@
                     <p id="url-error" class="url-error" style="display: none;"></p>
                     <p class="url-note">Note: Some enterprise GitHub instances may require authentication and won't load here.</p>
                 </div>
+                <div id="recent-files-section" class="recent-files-section" style="display: none;">
+                    <div class="recent-files-header">
+                        <span class="url-separator">recent</span>
+                        <button id="recent-files-clear" class="recent-files-clear" type="button">Clear</button>
+                    </div>
+                    <ul id="recent-files-list" class="recent-files-list"></ul>
+                </div>
             </div>
             <div class="drop-zone-overlay">
                 <p>Drop file to open</p>

--- a/markdown-viewer/src/features/file-loading.js
+++ b/markdown-viewer/src/features/file-loading.js
@@ -6,6 +6,7 @@
 import { normalizeMarkdownUrl } from '../core/utils.js';
 import { handleRepoUrl } from './repo-browser.js';
 import { showToast } from './toast.js';
+import { recordRecentFile, renderRecentFiles } from './recent-files.js';
 
 const VALID_EXTENSIONS = ['.md', '.markdown'];
 const el = (/** @type {string} */ id) => document.getElementById(id);
@@ -121,6 +122,9 @@ export async function handleUrl(url) {
     const markdown = await response.text();
     if (urlInput) urlInput.value = '';
     openTab(filename, markdown);
+    // Remember this URL for one-click re-open from the drop zone.
+    recordRecentFile({ ref: url, title: filename });
+    renderRecentFiles();
   } catch (e) {
     showUrlError(
       'Could not fetch URL — the server may not allow cross-origin requests. Try using the raw file URL.'

--- a/markdown-viewer/src/features/recent-files.js
+++ b/markdown-viewer/src/features/recent-files.js
@@ -1,0 +1,100 @@
+// @ts-check
+// Recent files: remember recently-opened documents and offer one-click re-open
+// from the empty-state drop zone. Persisted in localStorage.
+//
+// Scope: URLs only. Browser-picked local files can't be reopened by path (the
+// File System Access security model), so they're intentionally not recorded —
+// only things the app can actually re-fetch (URLs, incl. GitHub raw links).
+
+const RECENT_KEY = 'specdown-recent-files';
+const RECENT_MAX = 8;
+const el = (/** @type {string} */ id) => document.getElementById(id);
+
+/**
+ * @typedef {object} RecentEntry
+ * @property {'url'} type
+ * @property {string} ref The re-openable reference (the URL).
+ * @property {string} title Display label.
+ */
+
+/** @type {RecentEntry[]} */
+let recentEntries = loadRecent();
+/** @type {(entry: RecentEntry) => void} */
+let selectRecent = () => {};
+
+function loadRecent() {
+  try {
+    const raw = localStorage.getItem(RECENT_KEY);
+    const parsed = raw ? JSON.parse(raw) : [];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (e) {
+    return [];
+  }
+}
+
+function persistRecent() {
+  try {
+    localStorage.setItem(RECENT_KEY, JSON.stringify(recentEntries));
+  } catch (e) {
+    // quota / unavailable — non-critical
+  }
+}
+
+/** @param {{ onSelect?: (entry: RecentEntry) => void }} [deps] */
+export function configureRecentFiles(deps) {
+  if (deps && typeof deps.onSelect === 'function') selectRecent = deps.onSelect;
+}
+
+/** @returns {RecentEntry[]} */
+export function getRecentFiles() {
+  return recentEntries.slice();
+}
+
+/**
+ * Record a freshly-opened document at the top of the recents (most-recent-first,
+ * de-duplicated by ref, capped).
+ * @param {{ type?: 'url', ref: string, title?: string }} entry
+ */
+export function recordRecentFile(entry) {
+  if (!entry || !entry.ref) return;
+  recentEntries = recentEntries.filter((e) => e.ref !== entry.ref);
+  recentEntries.unshift({ type: 'url', ref: entry.ref, title: entry.title || entry.ref });
+  if (recentEntries.length > RECENT_MAX) {
+    recentEntries = recentEntries.slice(0, RECENT_MAX);
+  }
+  persistRecent();
+}
+
+export function clearRecentFiles() {
+  recentEntries = [];
+  persistRecent();
+}
+
+/** Render the recents into the drop-zone section, hiding it when empty. */
+export function renderRecentFiles() {
+  const section = el('recent-files-section');
+  const list = el('recent-files-list');
+  if (!section || !list) return;
+
+  list.innerHTML = '';
+  if (recentEntries.length === 0) {
+    section.style.display = 'none';
+    return;
+  }
+  section.style.display = '';
+
+  for (const entry of recentEntries) {
+    const li = document.createElement('li');
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'recent-file-item';
+    btn.textContent = entry.title;
+    btn.title = entry.ref;
+    btn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      selectRecent(entry);
+    });
+    li.appendChild(btn);
+    list.appendChild(li);
+  }
+}

--- a/markdown-viewer/src/main.js
+++ b/markdown-viewer/src/main.js
@@ -111,6 +111,11 @@ import {
   hasPresentableDiagrams,
 } from './features/presentation.js';
 import {
+  configureRecentFiles,
+  renderRecentFiles,
+  clearRecentFiles,
+} from './features/recent-files.js';
+import {
   setupDesktopIPC,
   updateWatchToggle,
   saveDesktopSession,
@@ -207,11 +212,13 @@ function init() {
     configureDesktop({
         renderMarkdown: (/** @type {string} */ content, /** @type {string} */ title) => renderMarkdown(content, title),
     });
+    configureRecentFiles({ onSelect: (entry) => handleUrl(entry.ref) });
     registerAppCommands();
     setupVersionInfo();
     setupTheme();
     setupIOSNativeUI();
     setupToolbarOverflow();
+    setupRecentFiles();
     setupEventListeners();
     configureMarked();
     checkForUpdates();
@@ -309,6 +316,21 @@ function registerAppCommands() {
             run: () => openShortcutsSheet(),
         },
     ]);
+}
+
+// ===========================
+// Recent Files
+// ===========================
+function setupRecentFiles() {
+    renderRecentFiles();
+    const clearBtn = $('recent-files-clear');
+    if (clearBtn) {
+        clearBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            clearRecentFiles();
+            renderRecentFiles();
+        });
+    }
 }
 
 // ===========================

--- a/markdown-viewer/styles.css
+++ b/markdown-viewer/styles.css
@@ -396,6 +396,67 @@ body {
     opacity: 0.75;
 }
 
+/* ===========================
+   Recent Files (drop zone)
+   =========================== */
+.recent-files-section {
+    margin-top: 1.25rem;
+    width: 100%;
+    max-width: 420px;
+}
+
+.recent-files-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+}
+
+.recent-files-clear {
+    background: transparent;
+    border: none;
+    color: var(--text-secondary);
+    font-size: 0.75rem;
+    cursor: pointer;
+    padding: 0.1rem 0.3rem;
+    border-radius: var(--radius-sm);
+}
+
+.recent-files-clear:hover {
+    color: var(--accent-color);
+    text-decoration: underline;
+}
+
+.recent-files-list {
+    list-style: none;
+    margin: 0.4rem 0 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.recent-file-item {
+    width: 100%;
+    text-align: left;
+    background-color: var(--bg-primary);
+    color: var(--text-primary);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    padding: 0.5rem 0.75rem;
+    font-size: 0.9rem;
+    cursor: pointer;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    transition: var(--transition-fast);
+}
+
+.recent-file-item:hover {
+    border-color: var(--accent-color);
+    background-color: var(--bg-secondary);
+}
+
 .drop-zone-overlay {
     display: none;
     position: absolute;

--- a/tests/unit/recentFiles.test.js
+++ b/tests/unit/recentFiles.test.js
@@ -1,0 +1,97 @@
+/**
+ * Unit tests for the recent-files feature (storage model + drop-zone rendering).
+ */
+
+const { loadHTML, loadApp } = require('../helpers/loadApp');
+require('../mocks/marked');
+require('../mocks/mermaid');
+require('../mocks/panzoom');
+require('../mocks/highlightjs');
+
+describe('Recent files', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    loadHTML(document);
+    loadApp(document);
+  });
+
+  describe('storage model', () => {
+    it('records most-recent-first', () => {
+      recordRecentFile({ ref: 'https://a/one.md', title: 'one.md' });
+      recordRecentFile({ ref: 'https://a/two.md', title: 'two.md' });
+
+      const refs = getRecentFiles().map((e) => e.ref);
+      expect(refs).toEqual(['https://a/two.md', 'https://a/one.md']);
+    });
+
+    it('de-duplicates by ref and moves a repeat to the top', () => {
+      recordRecentFile({ ref: 'https://a/one.md', title: 'one.md' });
+      recordRecentFile({ ref: 'https://a/two.md', title: 'two.md' });
+      recordRecentFile({ ref: 'https://a/one.md', title: 'one.md' });
+
+      const refs = getRecentFiles().map((e) => e.ref);
+      expect(refs).toEqual(['https://a/one.md', 'https://a/two.md']);
+    });
+
+    it('caps the list at 8 entries', () => {
+      for (let i = 0; i < 12; i++) {
+        recordRecentFile({ ref: 'https://a/' + i + '.md', title: i + '.md' });
+      }
+      expect(getRecentFiles().length).toBe(8);
+      // Newest kept, oldest dropped.
+      expect(getRecentFiles()[0].ref).toBe('https://a/11.md');
+    });
+
+    it('ignores entries without a ref', () => {
+      recordRecentFile(/** @type {any} */ ({ title: 'no ref' }));
+      expect(getRecentFiles().length).toBe(0);
+    });
+
+    it('persists to localStorage', () => {
+      recordRecentFile({ ref: 'https://a/one.md', title: 'one.md' });
+      const stored = JSON.parse(localStorage.getItem('specdown-recent-files'));
+      expect(stored[0].ref).toBe('https://a/one.md');
+    });
+
+    it('clears the list', () => {
+      recordRecentFile({ ref: 'https://a/one.md', title: 'one.md' });
+      clearRecentFiles();
+      expect(getRecentFiles()).toEqual([]);
+    });
+  });
+
+  describe('drop-zone rendering', () => {
+    it('hides the section when there are no recents', () => {
+      renderRecentFiles();
+      const section = document.getElementById('recent-files-section');
+      expect(section.style.display).toBe('none');
+    });
+
+    it('renders a clickable item per recent and shows the section', () => {
+      recordRecentFile({ ref: 'https://a/one.md', title: 'one.md' });
+      recordRecentFile({ ref: 'https://a/two.md', title: 'two.md' });
+      renderRecentFiles();
+
+      const section = document.getElementById('recent-files-section');
+      expect(section.style.display).not.toBe('none');
+
+      const items = document.querySelectorAll('.recent-file-item');
+      expect(items.length).toBe(2);
+      expect(items[0].textContent).toBe('two.md');
+      expect(items[0].getAttribute('title')).toBe('https://a/two.md');
+    });
+
+    it('invokes the configured onSelect with the entry when an item is clicked', () => {
+      const onSelect = jest.fn();
+      configureRecentFiles({ onSelect });
+      recordRecentFile({ ref: 'https://a/one.md', title: 'one.md' });
+      renderRecentFiles();
+
+      const item = document.querySelector('.recent-file-item');
+      item.dispatchEvent(new Event('click', { bubbles: true }));
+
+      expect(onSelect).toHaveBeenCalledTimes(1);
+      expect(onSelect.mock.calls[0][0].ref).toBe('https://a/one.md');
+    });
+  });
+});


### PR DESCRIPTION
Remembers recently-opened documents and offers one-click re-open from the empty-state drop zone (persisted in localStorage).

## What's in it
- **`features/recent-files.js`** (`// @ts-check`) — storage model (`recordRecentFile` most-recent-first, de-dup by ref, capped at 8; `getRecentFiles`; `clearRecentFiles`) + `renderRecentFiles()` for the drop-zone list; `configureRecentFiles({ onSelect })` decouples the re-open action.
- **drop zone** — a `#recent-files-section` ("recent" header + Clear button + list), hidden until populated; clicking an item re-opens it.
- **`file-loading.js`** — records + re-renders after a successful URL open (also covers GitHub repo-browser picks, which route through `handleUrl`).
- CSS built on the design tokens.

## Scope decision: URLs only
Browser-picked **local files can't be reopened by path** (File System Access security model), so they aren't recorded — only things the app can re-fetch (URLs, incl. GitHub raw links). Desktop file-path re-open would need a new pull-style IPC (`requestOpenPath`) in the Electron main process — a separate, desktop-only follow-up.

## Verification
- `tests/unit/recentFiles.test.js` (+9): order, de-dup/move-to-top, cap at 8, ignore-without-ref, localStorage persistence, clear; rendering (hidden when empty, one clickable item per recent, `onSelect` called with the entry).
- `npm run build` ✓, `lint` ✓, `typecheck` ✓, `npm test` → **371 passed**.

## Your manual check (visual)
Open a couple of markdown URLs → reload → the drop zone shows a **recent** list; click to re-open; Clear empties it. Confirm in light + dark.

https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA)_