### PR TITLE
Annotations: in-app editor (fixes desktop) + list panel

### DIFF
--- a/markdown-viewer/index.html
+++ b/markdown-viewer/index.html
@@ -130,6 +130,11 @@
                         <span class="annotation-toggle-icon" aria-hidden="true">✎</span>
                         <span class="annotation-toggle-label">Annotate</span>
                     </button>
+                    <button id="annotation-list-toggle" class="annotation-list-toggle-button" title="Show annotations list" aria-label="Show annotations list" style="display: none;">
+                        <span class="annotation-list-icon" aria-hidden="true">🗒</span>
+                        <span class="annotation-list-label">Notes</span>
+                        <span class="annotation-list-count">0</span>
+                    </button>
                     <button id="print-button" class="print-button" title="Print / Save as PDF (Cmd+P)" aria-label="Print or save as PDF">
                         <span class="print-button-icon" aria-hidden="true">⎙</span>
                         <span class="print-button-label">Print</span>
@@ -178,6 +183,15 @@
                         <pre id="split-raw-content" class="raw-markdown split-raw-content"></pre>
                     </div>
                 </div>
+
+                <!-- Annotations panel (list of the current doc's notes) -->
+                <aside id="annotation-panel" class="annotation-panel" style="display: none;">
+                    <div class="annotation-panel-header">
+                        <span>Annotations</span>
+                        <button id="annotation-panel-close" class="annotation-panel-close" title="Close annotations" aria-label="Close annotations">✕</button>
+                    </div>
+                    <ul id="annotation-list" class="annotation-list"></ul>
+                </aside>
             </div>
         </div>
 

--- a/markdown-viewer/src/features/annotations.js
+++ b/markdown-viewer/src/features/annotations.js
@@ -197,6 +197,9 @@ export function renderAnnotations(key) {
 
   // Re-arm double-click handlers if the user is currently annotating.
   if (annotationMode) attachAnnotationHandlers();
+
+  // Refresh the side panel + toolbar toggle for this document.
+  renderAnnotationPanel();
 }
 
 function attachAnnotationHandlers() {
@@ -224,21 +227,260 @@ function handleAnnotationDblClick(e) {
   if (!annotationMode) return;
   const el = /** @type {HTMLElement} */ (e.currentTarget);
   const idx = parseInt(el.getAttribute('data-annot-idx') || '', 10);
+  if (!Number.isNaN(idx)) openAnnotationEditor(idx);
+}
+
+/**
+ * The annotatable block at a given positional index, or null.
+ * @param {number} idx
+ */
+function annotatedElement(idx) {
+  const root = content();
+  if (!root) return null;
+  const el = root.querySelectorAll('[data-annot-idx]')[idx];
+  return el || null;
+}
+
+/**
+ * Add / edit / remove the note at `idx` and refresh the badge + panel.
+ * @param {number} idx
+ * @param {string} rawText
+ */
+function commitAnnotation(idx, rawText) {
+  const text = String(rawText || '').trim();
+  const el = annotatedElement(idx);
   const annotations = loadAnnotations(annotationKey);
-  const existing = annotations[idx] || '';
 
-  const note = prompt('Add annotation (leave blank to remove):', existing);
-  if (note === null) return; // cancelled
-
-  if (note.trim() === '') {
+  if (!text) {
     delete annotations[idx];
-    const badge = el.querySelector('.annotation-badge');
-    if (badge) badge.remove();
+    if (el) {
+      const badge = el.querySelector('.annotation-badge');
+      if (badge) badge.remove();
+      el.classList.remove('has-annotation');
+    }
   } else {
-    annotations[idx] = note.trim();
-    attachAnnotationBadge(el, idx, note.trim());
+    annotations[idx] = text;
+    if (el) attachAnnotationBadge(el, idx, text);
   }
   saveAnnotations(annotationKey, annotations);
+  renderAnnotationPanel();
+}
+
+// ===========================
+// In-app note editor
+// ===========================
+// Replaces window.prompt(), which Electron does not implement (so desktop
+// annotation editing silently did nothing). A small modal works on every
+// surface and is nicer than a native prompt.
+
+/** @type {(() => void) | null} */
+let editorCleanup = null;
+
+function ensureEditor() {
+  let backdrop = document.getElementById('annotation-editor-backdrop');
+  if (backdrop) return backdrop;
+
+  backdrop = document.createElement('div');
+  backdrop.id = 'annotation-editor-backdrop';
+  backdrop.className = 'annotation-editor-backdrop';
+  backdrop.innerHTML =
+    '<div class="annotation-editor" role="dialog" aria-modal="true" aria-label="Edit note">' +
+    '<textarea class="annotation-editor-input" rows="4" placeholder="Write a note…"></textarea>' +
+    '<div class="annotation-editor-actions">' +
+    '<button type="button" class="annotation-editor-delete">Delete</button>' +
+    '<span class="annotation-editor-spacer"></span>' +
+    '<button type="button" class="annotation-editor-cancel">Cancel</button>' +
+    '<button type="button" class="annotation-editor-save">Save</button>' +
+    '</div></div>';
+  document.body.appendChild(backdrop);
+  return backdrop;
+}
+
+/**
+ * Open the note editor for the block at `idx`.
+ * @param {number} idx
+ */
+function openAnnotationEditor(idx) {
+  const backdrop = ensureEditor();
+  const textarea = /** @type {HTMLTextAreaElement} */ (backdrop.querySelector('.annotation-editor-input'));
+  const deleteBtn = /** @type {HTMLButtonElement} */ (backdrop.querySelector('.annotation-editor-delete'));
+  const saveBtn = /** @type {HTMLButtonElement} */ (backdrop.querySelector('.annotation-editor-save'));
+  const cancelBtn = /** @type {HTMLButtonElement} */ (backdrop.querySelector('.annotation-editor-cancel'));
+
+  const existing = loadAnnotations(annotationKey)[idx] || '';
+  textarea.value = existing;
+  deleteBtn.style.display = existing ? '' : 'none';
+  backdrop.style.display = 'flex';
+  setTimeout(() => textarea.focus(), 0);
+
+  const close = () => {
+    backdrop.style.display = 'none';
+    if (editorCleanup) editorCleanup();
+    editorCleanup = null;
+  };
+  const save = () => {
+    commitAnnotation(idx, textarea.value);
+    close();
+  };
+  const remove = () => {
+    commitAnnotation(idx, '');
+    close();
+  };
+  /** @param {KeyboardEvent} e */
+  const onKey = (e) => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      close();
+    } else if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      save();
+    }
+  };
+  /** @param {Event} e */
+  const onBackdrop = (e) => {
+    if (e.target === backdrop) close();
+  };
+
+  saveBtn.addEventListener('click', save);
+  deleteBtn.addEventListener('click', remove);
+  cancelBtn.addEventListener('click', close);
+  backdrop.addEventListener('mousedown', onBackdrop);
+  document.addEventListener('keydown', onKey);
+
+  editorCleanup = () => {
+    saveBtn.removeEventListener('click', save);
+    deleteBtn.removeEventListener('click', remove);
+    cancelBtn.removeEventListener('click', close);
+    backdrop.removeEventListener('mousedown', onBackdrop);
+    document.removeEventListener('keydown', onKey);
+  };
+}
+
+// ===========================
+// Annotations panel (list)
+// ===========================
+
+/**
+ * Scroll to the annotated block and briefly flash it.
+ * @param {number} idx
+ */
+function jumpToAnnotation(idx) {
+  const el = /** @type {HTMLElement | null} */ (annotatedElement(idx));
+  if (!el) return;
+  el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  el.classList.add('annotation-flash');
+  setTimeout(() => el.classList.remove('annotation-flash'), 1200);
+}
+
+/**
+ * Render the annotations side panel (one row per note, in document order) and
+ * sync the toolbar toggle's visibility + count.
+ */
+export function renderAnnotationPanel() {
+  const list = document.getElementById('annotation-list');
+  const toggle = document.getElementById('annotation-list-toggle');
+  const annotations = loadAnnotations(annotationKey);
+  const indexes = Object.keys(annotations)
+    .map((k) => parseInt(k, 10))
+    .filter((n) => !Number.isNaN(n))
+    .sort((a, b) => a - b);
+
+  if (toggle) {
+    toggle.style.display = indexes.length ? '' : 'none';
+    const count = toggle.querySelector('.annotation-list-count');
+    if (count) count.textContent = String(indexes.length);
+  }
+
+  // An open-but-now-empty panel should close itself.
+  if (indexes.length === 0) {
+    const panel = document.getElementById('annotation-panel');
+    if (panel) {
+      panel.style.display = 'none';
+      panel.classList.remove('open');
+    }
+    if (toggle) toggle.classList.remove('active');
+  }
+
+  if (!list) return;
+  list.innerHTML = '';
+  for (const idx of indexes) {
+    const el = annotatedElement(idx);
+    let snippet = '';
+    if (el) {
+      // Read the block's text without the appended ✎ badge.
+      const clone = /** @type {HTMLElement} */ (el.cloneNode(true));
+      clone.querySelectorAll('.annotation-badge').forEach((b) => b.remove());
+      snippet = (clone.textContent || '').replace(/\s+/g, ' ').trim().slice(0, 80);
+    }
+
+    const li = document.createElement('li');
+    li.className = 'annotation-list-item';
+
+    const jump = document.createElement('button');
+    jump.type = 'button';
+    jump.className = 'annotation-list-jump';
+    const note = document.createElement('span');
+    note.className = 'annotation-list-note';
+    note.textContent = annotations[idx];
+    const ctx = document.createElement('span');
+    ctx.className = 'annotation-list-context';
+    ctx.textContent = snippet || '(text not found)';
+    jump.append(note, ctx);
+    jump.addEventListener('click', () => jumpToAnnotation(idx));
+
+    const edit = document.createElement('button');
+    edit.type = 'button';
+    edit.className = 'annotation-list-edit';
+    edit.title = 'Edit note';
+    edit.setAttribute('aria-label', 'Edit note');
+    edit.textContent = '✎';
+    edit.addEventListener('click', (e) => {
+      e.stopPropagation();
+      openAnnotationEditor(idx);
+    });
+
+    const del = document.createElement('button');
+    del.type = 'button';
+    del.className = 'annotation-list-delete';
+    del.title = 'Delete note';
+    del.setAttribute('aria-label', 'Delete note');
+    del.textContent = '✕';
+    del.addEventListener('click', (e) => {
+      e.stopPropagation();
+      commitAnnotation(idx, '');
+    });
+
+    li.append(jump, edit, del);
+    list.appendChild(li);
+  }
+}
+
+/** Show/hide the annotations panel. */
+export function toggleAnnotationPanel() {
+  const panel = document.getElementById('annotation-panel');
+  if (!panel) return;
+  const toggle = document.getElementById('annotation-list-toggle');
+  if (panel.classList.contains('open')) {
+    panel.classList.remove('open');
+    panel.style.display = 'none';
+    if (toggle) toggle.classList.remove('active');
+  } else {
+    renderAnnotationPanel();
+    panel.classList.add('open');
+    panel.style.display = '';
+    if (toggle) toggle.classList.add('active');
+  }
+}
+
+/** Open the annotations panel (idempotent). */
+export function openAnnotationPanel() {
+  const panel = document.getElementById('annotation-panel');
+  if (!panel) return;
+  renderAnnotationPanel();
+  panel.classList.add('open');
+  panel.style.display = '';
+  const toggle = document.getElementById('annotation-list-toggle');
+  if (toggle) toggle.classList.add('active');
 }
 
 /**

--- a/markdown-viewer/src/main.js
+++ b/markdown-viewer/src/main.js
@@ -42,6 +42,8 @@ import {
   renderAnnotations,
   exportAnnotations,
   importAnnotationsFromFile,
+  toggleAnnotationPanel,
+  openAnnotationPanel,
 } from './features/annotations.js';
 import { handleRepoUrl } from './features/repo-browser.js';
 import { updateMinimap, updateMinimapViewport } from './features/minimap.js';
@@ -176,6 +178,8 @@ const openUrlBtn = $('open-url-btn');
 const urlError = $('url-error');
 const tocToggle = $('toc-toggle');
 const annotationToggle = $('annotation-toggle');
+const annotationListToggle = $('annotation-list-toggle');
+const annotationPanelClose = $('annotation-panel-close');
 const splitToggle = $('split-toggle');
 const splitRawPane = $('split-raw-pane');
 const splitRawContent = $('split-raw-content');
@@ -314,6 +318,13 @@ function registerAppCommands() {
                 toggleAnnotationMode();
                 syncIOSChrome();
             },
+            isAvailable: isDocumentOpen,
+        },
+        {
+            id: 'show-annotations',
+            title: 'Show annotations list',
+            keywords: ['notes', 'annotations', 'panel', 'comments'],
+            run: () => openAnnotationPanel(),
             isAvailable: isDocumentOpen,
         },
         {
@@ -499,6 +510,14 @@ function setupEventListeners() {
             toggleAnnotationMode();
             syncIOSChrome();
         });
+    }
+
+    // Annotations list panel (toggle button + close button)
+    if (annotationListToggle) {
+        annotationListToggle.addEventListener('click', () => toggleAnnotationPanel());
+    }
+    if (annotationPanelClose) {
+        annotationPanelClose.addEventListener('click', () => toggleAnnotationPanel());
     }
 
     // Split view toggle

--- a/markdown-viewer/styles.css
+++ b/markdown-viewer/styles.css
@@ -2335,6 +2335,241 @@ mark.search-highlight-current {
     word-break: break-word;
 }
 
+/* Briefly highlight a block jumped-to from the annotations panel. */
+.annotation-flash {
+    animation: annotation-flash 1.2s ease;
+}
+
+@keyframes annotation-flash {
+    0% { background-color: rgba(243, 156, 18, 0.35); }
+    100% { background-color: transparent; }
+}
+
+/* Notes toggle button (mirrors the other toolbar buttons) */
+.annotation-list-toggle-button {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    background-color: var(--bg-tertiary);
+    color: var(--text-primary);
+    border: 1px solid var(--border-color);
+    padding: 0.5rem 0.9rem;
+    border-radius: var(--radius-md);
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: var(--transition);
+}
+
+.annotation-list-toggle-button:hover,
+.annotation-list-toggle-button.active {
+    background-color: var(--accent-color);
+    color: white;
+    border-color: var(--accent-color);
+}
+
+.annotation-list-count {
+    background-color: var(--accent-color);
+    color: white;
+    border-radius: var(--radius-pill);
+    padding: 0 0.4em;
+    font-size: 0.7rem;
+    font-weight: 600;
+    min-width: 1.2em;
+    text-align: center;
+}
+
+.annotation-list-toggle-button.active .annotation-list-count {
+    background-color: white;
+    color: var(--accent-color);
+}
+
+/* Annotations side panel */
+.annotation-panel {
+    width: 280px;
+    min-width: 240px;
+    flex-shrink: 0;
+    background-color: var(--bg-secondary);
+    border-left: 1px solid var(--border-color);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.annotation-panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-secondary);
+    padding: 0.6rem 0.75rem 0.5rem 1rem;
+    border-bottom: 1px solid var(--border-color);
+    flex-shrink: 0;
+}
+
+.annotation-panel-close {
+    background: none;
+    border: none;
+    color: var(--text-secondary);
+    cursor: pointer;
+    font-size: 0.9rem;
+    line-height: 1;
+    padding: 0.2rem 0.35rem;
+    border-radius: var(--radius-sm);
+}
+
+.annotation-panel-close:hover {
+    background-color: var(--bg-tertiary);
+    color: var(--text-primary);
+}
+
+.annotation-list {
+    list-style: none;
+    margin: 0;
+    padding: 0.5rem 0;
+    overflow-y: auto;
+    flex: 1;
+}
+
+.annotation-list-item {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.25rem;
+    padding: 0.25rem 0.5rem 0.25rem 0.75rem;
+}
+
+.annotation-list-item:hover {
+    background-color: var(--bg-tertiary);
+}
+
+.annotation-list-jump {
+    flex: 1;
+    min-width: 0;
+    text-align: left;
+    background: none;
+    border: none;
+    border-left: 2px solid var(--accent-color);
+    padding: 0.1rem 0 0.1rem 0.5rem;
+    cursor: pointer;
+    font-family: inherit;
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+}
+
+.annotation-list-note {
+    color: var(--text-primary);
+    font-size: 0.82rem;
+    line-height: 1.35;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.annotation-list-context {
+    color: var(--text-secondary);
+    font-size: 0.72rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.annotation-list-edit,
+.annotation-list-delete {
+    background: none;
+    border: none;
+    color: var(--text-secondary);
+    cursor: pointer;
+    font-size: 0.8rem;
+    line-height: 1;
+    padding: 0.15rem 0.3rem;
+    border-radius: var(--radius-sm);
+    flex-shrink: 0;
+}
+
+.annotation-list-edit:hover {
+    color: var(--accent-color);
+    background-color: var(--bg-primary);
+}
+
+.annotation-list-delete:hover {
+    color: var(--color-danger);
+    background-color: var(--bg-primary);
+}
+
+/* Note editor modal */
+.annotation-editor-backdrop {
+    position: fixed;
+    inset: 0;
+    background-color: rgba(0, 0, 0, 0.4);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+    padding: 1rem;
+}
+
+.annotation-editor {
+    background-color: var(--bg-primary);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-lg);
+    width: min(440px, 100%);
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.annotation-editor-input {
+    width: 100%;
+    resize: vertical;
+    font-family: inherit;
+    font-size: 0.9rem;
+    color: var(--text-primary);
+    background-color: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    padding: 0.6rem 0.7rem;
+}
+
+.annotation-editor-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.annotation-editor-spacer {
+    flex: 1;
+}
+
+.annotation-editor-actions button {
+    border: 1px solid var(--border-color);
+    background-color: var(--bg-tertiary);
+    color: var(--text-primary);
+    border-radius: var(--radius-md);
+    padding: 0.45rem 1rem;
+    font-size: 0.9rem;
+    font-family: inherit;
+    cursor: pointer;
+    transition: var(--transition-fast);
+}
+
+.annotation-editor-save {
+    background-color: var(--accent-color) !important;
+    border-color: var(--accent-color) !important;
+    color: white !important;
+}
+
+.annotation-editor-save:hover {
+    background-color: var(--accent-hover) !important;
+}
+
+.annotation-editor-delete {
+    color: var(--color-danger) !important;
+}
+
 /* ===========================
    GitHub Repo Browser Modal
    =========================== */

--- a/tests/unit/annotations.test.js
+++ b/tests/unit/annotations.test.js
@@ -316,3 +316,80 @@ describe('Annotation export / import', () => {
     expect(importAnnotations(JSON.stringify([1, 2, 3]))).toBe(false);
   });
 });
