### PR TITLE
Phase 4: session restore (reopen last document on launch)

### DIFF
--- a/docs/project-modernization/2026-06-15-tasks-session-17-session-restore.md
+++ b/docs/project-modernization/2026-06-15-tasks-session-17-session-restore.md
@@ -1,0 +1,47 @@
+# Tasks — Session 17: session restore (reopen last document)
+
+**Date:** 2026-06-15
+**Type:** tasks (session-level implementation checklist)
+**Phase:** 4 — differentiators (web persistence)
+
+On launch, reopen the document you last had open — picking up where you left
+off. Builds directly on the recent-files store (the most-recent entry *is* the
+last document).
+
+---
+
+## What shipped
+
+- **`features/recent-files.js`** — `restoreLastSession()`: re-opens the most
+  recent entry via the configured `onSelect` (which is `handleUrl`); no-op when
+  there's nothing to restore.
+- **`main.js` `init()`** — calls it **web-only** and only when nothing else has
+  already opened:
+  ```js
+  if (!isDesktop && !isIOSNative && state.tabs.length === 0) restoreLastSession();
+  ```
+  - excluded on the Electron / iOS shells (they manage their own session);
+  - skipped when a shared **`?diagram=`** link already opened a document
+    (`checkForDiagramLink` runs first, so `state.tabs` would be non-empty).
+
+## Scope / behavior note
+
+**Auto-reopen, URLs only.** Like recent files, only re-fetchable sources are
+restorable — the URL is re-fetched on launch (no stale cached content). If you'd
+rather this be a dismissible **"Resume <title>?"** prompt instead of an automatic
+reopen, that's a one-line change at the call site — say the word. Closing the
+restored document drops you back to the drop zone (with the recents list).
+
+## Verification
+
+- `tests/unit/recentFiles.test.js` (+4): `restoreLastSession` no-ops with no
+  history and re-opens the most-recent entry via `onSelect`; on-launch
+  integration — a stored session triggers a fetch for the URL at startup, and
+  nothing is reopened when there's no stored session.
+- `npm run build` ✓, `npm run lint` ✓, `npm run typecheck` ✓, `npm test` →
+  **383 passed**.
+
+## Manual check (visual)
+
+Open a markdown URL → reload the page → it reopens automatically. With no history,
+the drop zone shows as before.

--- a/docs/project-modernization/README.md
+++ b/docs/project-modernization/README.md
@@ -26,6 +26,7 @@ three-lens evaluation of the app at v0.0.82 and a phased roadmap.
 | 2026-06-15 | [tasks-session-14-recent-files](2026-06-15-tasks-session-14-recent-files.md) | Phase 4: recent files — remembers recently-opened URLs (localStorage), one-click re-open list on the drop zone with a Clear button; +9 tests |
 | 2026-06-15 | [tasks-session-15-code-copy](2026-06-15-tasks-session-15-code-copy.md) | UX polish: hover "Copy" button on rendered code blocks (clipboard + execCommand fallback, "Copied" flash, excluded from print); +4 tests |
 | 2026-06-15 | [tasks-session-16-presentation-enhancements](2026-06-15-tasks-session-16-presentation-enhancements.md) | Phase 4: presentation mode enhancements — pan/zoom inside a slide (Panzoom: −/⤢/+ buttons, wheel, +/-/0 keys) + a discoverable "Present" toolbar button (overflow-aware); +4 tests |
+| 2026-06-15 | [tasks-session-17-session-restore](2026-06-15-tasks-session-17-session-restore.md) | Phase 4: session restore — reopen the last-opened document on launch (web only, URL re-fetch; skipped in native shells / when a diagram link opened something); +4 tests |
 | 2026-06-14 | [handoff-next-wave](2026-06-14-handoff-next-wave.md) | **Resume point** — aggregated status, the remaining Phase 3/4 options, and the project gotchas. Start here after a break. |
 
 > **Resuming after a break?** Read **[handoff-next-wave](2026-06-14-handoff-next-wave.md)** first — it's the durable index of what's done, what's next, and the gotchas.

--- a/markdown-viewer/src/features/recent-files.js
+++ b/markdown-viewer/src/features/recent-files.js
@@ -70,6 +70,17 @@ export function clearRecentFiles() {
   persistRecent();
 }
 
