### PR TITLE
Add copy-to-clipboard buttons on code blocks

### DIFF
--- a/docs/project-modernization/2026-06-15-tasks-session-15-code-copy.md
+++ b/docs/project-modernization/2026-06-15-tasks-session-15-code-copy.md
@@ -1,0 +1,40 @@
+# Tasks — Session 15: code-block copy buttons
+
+**Date:** 2026-06-15
+**Type:** tasks (session-level implementation checklist)
+**Phase:** 4 / UX polish
+
+A hover **"Copy"** button on every rendered code block — the modern-viewer
+affordance SpecDown was missing. Works on all three surfaces; excluded from
+print/PDF output.
+
+---
+
+## What shipped
+
+- **`markdown-viewer/src/features/code-copy.js`** (`// @ts-check`):
+  `enhanceCodeBlocks(container)` adds a copy button to each `<pre><code>`
+  (idempotent — skips blocks already enhanced). Click copies the block's text via
+  `navigator.clipboard.writeText`, with a legacy `execCommand('copy')` fallback
+  for non-secure contexts; the button briefly flashes **"Copied"**.
+- **`main.js`** — calls `enhanceCodeBlocks(markdownContent)` after each render
+  (right after `revealHtmlComments`).
+- **`platform/ios-chrome.js`** — adds `.code-copy-btn` to the print-clone strip
+  list so buttons don't appear in printed/PDF output.
+- **CSS** — `.code-copy-btn` positioned top-right of the (now `position:
+  relative`) `<pre>`, revealed on hover/`focus-within`, green "copied" state via
+  `--color-success`, hidden in `@media print`.
+
+## Verification
+
+- `tests/unit/codeCopy.test.js` (+4): one button per code block, no button for a
+  `<pre>` without `<code>`, idempotent re-enhance, click copies the text (mocked
+  clipboard) + flashes feedback.
+- `npm run build` ✓, `npm run lint` ✓, `npm run typecheck` ✓, `npm test` →
+  **375 passed**.
+
+## Manual check (visual)
+
+Open a doc with code blocks → hover a block → a "Copy" button appears top-right →
+click → it copies and flashes "Copied". Confirm in light + dark, and that it
+doesn't show in Print/PDF.

--- a/docs/project-modernization/README.md
+++ b/docs/project-modernization/README.md
@@ -24,6 +24,7 @@ three-lens evaluation of the app at v0.0.82 and a phased roadmap.
 | 2026-06-15 | [tasks-session-12-pwa](2026-06-15-tasks-session-12-pwa.md) | Phase 3: PWA — installable + offline web app (manifest + icons + a conservative web-only service worker: network-first navigation, SWR assets, cross-origin never cached); +5 tests |
 | 2026-06-15 | [tasks-session-13-presentation-mode](2026-06-15-tasks-session-13-presentation-mode.md) | Phase 4: diagram presentation mode — full-screen step-through of a document’s Mermaid diagrams (prev/next, counter, keyboard nav), surfaced via a "Present diagrams" palette command; +6 tests |
 | 2026-06-15 | [tasks-session-14-recent-files](2026-06-15-tasks-session-14-recent-files.md) | Phase 4: recent files — remembers recently-opened URLs (localStorage), one-click re-open list on the drop zone with a Clear button; +9 tests |
+| 2026-06-15 | [tasks-session-15-code-copy](2026-06-15-tasks-session-15-code-copy.md) | UX polish: hover "Copy" button on rendered code blocks (clipboard + execCommand fallback, "Copied" flash, excluded from print); +4 tests |
 | 2026-06-14 | [handoff-next-wave](2026-06-14-handoff-next-wave.md) | **Resume point** — aggregated status, the remaining Phase 3/4 options, and the project gotchas. Start here after a break. |
 
 > **Resuming after a break?** Read **[handoff-next-wave](2026-06-14-handoff-next-wave.md)** first — it's the durable index of what's done, what's next, and the gotchas.

