### PR TITLE
Phase 4: presentation mode — zoom/pan + discoverable button

### DIFF
--- a/docs/project-modernization/2026-06-15-tasks-session-16-presentation-enhancements.md
+++ b/docs/project-modernization/2026-06-15-tasks-session-16-presentation-enhancements.md
@@ -1,0 +1,44 @@
+# Tasks — Session 16: presentation mode enhancements (zoom + discoverability)
+
+**Date:** 2026-06-15
+**Type:** tasks (session-level implementation checklist)
+**Phase:** 4 — differentiators
+
+Two follow-ups to the diagram presentation mode (session 13 / #132): **pan/zoom
+inside a slide** and a **discoverable toolbar button** (it was only reachable via
+the command palette before).
+
+---
+
+## What shipped
+
+### Zoom / pan in slides
+- `features/presentation.js` now applies **Panzoom** (the library already bundled
+  for the diagram engine) to each staged slide. The nav bar gains **− / ⤢ / +**
+  controls; **mouse-wheel** zooms; the keyboard adds **+ / - / 0** (in addition
+  to the existing arrows/Esc). The instance is destroyed and recreated per slide,
+  and destroyed on exit (no leaks).
+
+### Discoverable "Present" button
+- A `#present-button` in the content-header toolbar, **shown only when the
+  rendered document has ≥1 diagram** (toggled in `renderMarkdown` right after
+  diagrams process). Clicking it starts the presentation.
+- Added to the **overflow "⋮" menu** (`OVERFLOW_ACTIONS`), and the overflow menu
+  now **skips inline-hidden targets**, so "Present diagrams" only appears there
+  when the button is actually available. It collapses behind the overflow menu on
+  narrow viewports like the other secondary actions.
+
+## Verification
+
+- `tests/unit/presentation.test.js` (+3): zoom buttons drive the slide panzoom,
+  keyboard `+`/`-`/`0` zoom, panzoom destroyed on exit.
+- `tests/unit/toolbarOverflow.test.js` (+1): the menu skips the hidden Present
+  button and includes it once visible.
+- `npm run build` ✓, `npm run lint` ✓, `npm run typecheck` ✓, `npm test` →
+  **379 passed**.
+
+## Manual check (visual)
+
+Open a doc with diagrams → a **Present** button appears in the toolbar (and in the
+⋮ menu on narrow screens; Cmd/Ctrl+K still works) → start it → zoom with the
++/−/⤢ buttons, the mouse wheel, or +/-/0; pan by dragging. Confirm light + dark.

--- a/docs/project-modernization/README.md
+++ b/docs/project-modernization/README.md
@@ -25,6 +25,7 @@ three-lens evaluation of the app at v0.0.82 and a phased roadmap.
 | 2026-06-15 | [tasks-session-13-presentation-mode](2026-06-15-tasks-session-13-presentation-mode.md) | Phase 4: diagram presentation mode — full-screen step-through of a document’s Mermaid diagrams (prev/next, counter, keyboard nav), surfaced via a "Present diagrams" palette command; +6 tests |
 | 2026-06-15 | [tasks-session-14-recent-files](2026-06-15-tasks-session-14-recent-files.md) | Phase 4: recent files — remembers recently-opened URLs (localStorage), one-click re-open list on the drop zone with a Clear button; +9 tests |
 | 2026-06-15 | [tasks-session-15-code-copy](2026-06-15-tasks-session-15-code-copy.md) | UX polish: hover "Copy" button on rendered code blocks (clipboard + execCommand fallback, "Copied" flash, excluded from print); +4 tests |
+| 2026-06-15 | [tasks-session-16-presentation-enhancements](2026-06-15-tasks-session-16-presentation-enhancements.md) | Phase 4: presentation mode enhancements — pan/zoom inside a slide (Panzoom: −/⤢/+ buttons, wheel, +/-/0 keys) + a discoverable "Present" toolbar button (overflow-aware); +4 tests |
 | 2026-06-14 | [handoff-next-wave](2026-06-14-handoff-next-wave.md) | **Resume point** — aggregated status, the remaining Phase 3/4 options, and the project gotchas. Start here after a break. |
 
 > **Resuming after a break?** Read **[handoff-next-wave](2026-06-14-handoff-next-wave.md)** first — it's the durable index of what's done, what's next, and the gotchas.

--- a/markdown-viewer/index.html
+++ b/markdown-viewer/index.html
@@ -127,6 +127,10 @@
                         <span class="print-button-icon" aria-hidden="true">⎙</span>
                         <span class="print-button-label">Print</span>
                     </button>
+                    <button id="present-button" class="present-button" title="Present diagrams full-screen" aria-label="Present diagrams" style="display: none;">
+                        <span class="present-button-icon" aria-hidden="true">▶</span>
+                        <span class="present-button-label">Present</span>
+                    </button>
                     <button id="view-toggle" class="view-toggle-button" title="Toggle between preview and raw markdown" aria-label="Toggle raw markdown view">
                         <span class="view-toggle-icon" aria-hidden="true">&lt;/&gt;</span>
                         <span class="view-toggle-label">Raw</span>

--- a/markdown-viewer/src/features/presentation.js
+++ b/markdown-viewer/src/features/presentation.js
@@ -1,10 +1,13 @@
 // @ts-check
 // Diagram presentation mode: a focused, full-screen step-through of every
 // Mermaid diagram in the current document. Each diagram's already-rendered SVG
-// is cloned into a fit-to-screen stage; prev/next (buttons or keyboard) walk the
-// set. Self-contained — it doesn't touch the panzoom/fullscreen engine.
+// is cloned into a stage with pan/zoom (via the bundled Panzoom); prev/next
+// (buttons or keyboard) walk the set.
 
+import Panzoom from '@panzoom/panzoom';
 import { showToast } from './toast.js';
+
+/** @typedef {import('@panzoom/panzoom').PanzoomObject} PanzoomObject */
 
 const el = (/** @type {string} */ id) => document.getElementById(id);
 
@@ -15,6 +18,8 @@ let diagrams = [];
 let slideIndex = 0;
 /** @type {Element | null} */
 let presentationPrevFocus = null;
+/** @type {PanzoomObject | null} */
+let slidePanzoom = null;
 
 /** Collect the rendered diagram SVGs in document order. */
 function collectDiagrams() {
@@ -51,6 +56,26 @@ export function startPresentation() {
   renderSlide();
 }
 
+/**
+ * @param {string} className
+ * @param {string} label
+ * @param {string} ariaLabel
+ * @param {() => void} onClick
+ * @returns {HTMLButtonElement}
+ */
+function navButton(className, label, ariaLabel, onClick) {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = className;
+  button.textContent = label;
+  button.setAttribute('aria-label', ariaLabel);
+  button.addEventListener('click', (e) => {
+    e.stopPropagation();
+    onClick();
+  });
+  return button;
+}
+
 function buildPresentationOverlay() {
   presentationOverlay = document.createElement('div');
   presentationOverlay.className = 'presentation-overlay';
@@ -62,43 +87,61 @@ function buildPresentationOverlay() {
 
   const stage = document.createElement('div');
   stage.className = 'presentation-stage';
+  // Wheel zoom on the stage drives the current slide's panzoom.
+  stage.addEventListener(
+    'wheel',
+    (e) => {
+      if (slidePanzoom) {
+        e.preventDefault();
+        slidePanzoom.zoomWithWheel(e);
+      }
+    },
+    { passive: false }
+  );
 
   const nav = document.createElement('div');
   nav.className = 'presentation-nav';
 
-  const prev = document.createElement('button');
-  prev.className = 'presentation-prev';
-  prev.type = 'button';
-  prev.setAttribute('aria-label', 'Previous diagram');
-  prev.textContent = '‹';
-  prev.addEventListener('click', presentPrev);
-
+  const prev = navButton('presentation-prev', '‹', 'Previous diagram', presentPrev);
   const counter = document.createElement('span');
   counter.className = 'presentation-counter';
+  const next = navButton('presentation-next', '›', 'Next diagram', presentNext);
 
-  const next = document.createElement('button');
-  next.className = 'presentation-next';
-  next.type = 'button';
-  next.setAttribute('aria-label', 'Next diagram');
-  next.textContent = '›';
-  next.addEventListener('click', presentNext);
+  const zoomOut = navButton('presentation-zoom-out', '−', 'Zoom out', () => {
+    if (slidePanzoom) slidePanzoom.zoomOut();
+  });
+  const zoomFit = navButton('presentation-zoom-fit', '⤢', 'Reset zoom', () => {
+    if (slidePanzoom) slidePanzoom.reset();
+  });
+  const zoomIn = navButton('presentation-zoom-in', '+', 'Zoom in', () => {
+    if (slidePanzoom) slidePanzoom.zoomIn();
+  });
 
-  const close = document.createElement('button');
-  close.className = 'presentation-close';
-  close.type = 'button';
-  close.setAttribute('aria-label', 'Exit presentation');
-  close.textContent = '✕';
-  close.addEventListener('click', exitPresentation);
+  const close = navButton('presentation-close', '✕', 'Exit presentation', exitPresentation);
 
   nav.appendChild(prev);
   nav.appendChild(counter);
   nav.appendChild(next);
+  nav.appendChild(zoomOut);
+  nav.appendChild(zoomFit);
+  nav.appendChild(zoomIn);
   nav.appendChild(close);
 
   presentationOverlay.appendChild(stage);
   presentationOverlay.appendChild(nav);
   document.body.appendChild(presentationOverlay);
   presentationOverlay.focus();
+}
+
+function destroySlidePanzoom() {
+  if (slidePanzoom) {
+    try {
+      slidePanzoom.destroy();
+    } catch (err) {
+      // ignore
+    }
+    slidePanzoom = null;
+  }
 }
 
 function renderSlide() {
@@ -109,6 +152,7 @@ function renderSlide() {
   const next = /** @type {HTMLButtonElement | null} */ (presentationOverlay.querySelector('.presentation-next'));
   if (!stage) return;
 
+  destroySlidePanzoom();
   stage.innerHTML = '';
   const svg = diagrams[slideIndex];
   if (svg) {
@@ -118,6 +162,12 @@ function renderSlide() {
     clone.removeAttribute('height');
     clone.removeAttribute('style');
     stage.appendChild(clone);
+    slidePanzoom = Panzoom(clone, {
+      maxScale: 8,
+      minScale: 0.5,
+      step: 0.3,
+      cursor: 'grab',
+    });
   }
 
   if (counter) counter.textContent = `${slideIndex + 1} / ${diagrams.length}`;
@@ -141,6 +191,7 @@ export function presentPrev() {
 
 export function exitPresentation() {
   if (!presentationOverlay) return;
+  destroySlidePanzoom();
   if (presentationOverlay.parentNode) presentationOverlay.parentNode.removeChild(presentationOverlay);
   presentationOverlay = null;
   diagrams = [];
@@ -159,6 +210,15 @@ function onPresentationKeydown(e) {
   } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp' || e.key === 'PageUp') {
     e.preventDefault();
     presentPrev();
+  } else if (e.key === '+' || e.key === '=') {
+    e.preventDefault();
+    if (slidePanzoom) slidePanzoom.zoomIn();
+  } else if (e.key === '-') {
+    e.preventDefault();
+    if (slidePanzoom) slidePanzoom.zoomOut();
+  } else if (e.key === '0') {
+    e.preventDefault();
+    if (slidePanzoom) slidePanzoom.reset();
   } else if (e.key === 'Escape') {
     e.preventDefault();
     exitPresentation();

--- a/markdown-viewer/src/features/toolbar-overflow.js
+++ b/markdown-viewer/src/features/toolbar-overflow.js
@@ -11,6 +11,7 @@ const OVERFLOW_ACTIONS = [
   { targetId: 'toc-toggle', label: 'Table of contents' },
   { targetId: 'split-toggle', label: 'Split view' },
   { targetId: 'annotation-toggle', label: 'Annotate' },
+  { targetId: 'present-button', label: 'Present diagrams' },
   { targetId: 'print-button', label: 'Print / Save as PDF' },
   { targetId: 'view-toggle', label: 'Toggle raw / preview' },
 ];
@@ -34,6 +35,8 @@ export function openOverflowMenu() {
   for (const action of OVERFLOW_ACTIONS) {
     const target = el(action.targetId);
     if (!target) continue;
+    // Skip actions whose button is inline-hidden (e.g. Present with no diagrams).
+    if (target.style.display === 'none') continue;
     const item = document.createElement('button');
     item.className = 'overflow-menu-item';
     item.setAttribute('role', 'menuitem');

--- a/markdown-viewer/src/main.js
+++ b/markdown-viewer/src/main.js
@@ -169,6 +169,7 @@ const splitToggle = $('split-toggle');
 const splitRawPane = $('split-raw-pane');
 const splitRawContent = $('split-raw-content');
 const printButton = $('print-button');
+const presentButton = $('present-button');
 const searchBar = $('search-bar');
 const searchInput = /** @type {HTMLInputElement | null} */ ($('search-input'));
 const searchPrev = $('search-prev');
@@ -458,6 +459,11 @@ function setupEventListeners() {
         printButton.addEventListener('click', performPrint);
     }
 
+    // Present button (shown only when the document has diagrams)
+    if (presentButton) {
+        presentButton.addEventListener('click', () => startPresentation());
+    }
+
     if (iosOpenButton) {
         iosOpenButton.addEventListener('click', () => {
             closeIOSActionSheet();
@@ -740,6 +746,11 @@ async function renderMarkdown(content, filename) {
 
         // Process mermaid diagrams
         await processMermaidDiagrams();
+
+        // Reveal the Present button only when there are diagrams to present
+        if (presentButton) {
+            presentButton.style.display = hasPresentableDiagrams() ? '' : 'none';
+        }
 
         // Refresh TOC
         buildToc();

--- a/markdown-viewer/styles.css
+++ b/markdown-viewer/styles.css
@@ -643,7 +643,8 @@ body {
     50%      { opacity: 0.45; transform: scale(1.35); }
 }
 
-.view-toggle-button {
+.view-toggle-button,
+.present-button {
     background-color: var(--bg-tertiary);
     color: var(--text-primary);
     border: 1px solid var(--border-color);
@@ -655,6 +656,12 @@ body {
     display: flex;
     align-items: center;
     gap: 0.4rem;
+}
+
+.present-button:hover {
+    background-color: var(--accent-color);
+    color: var(--text-on-accent);
+    border-color: var(--accent-color);
 }
 
 .view-toggle-button:hover {
@@ -2328,6 +2335,7 @@ mark.search-highlight-current {
     .content-header-actions #toc-toggle,
     .content-header-actions #split-toggle,
     .content-header-actions #annotation-toggle,
+    .content-header-actions #present-button,
     .content-header-actions #print-button {
         display: none;
     }

--- a/tests/unit/presentation.test.js
+++ b/tests/unit/presentation.test.js
@@ -118,4 +118,51 @@ describe('Diagram presentation mode', () => {
     expect(isPresentationOpen()).toBe(false);
     expect(document.querySelector('.presentation-overlay')).toBeNull();
   });
+
+  describe('zoom', () => {
+    function currentPanzoom() {
+      const results = Panzoom.mock.results;
+      return results[results.length - 1].value;
+    }
+
+    it('drives the slide panzoom from the zoom buttons', () => {
+      Panzoom.mockClear();
+      addDiagrams(1);
+      startPresentation();
+      const pz = currentPanzoom();
+      expect(pz.getScale()).toBe(1);
+
+      document
+        .querySelector('.presentation-zoom-in')
+        .dispatchEvent(new Event('click', { bubbles: true }));
+      expect(pz.getScale()).toBeGreaterThan(1);
+
+      document
+        .querySelector('.presentation-zoom-fit')
+        .dispatchEvent(new Event('click', { bubbles: true }));
+      expect(pz.getScale()).toBe(1);
+    });
+
+    it('zooms with the keyboard (+ / - / 0)', () => {
+      Panzoom.mockClear();
+      addDiagrams(1);
+      startPresentation();
+      const pz = currentPanzoom();
+      const overlay = document.querySelector('.presentation-overlay');
+
+      overlay.dispatchEvent(new KeyboardEvent('keydown', { key: '+', bubbles: true }));
+      expect(pz.getScale()).toBeGreaterThan(1);
+      overlay.dispatchEvent(new KeyboardEvent('keydown', { key: '0', bubbles: true }));
+      expect(pz.getScale()).toBe(1);
+    });
+
+    it('destroys the panzoom instance on exit', () => {
+      Panzoom.mockClear();
+      addDiagrams(1);
+      startPresentation();
+      const pz = currentPanzoom();
+      exitPresentation();
+      expect(pz.destroyed).toBe(true);
+    });
+  });
 });

--- a/tests/unit/toolbarOverflow.test.js
+++ b/tests/unit/toolbarOverflow.test.js
@@ -36,6 +36,24 @@ describe('Toolbar overflow menu', () => {
     expect(menu.closest('.content-header-actions')).not.toBeNull();
   });
 
+  it('skips inline-hidden targets (e.g. Present with no diagrams)', () => {
+    const present = document.getElementById('present-button');
+    // Hidden by default (no diagrams) → not offered in the menu.
+    expect(present.style.display).toBe('none');
+    openOverflowMenu();
+    let labels = Array.from(document.querySelectorAll('.overflow-menu-item')).map(
+      (i) => i.textContent
+    );
+    expect(labels).not.toContain('Present diagrams');
+    closeOverflowMenu();
+
+    // Once visible (diagrams present), it appears.
+    present.style.display = '';
+    openOverflowMenu();
+    labels = Array.from(document.querySelectorAll('.overflow-menu-item')).map((i) => i.textContent);
+    expect(labels).toContain('Present diagrams');
+  });
+
   it('opens via the overflow toggle button and syncs aria-expanded', () => {
     const toggle = document.getElementById('overflow-toggle');
     expect(toggle.getAttribute('aria-expanded')).toBe('false');


### PR DESCRIPTION
Two follow-ups to diagram presentation mode (#132), since it shipped fit-to-screen-only and hidden behind Cmd/Ctrl+K.

## Zoom / pan in slides
`features/presentation.js` now applies **Panzoom** (the library already bundled for the diagram engine) to each staged slide:
- nav bar gains **− / ⤢ / +** controls, **mouse-wheel** zoom, and **+ / - / 0** keys (alongside the existing arrows/Esc);
- the instance is recreated per slide and **destroyed on slide-change + exit** (no leaks).

## Discoverable "Present" button
- A `#present-button` in the content-header toolbar, **shown only when the rendered doc has ≥1 diagram** (toggled in `renderMarkdown` after diagrams process); click → start presentation.
- Added to the **overflow "⋮" menu**, which now **skips inline-hidden targets** so "Present diagrams" only appears there when available; collapses behind the overflow menu on narrow viewports like the other secondary actions.

## Verification
- `presentation.test.js` (+3): zoom buttons drive the panzoom, keyboard `+`/`-`/`0`, destroy-on-exit. `toolbarOverflow.test.js` (+1): menu skips the hidden Present button, includes it once visible.
- `npm run build` ✓, `lint` ✓, `typecheck` ✓, `npm test` → **379 passed**.

## Your manual check (visual)
Open a doc with diagrams → a **Present** button appears in the toolbar (Cmd/Ctrl+K still works too) → start → zoom with +/−/⤢, the wheel, or +/-/0; drag to pan. Confirm light + dark.

https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA)_