+
+describe('Annotation editor + panel', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    loadHTML(document);
+    loadApp(document);
+  });
+
+  it('adds a note via the in-app editor (no window.prompt needed)', () => {
+    const mc = document.getElementById('markdown-content');
+    mc.innerHTML = '<p>Block zero</p>';
+    renderAnnotations('doc.md');
+    toggleAnnotationMode(); // arms double-click handlers
+
+    mc.querySelector('p').dispatchEvent(new Event('dblclick', { bubbles: true }));
+
+    const backdrop = document.getElementById('annotation-editor-backdrop');
+    expect(backdrop).not.toBeNull();
+    expect(backdrop.style.display).toBe('flex');
+
+    backdrop.querySelector('.annotation-editor-input').value = 'My note';
+    backdrop.querySelector('.annotation-editor-save').dispatchEvent(new Event('click', { bubbles: true }));
+
+    expect(mc.querySelector('p').querySelector('.annotation-badge')).not.toBeNull();
+    expect(JSON.parse(localStorage.getItem('specdown-annotations'))['doc.md']['0']).toBe('My note');
+    expect(backdrop.style.display).toBe('none');
+  });
+
+  it('renders the panel rows + toolbar count', () => {
+    localStorage.setItem('specdown-annotations', JSON.stringify({ 'doc.md': { 0: 'note A', 1: 'note B' } }));
+    const mc = document.getElementById('markdown-content');
+    mc.innerHTML = '<p>Zero</p><p>One</p>';
+    renderAnnotations('doc.md');
+
+    const toggle = document.getElementById('annotation-list-toggle');
+    expect(toggle.style.display).not.toBe('none');
+    expect(toggle.querySelector('.annotation-list-count').textContent).toBe('2');
+
+    const items = document.querySelectorAll('.annotation-list-item');
+    expect(items.length).toBe(2);
+    expect(items[0].querySelector('.annotation-list-note').textContent).toBe('note A');
+    expect(items[0].querySelector('.annotation-list-context').textContent).toBe('Zero');
+  });
+
+  it('hides the toggle when there are no notes', () => {
+    const mc = document.getElementById('markdown-content');
+    mc.innerHTML = '<p>Zero</p>';
+    renderAnnotations('doc.md');
+    expect(document.getElementById('annotation-list-toggle').style.display).toBe('none');
+  });
+
+  it('opens and closes the panel', () => {
+    localStorage.setItem('specdown-annotations', JSON.stringify({ 'doc.md': { 0: 'n' } }));
+    const mc = document.getElementById('markdown-content');
+    mc.innerHTML = '<p>Zero</p>';
+    renderAnnotations('doc.md');
+
+    const panel = document.getElementById('annotation-panel');
+    openAnnotationPanel();
+    expect(panel.classList.contains('open')).toBe(true);
+    toggleAnnotationPanel();
+    expect(panel.classList.contains('open')).toBe(false);
+  });
+
+  it('deleting the last note from the panel hides the toggle and closes the panel', () => {
+    localStorage.setItem('specdown-annotations', JSON.stringify({ 'doc.md': { 0: 'n' } }));
+    const mc = document.getElementById('markdown-content');
+    mc.innerHTML = '<p>Zero</p>';
+    renderAnnotations('doc.md');
+    openAnnotationPanel();
+
+    document.querySelector('.annotation-list-delete').dispatchEvent(new Event('click', { bubbles: true }));
+
+    expect(document.getElementById('annotation-list-toggle').style.display).toBe('none');
+    expect(document.getElementById('annotation-panel').classList.contains('open')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Heads-up: this is the stranded half of #148

When you merged **#148**, only its **first commit** (the badge-render fix + discoverability hint) landed on `main`. The **second commit — the actual desktop fix + the annotations tray — never made it** (I pushed it to the branch right after the PR had already merged, same way the universal-build commit got stranded earlier). So on the current build, desktop annotation editing is still broken and there's no panel yet. This re-submits exactly that work, rebased onto today's `main`.

## What's in it

**1. Desktop fix — in-app editor.** The add/edit flow used `window.prompt()`, which **Electron doesn't implement**, so the desktop app silently did nothing (web has a real `prompt`, which is why it worked there). Replaced with a small **in-app modal editor** (textarea + Save / Delete / Cancel; `Esc` cancels, `Cmd/Ctrl+Enter` saves). Works on every surface.

**2. Annotations tray.** A right-side panel listing every note in document order — each row shows the note + a snippet of its block; click a row to **scroll-and-flash** the block; per-row edit/delete. A toolbar **Notes** button with a live count appears when the doc has notes, plus a **"Show annotations list"** command. Deleting the last note hides the toggle and closes the panel.

## Verification

- `tests/unit/annotations.test.js`: editor add (no `prompt`), panel rows/count, empty-state, open/close, delete-last.
- Rebased onto current `main` (auto-merged cleanly with the workspace-tree changes). `npm run build` ✓, `npm run lint` ✓ (0 errors), `npm run typecheck` ✓, `npm test` → **440 passed**.

## Try on desktop after merge
Open a doc → **Annotate** → double-click a paragraph → the editor opens → Save → badge + the **Notes** count appear → click **Notes** → click a row to jump.

https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA)_