+/**
+ * Session restore: re-open the most recently opened document via the configured
+ * `onSelect`. No-op when there's nothing to restore. Callers gate this to the
+ * web surface (the native shells have their own session handling).
+ */
+export function restoreLastSession() {
+  if (recentEntries.length > 0) {
+    selectRecent(recentEntries[0]);
+  }
+}
+
 /** Render the recents into the drop-zone section, hiding it when empty. */
 export function renderRecentFiles() {
   const section = el('recent-files-section');

--- a/markdown-viewer/src/main.js
+++ b/markdown-viewer/src/main.js
@@ -114,6 +114,7 @@ import {
   configureRecentFiles,
   renderRecentFiles,
   clearRecentFiles,
+  restoreLastSession,
 } from './features/recent-files.js';
 import { enhanceCodeBlocks } from './features/code-copy.js';
 import {
@@ -226,6 +227,12 @@ function init() {
     checkForUpdates();
     checkForDiagramLink();
     registerServiceWorker();
+    // Session restore (web only): reopen the last document on launch, unless a
+    // shared diagram link already opened something. The native shells manage
+    // their own session, so they're excluded.
+    if (!isDesktop && !isIOSNative && state.tabs.length === 0) {
+        restoreLastSession();
+    }
     if (isDesktop) {
         setupDesktopIPC();
     }

--- a/tests/unit/recentFiles.test.js
+++ b/tests/unit/recentFiles.test.js
@@ -94,4 +94,53 @@ describe('Recent files', () => {
       expect(onSelect.mock.calls[0][0].ref).toBe('https://a/one.md');
     });
   });
+
+  describe('session restore', () => {
+    it('does nothing when there is no last session', () => {
+      const onSelect = jest.fn();
+      configureRecentFiles({ onSelect });
+      restoreLastSession();
+      expect(onSelect).not.toHaveBeenCalled();
+    });
+
+    it('re-opens the most recent document via onSelect', () => {
+      const onSelect = jest.fn();
+      recordRecentFile({ ref: 'https://a/old.md', title: 'old.md' });
+      recordRecentFile({ ref: 'https://a/last.md', title: 'last.md' });
+      configureRecentFiles({ onSelect });
+
+      restoreLastSession();
+
+      expect(onSelect).toHaveBeenCalledTimes(1);
+      expect(onSelect.mock.calls[0][0].ref).toBe('https://a/last.md');
+    });
+  });
+});
+
+describe('Session restore on launch', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('reopens the stored last document when the app starts', () => {
+    localStorage.setItem(
+      'specdown-recent-files',
+      JSON.stringify([{ type: 'url', ref: 'https://example.com/a.md', title: 'a.md' }])
+    );
+    loadHTML(document);
+    loadApp(document);
+
+    // init() should have kicked off a fetch for the restored URL.
+    expect(global.fetch).toHaveBeenCalledWith('https://example.com/a.md', expect.anything());
+  });
+
+  it('does not reopen anything when there is no stored session', () => {
+    loadHTML(document);
+    loadApp(document);
+
+    expect(global.fetch).not.toHaveBeenCalledWith(
+      'https://example.com/a.md',
+      expect.anything()
+    );
+  });
 });


### PR DESCRIPTION
First of the three you asked for. On launch, reopen the document you last had open — picking up where you left off. Builds on the recent-files store (the most-recent entry *is* the last doc).

## What's in it
- **`recent-files.js`** — `restoreLastSession()`: re-opens the most-recent entry via the configured `onSelect` (= `handleUrl`); no-op with no history.
- **`main.js init()`** — calls it **web-only**, and only when nothing else already opened:
  `if (!isDesktop && !isIOSNative && state.tabs.length === 0) restoreLastSession();`
  So the Electron/iOS shells (own session handling) and shared `?diagram=` links take precedence.

## Behavior note (your call)
**Auto-reopen, URLs only** — the URL is re-fetched on launch (no stale content). If you'd rather a dismissible **"Resume &lt;title&gt;?"** prompt than an automatic reopen, it's a one-line swap at the call site — just say so. Closing the restored doc returns you to the drop zone + recents.

## Verification
- `recentFiles.test.js` (+4): `restoreLastSession` no-ops empty / re-opens the most-recent via `onSelect`; on-launch integration — a stored session fetches the URL at startup, none when there's no history.
- `npm run build` ✓, `lint` ✓, `typecheck` ✓, `npm test` → **383 passed**.

## Your manual check
Open a markdown URL → reload → it reopens automatically; with no history the drop zone shows as before.

Next: **annotations 2.0 (export/import)**, then **desktop recent file-paths**.

https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA)_