--- a/markdown-viewer/src/features/code-copy.js
+++ b/markdown-viewer/src/features/code-copy.js
@@ -1,0 +1,78 @@
+// @ts-check
+// Copy-to-clipboard buttons on rendered code blocks. After each render, every
+// `<pre><code>` gets a hover "Copy" button that copies the block's text. Works
+// on all surfaces; the button is excluded from print output.
+
+const COPIED_RESET_MS = 1500;
+
+/**
+ * Copy text to the clipboard, with a legacy fallback for non-secure contexts.
+ * @param {string} text
+ * @returns {Promise<void>}
+ */
+function copyToClipboard(text) {
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    return navigator.clipboard.writeText(text);
+  }
+  // Fallback: a temporary off-screen textarea + execCommand.
+  return new Promise((resolve, reject) => {
+    try {
+      const ta = document.createElement('textarea');
+      ta.value = text;
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand('copy');
+      document.body.removeChild(ta);
+      resolve();
+    } catch (err) {
+      reject(err);
+    }
+  });
+}
+
+/**
+ * Add a copy button to every code block inside `container`.
+ * @param {HTMLElement} container
+ */
+export function enhanceCodeBlocks(container) {
+  if (!container) return;
+  container.querySelectorAll('pre').forEach((pre) => {
+    const code = pre.querySelector('code');
+    if (!code) return;
+    // Idempotent: skip if already enhanced.
+    if (pre.querySelector('.code-copy-btn')) return;
+    pre.classList.add('has-code-copy');
+
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'code-copy-btn';
+    button.textContent = 'Copy';
+    button.setAttribute('aria-label', 'Copy code to clipboard');
+
+    button.addEventListener('click', (e) => {
+      e.stopPropagation();
+      copyToClipboard(code.textContent || '').then(
+        () => flash(button, 'Copied'),
+        () => flash(button, 'Failed')
+      );
+    });
+
+    pre.appendChild(button);
+  });
+}
+
+/**
+ * Briefly show feedback text on the button, then restore "Copy".
+ * @param {HTMLButtonElement} button
+ * @param {string} label
+ */
+function flash(button, label) {
+  button.textContent = label;
+  button.classList.add('is-copied');
+  setTimeout(() => {
+    button.textContent = 'Copy';
+    button.classList.remove('is-copied');
+  }, COPIED_RESET_MS);
+}

--- a/markdown-viewer/src/main.js
+++ b/markdown-viewer/src/main.js
@@ -115,6 +115,7 @@ import {
   renderRecentFiles,
   clearRecentFiles,
 } from './features/recent-files.js';
