### PR TITLE
Workspace: collapsible tree + web folder support

### DIFF
--- a/markdown-viewer/src/features/workspace.js
+++ b/markdown-viewer/src/features/workspace.js
@@ -1,16 +1,21 @@
 // @ts-check
-// Workspace (folder) mode — desktop only. Open a folder and browse its markdown
-// files from an in-app sidebar; click a file to open it in a tab, and follow
-// relative `.md` links between documents.
+// Workspace (folder) mode. Open a folder and browse its markdown files from an
+// in-app sidebar (rendered as a collapsible tree), click a file to open it, and
+// follow relative `.md` links between documents.
 //
-// The heavy lifting (scanning the folder, resolving relative links) lives in the
-// Electron main process; this module owns the sidebar UI and the click wiring.
-// The shared web/iOS surfaces have no `window.specdown` bridge, so the entry
-// points here are inert there (the open-folder button is shown only on desktop).
+// Two backends, same UI:
+//   - Desktop (Electron): the main process scans the folder and resolves links
+//     by absolute path over the `window.specdown` bridge. Files carry `path`.
+//   - Web (Chromium): the File System Access API (`showDirectoryPicker`) scans
+//     the folder in-page; files carry a `handle` read on open, and relative
+//     links resolve within the loaded file set. Other browsers (no API) simply
+//     don't show the Open Folder button.
 
 import { state } from '../core/state.js';
 import { isDesktop } from '../core/platform.js';
