### PR TITLE
Annotations 2.0: export / import the annotation store

### DIFF
--- a/docs/project-modernization/2026-06-15-tasks-session-18-annotations-export.md
+++ b/docs/project-modernization/2026-06-15-tasks-session-18-annotations-export.md
@@ -1,0 +1,47 @@
+# Tasks — Session 18: annotations 2.0 (export / import)
+
+**Date:** 2026-06-15
+**Type:** tasks (session-level implementation checklist)
+**Phase:** 4 — differentiators
+
+Annotations have lived only in `localStorage` (per browser/device). This session
+makes them **portable**: export the full store as JSON and import it back,
+merging across devices so notes can be shared or backed up.
+
+---
+
+## What shipped
+
+### Export
+- `features/annotations.js` gains `getAnnotationsJSON()` (pretty-printed dump of
+  the whole `specdown-annotations` store) and `exportAnnotations()`, which
+  downloads it as `specdown-annotations.json` via a transient `<a download>`
+  blob URL (revoked after the click).
+
+### Import (merge)
+- `importAnnotations(jsonText)` parses and **merges** into the existing store:
+  per file, incoming notes win on an element-index conflict; untouched files and
+  notes are preserved. Invalid JSON or a non-object payload is rejected with an
+  **error toast**; success reports the document count. If the imported file is
+  the one currently open, its badges re-render immediately.
+- `importAnnotationsFromFile()` opens a hidden `<input type="file">` picker and
+  feeds the chosen file through `importAnnotations`.
+
+### Wiring
+- Two command-palette commands in `main.js`: **Export annotations** and
+  **Import annotations** (the latter opens the file picker).
+
+## Verification
+
+- `tests/unit/annotations.test.js` (+6): export emits pretty JSON; empty store
+  exports `{}`; import merges across files; incoming wins on a key conflict;
+  invalid JSON and non-object payloads are both rejected with an error toast.
+- `npm run build` ✓, `npm run lint` ✓ (0 errors), `npm run typecheck` ✓,
+  `npm test` → **385 passed**.
+
+## Manual check (visual)
+
+Add a few annotations to a doc → command palette (Cmd/Ctrl+K) → **Export
+annotations** downloads a JSON file. Clear storage or switch device → **Import
+annotations** → pick the file → badges reappear; a success toast names the
+document count. Confirm light + dark.

--- a/docs/project-modernization/README.md
+++ b/docs/project-modernization/README.md
@@ -27,6 +27,7 @@ three-lens evaluation of the app at v0.0.82 and a phased roadmap.
 | 2026-06-15 | [tasks-session-15-code-copy](2026-06-15-tasks-session-15-code-copy.md) | UX polish: hover "Copy" button on rendered code blocks (clipboard + execCommand fallback, "Copied" flash, excluded from print); +4 tests |
 | 2026-06-15 | [tasks-session-16-presentation-enhancements](2026-06-15-tasks-session-16-presentation-enhancements.md) | Phase 4: presentation mode enhancements — pan/zoom inside a slide (Panzoom: −/⤢/+ buttons, wheel, +/-/0 keys) + a discoverable "Present" toolbar button (overflow-aware); +4 tests |
 | 2026-06-15 | [tasks-session-17-session-restore](2026-06-15-tasks-session-17-session-restore.md) | Phase 4: session restore — reopen the last-opened document on launch (web only, URL re-fetch; skipped in native shells / when a diagram link opened something); +4 tests |
+| 2026-06-15 | [tasks-session-18-annotations-export](2026-06-15-tasks-session-18-annotations-export.md) | Phase 4: annotations 2.0 — export the annotation store as JSON and import/merge it back (incoming wins per element-index, error-toast on bad input), surfaced via Export/Import palette commands; +6 tests |
 | 2026-06-14 | [handoff-next-wave](2026-06-14-handoff-next-wave.md) | **Resume point** — aggregated status, the remaining Phase 3/4 options, and the project gotchas. Start here after a break. |
 
 > **Resuming after a break?** Read **[handoff-next-wave](2026-06-14-handoff-next-wave.md)** first — it's the durable index of what's done, what's next, and the gotchas.

--- a/markdown-viewer/src/features/annotations.js
+++ b/markdown-viewer/src/features/annotations.js
@@ -3,6 +3,8 @@
 // filename. Users can double-click any paragraph or heading to add/edit one.
 // State is private to this module.
 
+import { showToast } from './toast.js';
+
 const ANNOTATIONS_KEY = 'specdown-annotations';
 
 let annotationMode = false;
@@ -41,6 +43,97 @@ function saveAnnotations(key, annotations) {
   } catch (e) {
     // localStorage quota exceeded — silently ignore
   }
+}
+
+/**
+ * The full annotation store: filename → { elementIndex → note }.
+ * @returns {Record<string, Record<string, string>>}
+ */
+function getAllAnnotations() {
+  try {
+    const raw = localStorage.getItem(ANNOTATIONS_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch (e) {
+    return {};
+  }
+}
+
+/**
+ * Pretty-printed JSON of the entire annotation store (for export / inspection).
+ * @returns {string}
+ */
+export function getAnnotationsJSON() {
+  return JSON.stringify(getAllAnnotations(), null, 2);
+}
+
+/** Download all annotations as a JSON file. */
+export function exportAnnotations() {
+  const json = getAnnotationsJSON();
+  const blob = new Blob([json], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'specdown-annotations.json';
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+/**
+ * Merge imported annotations into the store. Per file, incoming notes win on a
+ * key (element-index) conflict; other files/notes are preserved. Re-renders the
+ * current document's badges. Returns whether the import succeeded.
+ * @param {string} jsonText
+ * @returns {boolean}
+ */
+export function importAnnotations(jsonText) {
+  let incoming;
+  try {
+    incoming = JSON.parse(jsonText);
+  } catch (e) {
+    showToast('Import failed: the file is not valid JSON.', { type: 'error' });
+    return false;
+  }
+  if (!incoming || typeof incoming !== 'object' || Array.isArray(incoming)) {
+    showToast('Import failed: unexpected annotations format.', { type: 'error' });
+    return false;
+  }
+
+  const existing = getAllAnnotations();
+  let fileCount = 0;
+  for (const [file, notes] of Object.entries(incoming)) {
+    if (!notes || typeof notes !== 'object') continue;
+    existing[file] = Object.assign({}, existing[file] || {}, notes);
+    fileCount += 1;
+  }
+
+  try {
+    localStorage.setItem(ANNOTATIONS_KEY, JSON.stringify(existing));
+  } catch (e) {
+    showToast('Import failed: could not save (storage full?).', { type: 'error' });
+    return false;
+  }
+
+  if (annotationKey) renderAnnotations(annotationKey);
+  showToast(`Imported annotations for ${fileCount} document(s).`, { type: 'success' });
+  return true;
+}
+
+/** Open a file picker and import the chosen annotations JSON. */
+export function importAnnotationsFromFile() {
+  const input = document.createElement('input');
+  input.type = 'file';
+  input.accept = 'application/json,.json';
+  input.addEventListener('change', () => {
+    const file = input.files && input.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => importAnnotations(String(reader.result || ''));
+    reader.onerror = () => showToast('Could not read the file.', { type: 'error' });
+    reader.readAsText(file);
+  });
+  input.click();
 }
 
 /**

--- a/markdown-viewer/src/main.js
+++ b/markdown-viewer/src/main.js
@@ -40,6 +40,8 @@ import {
 import {
   toggleAnnotationMode,
   renderAnnotations,
+  exportAnnotations,
+  importAnnotationsFromFile,
 } from './features/annotations.js';
 import { handleRepoUrl } from './features/repo-browser.js';
 import { updateMinimap, updateMinimapViewport } from './features/minimap.js';
@@ -316,6 +318,18 @@ function registerAppCommands() {
             keywords: ['presentation', 'slideshow', 'fullscreen', 'mermaid', 'diagram'],
             run: () => startPresentation(),
             isAvailable: () => isDocumentOpen() && hasPresentableDiagrams(),
+        },
+        {
+            id: 'export-annotations',
+            title: 'Export annotations',
+            keywords: ['annotations', 'notes', 'download', 'backup', 'json'],
+            run: () => exportAnnotations(),
+        },
+        {
+            id: 'import-annotations',
+            title: 'Import annotations',
+            keywords: ['annotations', 'notes', 'upload', 'restore', 'json'],
+            run: () => importAnnotationsFromFile(),
         },
         {
             id: 'shortcuts',

--- a/tests/unit/annotations.test.js
+++ b/tests/unit/annotations.test.js
@@ -247,3 +247,53 @@ describe('Annotation Mode', () => {
     });
   });
 });
+
+describe('Annotation export / import', () => {
+  const KEY = 'specdown-annotations';
+
+  beforeEach(() => {
+    localStorage.clear();
+    loadHTML(document);
+    loadApp(document);
+  });
+
+  it('exports the full store as pretty JSON', () => {
+    localStorage.setItem(KEY, JSON.stringify({ 'a.md': { 0: 'note' } }));
+    const parsed = JSON.parse(getAnnotationsJSON());
+    expect(parsed).toEqual({ 'a.md': { 0: 'note' } });
+  });
+
+  it('returns an empty object JSON when there are no annotations', () => {
+    expect(JSON.parse(getAnnotationsJSON())).toEqual({});
+  });
+
+  it('merges imported annotations across files', () => {
+    localStorage.setItem(KEY, JSON.stringify({ 'a.md': { 0: 'keep' } }));
+    const ok = importAnnotations(JSON.stringify({ 'a.md': { 1: 'add' }, 'b.md': { 0: 'new' } }));
+
+    expect(ok).toBe(true);
+    const store = JSON.parse(localStorage.getItem(KEY));
+    expect(store).toEqual({
+      'a.md': { 0: 'keep', 1: 'add' },
+      'b.md': { 0: 'new' },
+    });
+  });
+
+  it('lets incoming notes win on a key conflict', () => {
+    localStorage.setItem(KEY, JSON.stringify({ 'a.md': { 0: 'old' } }));
+    importAnnotations(JSON.stringify({ 'a.md': { 0: 'new' } }));
+    expect(JSON.parse(localStorage.getItem(KEY))['a.md']['0']).toBe('new');
+  });
+
+  it('rejects invalid JSON with an error toast', () => {
+    const ok = importAnnotations('{ not json');
+    expect(ok).toBe(false);
+    const toast = document.querySelector('.toast');
+    expect(toast).not.toBeNull();
+    expect(toast.classList.contains('toast-error')).toBe(true);
+  });
+
+  it('rejects a non-object payload', () => {
+    expect(importAnnotations(JSON.stringify([1, 2, 3]))).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Makes annotations portable across browsers and devices — the second of the three Phase 4 features you asked for (session restore #137 was the first; desktop recent file-paths is next).

Annotations have lived only in `localStorage`, so they were trapped per browser/device. This adds **export to JSON** and **import (merge) from JSON**.

## Changes

- **`exportAnnotations()`** — downloads the full `specdown-annotations` store as pretty-printed `specdown-annotations.json` via a transient `<a download>` blob URL (revoked after click). `getAnnotationsJSON()` is the underlying dump.
- **`importAnnotations(jsonText)` / `importAnnotationsFromFile()`** — parse and **merge** an imported store. Per file, incoming notes win on an element-index conflict; untouched files/notes are preserved. Invalid JSON or a non-object payload is rejected with an **error toast**; success reports the document count. If the imported file is the one currently open, its badges re-render immediately.
- **Command palette** — two new commands: **Export annotations** and **Import annotations**.

## Verification

- `tests/unit/annotations.test.js` (+6): export shape, empty store (`{}`), cross-file merge, incoming-wins on key conflict, invalid-JSON rejection, non-object rejection.
- `npm run build` ✓, `npm run lint` ✓ (0 errors), `npm run typecheck` ✓, `npm test` → **385 passed**.

## Manual check

Add annotations → Cmd/Ctrl+K → **Export annotations** downloads JSON. Clear storage or switch device → **Import annotations** → pick the file → badges reappear with a success toast. Confirm light + dark.

https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA)_