+import { enhanceCodeBlocks } from './features/code-copy.js';
 import {
   setupDesktopIPC,
   updateWatchToggle,
@@ -728,6 +729,9 @@ async function renderMarkdown(content, filename) {
 
         // Make HTML comments visible
         revealHtmlComments(markdownContent);
+
+        // Add copy buttons to code blocks
+        enhanceCodeBlocks(markdownContent);
 
         // Show content area, hide drop zone
         dropZone.style.display = 'none';

--- a/markdown-viewer/src/platform/ios-chrome.js
+++ b/markdown-viewer/src/platform/ios-chrome.js
@@ -149,7 +149,7 @@ function buildPrintableDocument() {
   const printableContent = /** @type {HTMLElement} */ (markdownContent.cloneNode(true));
 
   printableContent
-    .querySelectorAll('.diagram-controls, .annotation-popover, .search-highlight, .search-highlight-current')
+    .querySelectorAll('.diagram-controls, .annotation-popover, .search-highlight, .search-highlight-current, .code-copy-btn')
     .forEach((element) => element.remove());
   printableContent.querySelectorAll('.annotation-badge').forEach((badge) => badge.remove());
   printableContent.querySelectorAll('.has-annotation').forEach((element) => {

--- a/markdown-viewer/styles.css
+++ b/markdown-viewer/styles.css
@@ -764,6 +764,51 @@ body {
     padding: 1em;
     overflow-x: auto;
     margin-bottom: 1em;
+    position: relative;
+}
+
+/* ===========================
+   Code Block Copy Button
+   =========================== */
+.code-copy-btn {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    padding: 0.2rem 0.55rem;
+    font-size: 0.72rem;
+    font-family: var(--font-sans);
+    color: #e6edf3;
+    background-color: rgba(255, 255, 255, 0.08);
+    border: 1px solid #30363d;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 0.12s ease, background-color 0.12s ease;
+}
+
+.markdown-content pre:hover .code-copy-btn,
+.markdown-content pre:focus-within .code-copy-btn {
+    opacity: 1;
+}
+
+.code-copy-btn:hover {
+    background-color: rgba(255, 255, 255, 0.16);
+}
+
+.code-copy-btn:focus-visible {
+    opacity: 1;
+}
+
+.code-copy-btn.is-copied {
+    color: #fff;
+    background-color: var(--color-success);
+    border-color: var(--color-success);
+}
+
+@media print {
+    .code-copy-btn {
+        display: none;
+    }
 }
 
 .markdown-content pre code {

--- a/tests/unit/codeCopy.test.js
+++ b/tests/unit/codeCopy.test.js
@@ -1,0 +1,69 @@
+/**
+ * Unit tests for code-block copy buttons.
+ */
+
+const { loadHTML, loadApp } = require('../helpers/loadApp');
+require('../mocks/marked');
+require('../mocks/mermaid');
+require('../mocks/panzoom');
+require('../mocks/highlightjs');
+
+function makeContainer(html) {
+  const container = document.createElement('div');
+  container.innerHTML = html;
+  document.body.appendChild(container);
+  return container;
+}
+
+describe('Code block copy buttons', () => {
+  beforeEach(() => {
+    loadHTML(document);
+    loadApp(document);
+  });
+
+  it('adds one copy button per code block', () => {
+    const container = makeContainer(
+      '<pre><code>one()</code></pre><p>text</p><pre><code>two()</code></pre>'
+    );
+    enhanceCodeBlocks(container);
+
+    const buttons = container.querySelectorAll('.code-copy-btn');
+    expect(buttons.length).toBe(2);
+    expect(buttons[0].getAttribute('aria-label')).toBe('Copy code to clipboard');
+  });
+
+  it('does not add a button to a <pre> without a <code> child', () => {
+    const container = makeContainer('<pre>raw text, no code element</pre>');
+    enhanceCodeBlocks(container);
+    expect(container.querySelector('.code-copy-btn')).toBeNull();
+  });
+
+  it('is idempotent (no duplicate buttons on re-enhance)', () => {
+    const container = makeContainer('<pre><code>x()</code></pre>');
+    enhanceCodeBlocks(container);
+    enhanceCodeBlocks(container);
+    expect(container.querySelectorAll('.code-copy-btn').length).toBe(1);
+  });
+
+  it('copies the code text to the clipboard on click', async () => {
+    const writeText = jest.fn(() => Promise.resolve());
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+
+    const container = makeContainer('<pre><code>console.log("hi")</code></pre>');
+    enhanceCodeBlocks(container);
+
+    const button = container.querySelector('.code-copy-btn');
+    button.dispatchEvent(new Event('click', { bubbles: true }));
+
+    expect(writeText).toHaveBeenCalledWith('console.log("hi")');
+
+    // Button flashes feedback then resets.
+    await Promise.resolve();
+    expect(button.textContent).toBe('Copied');
+
+    delete navigator.clipboard;
+  });
+});


### PR DESCRIPTION
A hover **"Copy"** button on every rendered code block — the modern-viewer affordance SpecDown was missing. Works on web/desktop/iOS; excluded from print/PDF.

## What's in it
- **`features/code-copy.js`** (`// @ts-check`): `enhanceCodeBlocks(container)` adds a copy button to each `<pre><code>` (idempotent). Click copies via `navigator.clipboard.writeText` with an `execCommand('copy')` fallback for non-secure contexts; the button briefly flashes **"Copied"**.
- **`main.js`**: runs it after each render (after `revealHtmlComments`).
- **`ios-chrome.js`**: `.code-copy-btn` added to the print-clone strip list, so buttons don't show in printed/PDF output.
- **CSS**: button top-right of the (now `position: relative`) `<pre>`, revealed on hover / `focus-within`, green "copied" state via `--color-success`, hidden in `@media print`.

## Verification
- `tests/unit/codeCopy.test.js` (+4): one button per block, none for a `<pre>` without `<code>`, idempotent re-enhance, click copies the text (mocked clipboard) + flashes feedback.
- `npm run build` ✓, `lint` ✓, `typecheck` ✓, `npm test` → **375 passed**.

## Your manual check (visual)
Hover a code block → "Copy" appears top-right → click → it copies + flashes "Copied". Confirm in light + dark, and that it's absent from Print/PDF.

https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA)_