+import { showToast } from './toast.js';
 import {
+  hasDesktopBridge,
   bridgeRequestOpenPath,
   bridgeRequestOpenFolder,
   bridgeRequestOpenRelative,
@@ -21,11 +26,20 @@ const wsEl = (/** @type {string} */ id) => document.getElementById(id);
 
 const MARKDOWN_LINK_RE = /\.(md|markdown)$/i;
 
+// Bounds + noise filter for the web directory scan (mirrors the desktop scan).
+const WS_WEB_IGNORE = new Set([
+  'node_modules', '.git', '.svn', '.hg', 'dist', 'build', 'out',
+  'coverage', '.next', '.cache', '.vite', '.idea', '.vscode',
+]);
+const WS_MAX_DEPTH = 8;
+const WS_MAX_FILES = 2000;
+
 /**
  * @typedef {object} WorkspaceFile
- * @property {string} path Absolute path on disk.
- * @property {string} relPath Path relative to the workspace root (display).
  * @property {string} name Basename.
+ * @property {string} relPath Path relative to the workspace root (display + tree).
+ * @property {string} [path] Absolute path on disk (desktop only).
+ * @property {any} [handle] FileSystemFileHandle (web only).
  */
 
 /**
@@ -39,26 +53,88 @@ let workspaceRoot = '';
 /** @type {WorkspaceFile[]} */
 let workspaceFiles = [];
 let workspaceSidebarVisible = false;
+/** Relative path of the doc currently shown (for highlight + web link resolve). */
+let currentWorkspaceRelPath = '';
+/** Directory relPaths the user has collapsed in the tree. */
+const collapsedDirs = new Set();
 
 /** @type {(filePath: string) => void} */
 let workspaceOpenPath = (filePath) => {
   bridgeRequestOpenPath(filePath);
 };
+/** @type {(name: string, content: string, relPath: string) => void} */
+let workspaceOpenFile = () => {};
 
-/** @param {{ openPath?: (filePath: string) => void }} [deps] */
+/**
+ * @param {{ openPath?: (filePath: string) => void,
+ *           openFile?: (name: string, content: string, relPath: string) => void }} [deps]
+ */
 export function configureWorkspace(deps) {
-  if (deps && typeof deps.openPath === 'function') {
-    workspaceOpenPath = deps.openPath;
+  if (deps && typeof deps.openPath === 'function') workspaceOpenPath = deps.openPath;
+  if (deps && typeof deps.openFile === 'function') workspaceOpenFile = deps.openFile;
+}
+
+/** Whether the browser supports the File System Access directory picker. */
+function isWebFolderSupported() {
+  return typeof window !== 'undefined' &&
+    typeof /** @type {any} */ (window).showDirectoryPicker === 'function';
+}
+
+/** Open a folder: native picker on desktop, File System Access on the web. */
+export function openWorkspaceFolder() {
+  if (isDesktop) {
+    bridgeRequestOpenFolder();
+  } else if (isWebFolderSupported()) {
+    pickWebFolder();
   }
 }
 
-/** Ask the desktop shell to show its folder picker. No-op off desktop. */
-export function openWorkspaceFolder() {
-  bridgeRequestOpenFolder();
+/**
+ * Recursively collect markdown files from a directory handle (web).
+ * @param {any} dirHandle
+ * @param {string} prefix
+ * @param {WorkspaceFile[]} out
+ * @param {number} depth
+ */
+async function scanDirectoryHandle(dirHandle, prefix, out, depth) {
+  if (depth > WS_MAX_DEPTH || out.length >= WS_MAX_FILES) return;
+  for await (const entry of dirHandle.values()) {
+    if (out.length >= WS_MAX_FILES) break;
+    if (entry.kind === 'directory') {
+      if (entry.name.startsWith('.') || WS_WEB_IGNORE.has(entry.name)) continue;
+      await scanDirectoryHandle(entry, `${prefix}${entry.name}/`, out, depth + 1);
+    } else if (entry.kind === 'file' && MARKDOWN_LINK_RE.test(entry.name)) {
+      out.push({ name: entry.name, relPath: `${prefix}${entry.name}`, handle: entry });
+    }
+  }
+}
+
+/** Show the web folder picker, scan it, and adopt the workspace. */
+async function pickWebFolder() {
+  const w = /** @type {any} */ (window);
+  let dirHandle;
+  try {
+    dirHandle = await w.showDirectoryPicker();
+  } catch (e) {
+    return; // user dismissed the picker
+  }
+  /** @type {WorkspaceFile[]} */
+  const files = [];
+  try {
+    await scanDirectoryHandle(dirHandle, '', files, 0);
+  } catch (e) {
+    showToast('Could not read the folder.', { type: 'error' });
+    return;
+  }
+  files.sort((a, b) => a.relPath.localeCompare(b.relPath));
+  if (files.length === 0) {
+    showToast('No markdown files found in that folder.', { type: 'warning' });
+  }
+  applyWorkspace({ root: dirHandle.name || '', files });
 }
 
 /**
- * Adopt a scanned workspace (from the desktop shell) and show its sidebar.
+ * Adopt a scanned workspace (desktop IPC or web picker) and show its sidebar.
  * Opens the first file (preferring a top-level README) so the content area —
  * which hosts the sidebar — becomes visible.
  * @param {Workspace} workspace
@@ -68,6 +144,7 @@ export function applyWorkspace(workspace) {
   workspaceRoot = workspace.root || '';
   workspaceFiles = workspace.files;
   workspaceSidebarVisible = workspaceFiles.length > 0;
+  collapsedDirs.clear();
   renderWorkspaceSidebar();
 
   if (workspaceFiles.length === 0) return;
@@ -75,17 +152,106 @@ export function applyWorkspace(workspace) {
   // doesn't yank the user off their current document.
   if (state.tabs.length === 0) {
     const readme = workspaceFiles.find((f) => /^readme\.(md|markdown)$/i.test(f.name));
-    workspaceOpenPath((readme || workspaceFiles[0]).path);
+    openWorkspaceEntry(readme || workspaceFiles[0]);
   }
 }
 
-/** The active tab's file path, or '' when none. */
+/**
+ * Open a workspace file by its backend: desktop path or web handle.
+ * @param {WorkspaceFile | undefined} entry
+ */
+function openWorkspaceEntry(entry) {
+  if (!entry) return;
+  currentWorkspaceRelPath = entry.relPath || '';
+  if (entry.handle) {
+    readHandleAndOpen(entry);
+  } else if (entry.path) {
+    workspaceOpenPath(entry.path);
+  }
+}
+
+/**
+ * Read a web file handle and hand its contents to the tab layer.
+ * @param {WorkspaceFile} entry
+ */
+async function readHandleAndOpen(entry) {
+  try {
+    const file = await entry.handle.getFile();
+    const text = await file.text();
+    workspaceOpenFile(entry.name, text, entry.relPath);
+  } catch (e) {
+    showToast('Could not open the file.', { type: 'error' });
+  }
+}
+
+/** The active tab's file path, or '' when none (desktop). */
 function activeWorkspacePath() {
   const tab = state.activeTabId !== null ? state.tabs.find((t) => t.id === state.activeTabId) : null;
   return tab && tab.filePath ? tab.filePath : '';
 }
 
-/** Render the workspace file list, hiding the sidebar when inactive/empty. */
+/**
+ * Build a nested tree (directories first, then files; each level sorted) from
+ * the flat workspace file list. Pure — exported for testing.
+ * @param {WorkspaceFile[]} files
+ * @returns {Array<{type:'dir',name:string,relPath:string,children:any[]} | {type:'file',name:string,relPath:string,file:WorkspaceFile}>}
+ */
+export function buildWorkspaceTree(files) {
+  const rootDir = { dirs: /** @type {Record<string, any>} */ ({}), files: /** @type {WorkspaceFile[]} */ ([]) };
+  for (const f of files) {
+    const parts = f.relPath.split('/').filter(Boolean);
+    let cur = rootDir;
+    for (let i = 0; i < parts.length - 1; i++) {
+      const seg = parts[i];
+      if (!cur.dirs[seg]) {
+        cur.dirs[seg] = { name: seg, relPath: parts.slice(0, i + 1).join('/'), dirs: {}, files: [] };
+      }
+      cur = cur.dirs[seg];
+    }
+    cur.files.push(f);
+  }
+  /** @param {any} node @returns {any[]} */
+  const serialize = (node) => {
+    const dirs = Object.values(node.dirs)
+      .sort((/** @type {any} */ a, /** @type {any} */ b) => a.name.localeCompare(b.name))
+      .map((/** @type {any} */ d) => ({ type: 'dir', name: d.name, relPath: d.relPath, children: serialize(d) }));
+    const fileNodes = node.files
+      .slice()
+      .sort((/** @type {any} */ a, /** @type {any} */ b) => a.name.localeCompare(b.name))
+      .map((/** @type {any} */ f) => ({ type: 'file', name: f.name, relPath: f.relPath, file: f }));
+    return [...dirs, ...fileNodes];
+  };
+  return serialize(rootDir);
+}
+
+/**
+ * Resolve a relative href against a source document's relative path, normalizing
+ * `.`/`..`. Pure — exported for testing.
+ * @param {string} fromRelPath
+ * @param {string} href
+ * @returns {string}
+ */
+export function resolveRelativeRelPath(fromRelPath, href) {
+  let clean = String(href || '').split('#')[0].split('?')[0];
+  try {
+    clean = decodeURIComponent(clean);
+  } catch (e) {
+    // leave as-is on bad encoding
+  }
+  if (!clean) return '';
+  const stack = String(fromRelPath || '').split('/').slice(0, -1);
+  for (const part of clean.split('/')) {
+    if (part === '' || part === '.') continue;
+    if (part === '..') {
+      if (stack.length) stack.pop();
+      continue;
+    }
+    stack.push(part);
+  }
+  return stack.join('/');
+}
+
+/** Render the workspace tree, hiding the sidebar when inactive/empty. */
 export function renderWorkspaceSidebar() {
   const sidebar = wsEl('workspace-sidebar');
   const list = wsEl('workspace-file-list');
@@ -97,23 +263,70 @@ export function renderWorkspaceSidebar() {
   }
   sidebar.style.display = '';
 
-  const active = activeWorkspacePath();
+  const activePath = activeWorkspacePath();
   list.innerHTML = '';
-  for (const file of workspaceFiles) {
+  renderTreeNodes(buildWorkspaceTree(workspaceFiles), list, activePath);
+}
+
+/** @param {any[]} nodes @param {HTMLElement} container @param {string} activePath */
+function renderTreeNodes(nodes, container, activePath) {
+  for (const node of nodes) {
     const li = document.createElement('li');
-    const btn = document.createElement('button');
-    btn.type = 'button';
-    btn.className = 'workspace-file-item';
-    if (file.path === active) btn.classList.add('workspace-file-active');
-    btn.textContent = file.relPath;
-    btn.title = file.relPath;
-    btn.addEventListener('click', (e) => {
-      e.stopPropagation();
-      workspaceOpenPath(file.path);
-    });
-    li.appendChild(btn);
-    list.appendChild(li);
+
+    if (node.type === 'dir') {
+      const collapsed = collapsedDirs.has(node.relPath);
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'workspace-dir-item';
+      btn.title = node.relPath;
+      btn.setAttribute('aria-expanded', String(!collapsed));
+
+      const caret = document.createElement('span');
+      caret.className = 'workspace-caret';
+      caret.setAttribute('aria-hidden', 'true');
+      caret.textContent = collapsed ? '▸' : '▾';
+      const label = document.createElement('span');
+      label.className = 'workspace-dir-name';
+      label.textContent = node.name;
+      btn.append(caret, label);
+      btn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        toggleDir(node.relPath);
+      });
+      li.appendChild(btn);
+
+      const childUl = document.createElement('ul');
+      childUl.className = 'workspace-tree';
+      if (collapsed) childUl.style.display = 'none';
+      renderTreeNodes(node.children, childUl, activePath);
+      li.appendChild(childUl);
+    } else {
+      const f = node.file;
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'workspace-file-item';
+      const isActive =
+        (f.path && f.path === activePath) ||
+        (f.relPath && f.relPath === currentWorkspaceRelPath);
+      if (isActive) btn.classList.add('workspace-file-active');
+      btn.textContent = node.name;
+      btn.title = node.relPath;
+      btn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        openWorkspaceEntry(f);
+      });
+      li.appendChild(btn);
+    }
+
+    container.appendChild(li);
   }
+}
+
+/** @param {string} relPath */
+function toggleDir(relPath) {
+  if (collapsedDirs.has(relPath)) collapsedDirs.delete(relPath);
+  else collapsedDirs.add(relPath);
+  renderWorkspaceSidebar();
 }
 
 /** Toggle the workspace sidebar (when a workspace is active). */
