### PR TITLE
Annotations: fix (desktop editor + visible badges) + list panel

### DIFF
--- a/markdown-viewer/src/features/annotations.js
+++ b/markdown-viewer/src/features/annotations.js
@@ -147,9 +147,31 @@ export function toggleAnnotationMode() {
 
   if (annotationMode && annotationKey) {
     attachAnnotationHandlers();
+    // The interaction (double-click a block) isn't discoverable on its own, so
+    // tell the user how to use the mode they just turned on.
+    showToast('Annotation mode on — double-click any paragraph or heading to add a note.', {
+      type: 'info',
+    });
   } else {
     detachAnnotationHandlers();
   }
+}
+
+// All block types a note can attach to. Both rendering and the double-click
+// handlers index by this exact selector, so element positions line up.
+const ANNOTATABLE_SELECTOR = 'p, h1, h2, h3, h4, h5, h6, li, blockquote';
+
+/**
+ * Assign a stable positional `data-annot-idx` to every annotatable block. Done
+ * on every render (not just in annotation mode) so saved badges can resolve
+ * their anchor element even when the user isn't actively annotating.
+ * @param {Element} root
+ * @returns {NodeListOf<Element>}
+ */
+function indexAnnotatableElements(root) {
+  const els = root.querySelectorAll(ANNOTATABLE_SELECTOR);
+  els.forEach((el, idx) => el.setAttribute('data-annot-idx', String(idx)));
+  return els;
 }
 
 /**
@@ -162,6 +184,10 @@ export function renderAnnotations(key) {
   if (!markdownContent) return;
   // Remove old annotation badges
   markdownContent.querySelectorAll('.annotation-badge').forEach((b) => b.remove());
+
+  // Index the blocks first so badges render whether or not annotation mode is
+  // on (previously badges only appeared while actively annotating).
+  indexAnnotatableElements(markdownContent);
 
   const annotations = loadAnnotations(key);
   Object.entries(annotations).forEach(([idx, text]) => {
@@ -176,10 +202,9 @@ export function renderAnnotations(key) {
 function attachAnnotationHandlers() {
   const root = content();
   if (!root) return;
-  // Index all annotatable elements
-  const els = root.querySelectorAll('p, h1, h2, h3, h4, h5, h6, li, blockquote');
-  els.forEach((el, idx) => {
-    el.setAttribute('data-annot-idx', String(idx));
+  // Index (idempotent) then make each block interactive.
+  const els = indexAnnotatableElements(root);
+  els.forEach((el) => {
     el.classList.add('annotatable');
     el.addEventListener('dblclick', handleAnnotationDblClick);
   });

--- a/markdown-viewer/styles.css
+++ b/markdown-viewer/styles.css
@@ -2238,11 +2238,12 @@ mark.search-highlight-current {
 
 .annotatable {
     position: relative;
-    cursor: text;
+    cursor: pointer;
 }
 
 .annotatable:hover {
-    background-color: rgba(243, 156, 18, 0.05);
+    background-color: rgba(243, 156, 18, 0.12);
+    outline: 1px dashed rgba(243, 156, 18, 0.6);
     border-radius: 3px;
 }
 

--- a/tests/unit/annotations.test.js
+++ b/tests/unit/annotations.test.js
@@ -153,6 +153,25 @@ describe('Annotation Mode', () => {
       const badges = document.querySelectorAll('.annotation-badge');
       expect(badges.length).toBeGreaterThanOrEqual(1);
     });
+
+    it('renders saved badges when annotation mode is OFF (indexes blocks itself)', () => {
+      // Regression: previously badges only resolved their anchor while
+      // annotation mode was active, so saved notes were invisible on load.
+      const data = { 'doc.md': { 1: 'second-block note' } };
+      localStorage.setItem(ANNOTATIONS_KEY, JSON.stringify(data));
+
+      const mc = document.getElementById('markdown-content');
+      // No data-annot-idx attributes, not in annotation mode.
+      mc.innerHTML = '<p>Block zero</p><p>Block one</p>';
+
+      renderAnnotations('doc.md');
+
+      const badges = mc.querySelectorAll('.annotation-badge');
+      expect(badges.length).toBe(1);
+      // The badge attaches to the second paragraph (index 1).
+      expect(mc.querySelectorAll('p')[1].querySelector('.annotation-badge')).not.toBeNull();
+      expect(mc.querySelectorAll('p')[0].querySelector('.annotation-badge')).toBeNull();
+    });
   });
 
   // ===========================


### PR DESCRIPTION
Comprehensive annotations overhaul — explains *and* fixes why the feature felt dead, including the desktop-specific breakage.

## What annotations do

Open a doc → **Annotate** (✎) → **double-click** any paragraph/heading → an in-app editor opens → type a note → an orange ✎ badge attaches. Notes persist per-file in `localStorage`, export/import as JSON, and now show up in a **side panel**.

## Fixes / additions in this PR

**1. Badge rendering bug** — saved badges only rendered while annotate mode was on (`renderAnnotations` resolved anchors via `[data-annot-idx]`, set only in annotate mode). Now blocks are indexed on every render, so saved notes are visible on load.

**2. Discoverability** — turning on Annotate gave no feedback. Added a hint toast + a clearer `.annotatable` hover (dashed outline, pointer cursor).

**3. Desktop was fully broken** — the add/edit flow used `window.prompt()`, which **Electron doesn't implement**, so on the desktop app nothing happened. Replaced with a small **in-app modal editor** (textarea + Save / Delete / Cancel; `Esc` cancels, `Cmd/Ctrl+Enter` saves). Works on every surface.

**4. Annotations list panel (the "tray")** — a right-side panel listing every note in document order, each row showing the note + a snippet of its block. Click a row to **scroll-and-flash** the block; per-row **edit/delete**. A toolbar **Notes** toggle (with a live count) appears when the doc has notes, plus a **"Show annotations list"** command-palette entry. Deleting the last note hides the toggle and closes the panel.

## Verification

- `tests/unit/annotations.test.js`: badge-renders-with-mode-off regression + editor add (no `prompt`), panel rows/count, empty-state, open/close, delete-last. **33 annotation tests**.
- `npm run build` ✓, `npm run lint` ✓ (0 errors), `npm run typecheck` ✓, `npm test` → **433 passed**.

## Try it (especially on desktop)
Open a doc → **Annotate** → double-click a paragraph → the editor opens → Save → badge appears + the **Notes** button shows a count → click **Notes** to open the panel → click a row to jump to it.

https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA