### PR TITLE
Desktop: build a universal (Intel + Apple Silicon) macOS DMG

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -55,7 +55,7 @@ jobs:
       # password and APPLE_TEAM_ID from the env below.
       - name: Build DMG (signed + notarized)
         if: env.HAS_SIGNING == 'true'
-        run: npm run desktop:build -- --mac dmg -c.mac.notarize=true
+        run: npm run desktop:build -- --mac dmg --universal -c.mac.notarize=true
         env:
           CSC_LINK: ${{ secrets.MAC_CERT_P12 }}
           CSC_KEY_PASSWORD: ${{ secrets.MAC_CERT_PASSWORD }}
@@ -69,7 +69,7 @@ jobs:
       # the real distribution build.
       - name: Build DMG (unsigned fallback)
         if: env.HAS_SIGNING != 'true'
-        run: npm run desktop:build -- --mac dmg
+        run: npm run desktop:build -- --mac dmg --universal
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## What

Re-submits the **universal build** change that got stranded: #145 merged at 04:50 with only its icon commit, and my `--universal` commit landed on that branch ~8 min *after* the merge — so it never reached `main`. The icon is live (v0.0.128), but the macOS DMG is still **arm64-only**.

## Change

Pass `--universal` to electron-builder in **both** the signed and unsigned `build-macos` steps, so the DMG is a universal binary that runs on **Intel and Apple Silicon**. (chokidar 5 is pure JS — no native modules to complicate the universal merge.)

Trade-off: universal adds some build time and ~2× DMG size; the notarization wait is unchanged (Apple-queue-bound).

Merging bumps to **v0.0.129** and produces a **signed + notarized, universal** DMG (with the icon from #145).

https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA)_