@@ -131,38 +344,50 @@ export function hasWorkspace() {
 }
 
 /**
- * Intercept clicks on relative markdown links inside the rendered document and
- * route them to the desktop shell, which resolves the path against the source
- * document's folder and opens it. Absolute/external/anchor links are left alone.
+ * Follow a relative markdown link clicked inside a workspace document. On
+ * desktop the shell resolves it by absolute path; on the web it resolves within
+ * the loaded file set. Absolute/external/anchor/non-markdown links are ignored.
  * @param {Event} e
  */
 export function handleWorkspaceLinkClick(e) {
-  if (!isDesktop || !hasWorkspace()) return;
+  if (!hasWorkspace()) return;
   const target = /** @type {HTMLElement} */ (e.target);
   const anchor = target && target.closest ? target.closest('a') : null;
   if (!anchor) return;
 
-  // Prefer the literal attribute over the resolved `.href` property, which the
-  // browser turns into an absolute file:// URL.
+  // Prefer the literal attribute over `.href`, which the browser absolutizes.
   const href = anchor.getAttribute('href') || '';
   if (!href || href.startsWith('#')) return;
-  // Only handle relative links — skip protocols (http:, mailto:, file:, …).
+  // Skip protocols (http:, mailto:, file:, …) and protocol-relative links.
   if (/^[a-z][a-z0-9+.-]*:/i.test(href) || href.startsWith('//')) return;
   if (!MARKDOWN_LINK_RE.test(href.split('#')[0].split('?')[0])) return;
 
-  const fromPath = activeWorkspacePath();
-  if (!fromPath) return;
+  if (isDesktop && hasDesktopBridge()) {
+    const fromPath = activeWorkspacePath();
+    if (!fromPath) return;
+    e.preventDefault();
+    bridgeRequestOpenRelative(fromPath, href);
+    return;
+  }
 
-  e.preventDefault();
-  bridgeRequestOpenRelative(fromPath, href);
+  // Web: resolve against the current doc's relPath and open the matching entry.
+  if (currentWorkspaceRelPath) {
+    const targetRel = resolveRelativeRelPath(currentWorkspaceRelPath, href);
+    const entry = workspaceFiles.find((f) => f.relPath === targetRel);
+    if (entry) {
+      e.preventDefault();
+      openWorkspaceEntry(entry);
+    }
+  }
 }
 
 /** Wire the open-folder entry points, the IPC listener, and relative links. */
 export function setupWorkspace() {
-  // Show the desktop-only entry points and wire them.
+  // Show the Open Folder button where a folder can actually be opened:
+  // the Electron shell, or a browser with the File System Access API.
   const openBtn = wsEl('open-folder-button');
   if (openBtn) {
-    if (isDesktop) openBtn.style.display = '';
+    if (isDesktop || isWebFolderSupported()) openBtn.style.display = '';
     openBtn.addEventListener('click', (e) => {
       // Stop the drop-zone's click-to-browse handler from also firing.
       e.stopPropagation();

--- a/markdown-viewer/src/main.js
+++ b/markdown-viewer/src/main.js
@@ -124,6 +124,7 @@ import {
   renderWorkspaceSidebar,
   openWorkspaceFolder,
   hasWorkspace,
+  configureWorkspace,
 } from './features/workspace.js';
 import {
   setupDesktopIPC,
@@ -226,6 +227,9 @@ function init() {
         renderMarkdown: (/** @type {string} */ content, /** @type {string} */ title) => renderMarkdown(content, title),
     });
     configureRecentFiles({ onSelect: (entry) => openRecentEntry(entry) });
+    configureWorkspace({
+        openFile: (/** @type {string} */ name, /** @type {string} */ content) => createTab(name, content, null),
+    });
     registerAppCommands();
     setupVersionInfo();
     setupTheme();

--- a/markdown-viewer/styles.css
+++ b/markdown-viewer/styles.css
@@ -1442,6 +1442,51 @@ body {
     font-weight: 500;
 }
 
+/* Nested tree: each level of <ul> indents under its folder row. */
+.workspace-tree {
+    list-style: none;
+    margin: 0;
+    padding-left: 0.85rem;
+}
+
+.workspace-dir-item {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    width: 100%;
+    text-align: left;
+    background: none;
+    border: none;
+    border-left: 2px solid transparent;
+    padding: 0.3rem 1rem;
+    font-size: 0.82rem;
+    font-weight: 500;
+    font-family: inherit;
+    color: var(--text-primary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    cursor: pointer;
+    transition: color 0.15s ease, background-color 0.15s ease;
+}
+
+.workspace-dir-item:hover {
+    background-color: var(--bg-tertiary);
+}
+
+.workspace-caret {
+    display: inline-block;
+    width: 0.8em;
+    flex-shrink: 0;
+    color: var(--text-secondary);
+    font-size: 0.7rem;
+}
+
+.workspace-dir-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 /* Workspace toggle button (mirrors the TOC toggle) */
 .workspace-toggle-button {
     background-color: var(--bg-tertiary);

--- a/tests/unit/workspace.test.js
+++ b/tests/unit/workspace.test.js
@@ -1,6 +1,7 @@
 /**
- * Unit tests for workspace (folder) mode — the desktop-only folder sidebar,
- * auto-open, and relative-link navigation wired in the renderer.
+ * Unit tests for workspace (folder) mode — the folder sidebar (collapsible
+ * tree), auto-open, relative-link navigation, and both backends (desktop path
+ * bridge + web File System Access).
  */
 
 const { loadHTML, loadApp } = require('../helpers/loadApp');
@@ -9,13 +10,12 @@ require('../mocks/mermaid');
 require('../mocks/panzoom');
 require('../mocks/highlightjs');
 
-const file = (relPath, name) => ({ path: '/ws/' + relPath, relPath, name: name || relPath });
+const file = (relPath, name) => ({ path: '/ws/' + relPath, relPath, name: name || relPath.split('/').pop() });
+const flush = () => new Promise((r) => setTimeout(r, 0));
 
-describe('Workspace (folder) mode', () => {
+describe('Workspace (folder) mode — desktop', () => {
   beforeEach(() => {
     localStorage.clear();
-    // isDesktop is resolved at module-load time, so the bridge must exist
-    // before loadApp evals the graph.
     window.specdown = {
       isDesktop: true,
       requestFileOpen: jest.fn(),
@@ -41,26 +41,24 @@ describe('Workspace (folder) mode', () => {
 
   describe('entry points', () => {
     it('reveals the Open Folder button on desktop', () => {
-      const btn = document.getElementById('open-folder-button');
-      expect(btn.style.display).not.toBe('none');
+      expect(document.getElementById('open-folder-button').style.display).not.toBe('none');
     });
 
     it('asks the shell to pick a folder when Open Folder is clicked', () => {
       document.getElementById('open-folder-button').dispatchEvent(new Event('click', { bubbles: true }));
       expect(window.specdown.requestOpenFolder).toHaveBeenCalledTimes(1);
-      // Must not also trip the drop-zone's click-to-browse (file open) handler.
       expect(window.specdown.requestFileOpen).not.toHaveBeenCalled();
     });
   });
 
-  describe('sidebar', () => {
-    it('renders one item per file and auto-opens the first when nothing is open', () => {
-      applyWorkspace({ root: '/ws', files: [file('a.md'), file('docs/b.md', 'b.md')] });
+  describe('tree sidebar', () => {
+    it('renders files + folders and auto-opens the first file', () => {
+      applyWorkspace({ root: '/ws', files: [file('a.md'), file('docs/b.md')] });
 
-      const items = document.querySelectorAll('.workspace-file-item');
-      expect(items.length).toBe(2);
-      expect(items[0].textContent).toBe('a.md');
-      expect(items[1].textContent).toBe('docs/b.md');
+      const files = [...document.querySelectorAll('.workspace-file-item')].map((b) => b.textContent);
+      expect(files.sort()).toEqual(['a.md', 'b.md']); // basenames, not relPaths
+      const dir = document.querySelector('.workspace-dir-item');
+      expect(dir.textContent).toContain('docs');
 
       expect(window.specdown.requestOpenPath).toHaveBeenCalledWith('/ws/a.md');
       expect(document.getElementById('workspace-sidebar').style.display).not.toBe('none');
@@ -71,12 +69,25 @@ describe('Workspace (folder) mode', () => {
       expect(window.specdown.requestOpenPath).toHaveBeenCalledWith('/ws/README.md');
     });
 
-    it('opens a file by path when its sidebar item is clicked', () => {
+    it('opens a file by path when its item is clicked', () => {
       applyWorkspace({ root: '/ws', files: [file('a.md'), file('b.md')] });
       window.specdown.requestOpenPath.mockClear();
 
-      document.querySelectorAll('.workspace-file-item')[1].dispatchEvent(new Event('click', { bubbles: true }));
+      const bItem = [...document.querySelectorAll('.workspace-file-item')].find((b) => b.textContent === 'b.md');
+      bItem.dispatchEvent(new Event('click', { bubbles: true }));
       expect(window.specdown.requestOpenPath).toHaveBeenCalledWith('/ws/b.md');
+    });
+
+    it('collapses and expands a folder', () => {
+      applyWorkspace({ root: '/ws', files: [file('docs/b.md')] });
+      const dir = document.querySelector('.workspace-dir-item');
+      const childUl = dir.parentElement.querySelector('.workspace-tree');
+
+      expect(childUl.style.display).not.toBe('none');
+      dir.dispatchEvent(new Event('click', { bubbles: true }));
+      expect(document.querySelector('.workspace-tree').style.display).toBe('none');
+      document.querySelector('.workspace-dir-item').dispatchEvent(new Event('click', { bubbles: true }));
+      expect(document.querySelector('.workspace-tree').style.display).not.toBe('none');
     });
 
     it('hides the sidebar for an empty folder', () => {
@@ -87,8 +98,6 @@ describe('Workspace (folder) mode', () => {
     it('toggles sidebar visibility', () => {
       applyWorkspace({ root: '/ws', files: [file('a.md')] });
       const sidebar = document.getElementById('workspace-sidebar');
-      expect(sidebar.style.display).not.toBe('none');
-
       toggleWorkspaceSidebar();
       expect(sidebar.style.display).toBe('none');
       toggleWorkspaceSidebar();
@@ -96,8 +105,7 @@ describe('Workspace (folder) mode', () => {
     });
   });
 
-  describe('relative links', () => {
-    // Put a workspace + an active file-backed tab in place, then inject a link.
+  describe('relative links (desktop)', () => {
     function withActiveDoc(html) {
       applyWorkspace({ root: '/ws', files: [file('a.md')] });
       state.tabs.push({
@@ -123,5 +131,104 @@ describe('Workspace (folder) mode', () => {
       content.querySelectorAll('a').forEach((a) => a.dispatchEvent(new Event('click', { bubbles: true })));
       expect(window.specdown.requestOpenRelative).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('Workspace pure helpers', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    loadHTML(document);
+    loadApp(document);
+  });
+
+  it('buildWorkspaceTree nests dirs (sorted) before files', () => {
+    const tree = buildWorkspaceTree([
+      { name: 'z.md', relPath: 'z.md' },
+      { name: 'a.md', relPath: 'docs/a.md' },
+      { name: 'b.md', relPath: 'docs/b.md' },
+    ]);
+    expect(tree[0].type).toBe('dir');
+    expect(tree[0].name).toBe('docs');
+    expect(tree[0].children.map((c) => c.name)).toEqual(['a.md', 'b.md']);
+    expect(tree[1].type).toBe('file');
+    expect(tree[1].name).toBe('z.md');
+  });
+
+  it('resolveRelativeRelPath normalizes . and ..', () => {
+    expect(resolveRelativeRelPath('docs/a.md', './b.md')).toBe('docs/b.md');
+    expect(resolveRelativeRelPath('docs/a.md', '../top.md')).toBe('top.md');
+    expect(resolveRelativeRelPath('docs/guide/a.md', '../api/b.md')).toBe('docs/api/b.md');
+    expect(resolveRelativeRelPath('a.md', './b.md#frag')).toBe('b.md');
+  });
+});
+
+describe('Workspace (folder) mode — web', () => {
+  // A minimal fake File System Access API.
+  const fileHandle = (name, text) => ({ kind: 'file', name, getFile: jest.fn(async () => ({ text: async () => text })) });
+  const dirHandle = (name, entries) => ({
+    kind: 'directory', name,
+    async *values() { for (const e of entries) yield e; },
+  });
+
+  beforeEach(() => {
+    localStorage.clear();
+    delete window.specdown;
+    window.showDirectoryPicker = jest.fn(async () =>
+      dirHandle('myfolder', [
+        fileHandle('a.md', '# A'),
+        dirHandle('docs', [fileHandle('b.md', '# B')]),
+        fileHandle('notes.txt', 'ignored'),
+        dirHandle('node_modules', [fileHandle('x.md', 'nope')]),
+      ])
+    );
+    loadHTML(document);
+    loadApp(document);
+  });
+
+  afterEach(() => {
+    delete window.showDirectoryPicker;
+  });
+
+  it('shows the Open Folder button when the API is available', () => {
+    expect(document.getElementById('open-folder-button').style.display).not.toBe('none');
+  });
+
+  it('scans the picked folder (ignoring non-md + node_modules) into the tree', async () => {
+    document.getElementById('open-folder-button').dispatchEvent(new Event('click', { bubbles: true }));
+    await flush();
+    await flush();
+
+    const files = [...document.querySelectorAll('.workspace-file-item')].map((b) => b.textContent).sort();
+    expect(files).toEqual(['a.md', 'b.md']); // notes.txt + node_modules/x.md excluded
+    expect(document.querySelector('.workspace-dir-item').textContent).toContain('docs');
+    expect(window.showDirectoryPicker).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens a web file by reading its handle', async () => {
+    const handleA = fileHandle('a.md', '# A');
+    applyWorkspace({ root: 'ws', files: [{ name: 'a.md', relPath: 'a.md', handle: handleA }] });
+    await flush();
+    expect(handleA.getFile).toHaveBeenCalled();
+  });
+
+  it('follows a relative link within the loaded web workspace', async () => {
+    const handleA = fileHandle('a.md', '# A');
+    const handleB = fileHandle('b.md', '# B');
+    applyWorkspace({
+      root: 'ws',
+      files: [
+        { name: 'a.md', relPath: 'a.md', handle: handleA },
+        { name: 'b.md', relPath: 'b.md', handle: handleB },
+      ],
+    });
+    await flush(); // auto-open a.md → sets the current relPath
+    handleB.getFile.mockClear();
+
+    const content = document.getElementById('markdown-content');
+    content.innerHTML = '<a href="./b.md">b</a>';
+    content.querySelector('a').dispatchEvent(new Event('click', { bubbles: true }));
+    await flush();
+
+    expect(handleB.getFile).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What

The last two workspace nice-to-haves, bundled (both touch `workspace.js` + the sidebar):

### 1. Collapsible nested tree
The sidebar rendered a flat list of relative paths. It now renders the real folder hierarchy as a **collapsible tree** — folders first (sorted), click a folder row (▾/▸) to expand/collapse. `buildWorkspaceTree()` is a pure, tested helper.

### 2. Web folder support (File System Access API)
Workspace mode was desktop-only. On **Chromium browsers** it now works on the web too:
- The **Open Folder** button appears when `showDirectoryPicker` is available (hidden on Safari/Firefox).
- It scans the picked folder **in-page** (same depth/count bounds + ignore list as the desktop scan), files carry a `FileSystemFileHandle` read on open.
- **Relative `.md` links** resolve within the loaded file set via `resolveRelativeRelPath()` (also pure + tested).

`workspace.js` now drives both backends behind one UI: desktop entries carry a `path` (opened via the `window.specdown` bridge), web entries carry a `handle` (read → `createTab` via a new `configureWorkspace({ openFile })` dep).

## Verification

- `tests/unit/workspace.test.js` rewritten for the tree + split into desktop / pure-helper / web suites: tree render + collapse/expand, `buildWorkspaceTree`, `resolveRelativeRelPath`, web scan (ignoring non-md + `node_modules`), open-by-handle, and web relative-link resolution.
- `npm run build` ✓, `npm run lint` ✓ (0 errors), `npm run typecheck` ✓, `npm test` → **434 passed**.

## Manual check
- **Desktop:** open a nested docs folder → tree with collapsible folders → click around; relative links still work.
- **Web (Chrome/Edge):** Open Folder → pick a folder → same tree + click-to-open + relative links.

That completes all three nice-to-haves (squircle #150, + this).

https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA)_