### PR TITLE
iOS: surface Comments + Annotations in the More sheet

### DIFF
--- a/markdown-viewer/index.html
+++ b/markdown-viewer/index.html
@@ -237,6 +237,8 @@
                 </div>
                 <div class="ios-sheet-actions">
                     <button id="ios-split-button" class="ios-sheet-action-button">Split View</button>
+                    <button id="ios-comments-button" class="ios-sheet-action-button">Toggle Comments</button>
+                    <button id="ios-annotations-button" class="ios-sheet-action-button">Annotations</button>
                     <button id="ios-print-button" class="ios-sheet-action-button">Print</button>
                     <button id="ios-theme-button" class="ios-sheet-action-button">Theme</button>
                 </div>

--- a/markdown-viewer/src/main.js
+++ b/markdown-viewer/src/main.js
@@ -204,6 +204,8 @@ const iosMoreButton = /** @type {HTMLButtonElement | null} */ ($('ios-more-butto
 const iosActionSheet = $('ios-action-sheet');
 const iosActionSheetClose = $('ios-action-sheet-close');
 const iosSplitButton = /** @type {HTMLButtonElement | null} */ ($('ios-split-button'));
+const iosCommentsButton = /** @type {HTMLButtonElement | null} */ ($('ios-comments-button'));
+const iosAnnotationsButton = /** @type {HTMLButtonElement | null} */ ($('ios-annotations-button'));
 const iosPrintButton = /** @type {HTMLButtonElement | null} */ ($('ios-print-button'));
 const iosThemeButton = $('ios-theme-button');
 const iosTocSheet = $('ios-toc-sheet');
@@ -608,6 +610,20 @@ function setupEventListeners() {
             if (iosSplitButton.disabled) return;
             closeIOSActionSheet();
             toggleSplitView();
+        });
+    }
+
+    if (iosCommentsButton) {
+        iosCommentsButton.addEventListener('click', () => {
+            closeIOSActionSheet();
+            toggleComments();
+        });
+    }
+
+    if (iosAnnotationsButton) {
+        iosAnnotationsButton.addEventListener('click', () => {
+            closeIOSActionSheet();
+            openAnnotationPanel();
         });
     }
 

--- a/markdown-viewer/styles.css
+++ b/markdown-viewer/styles.css
@@ -2450,6 +2450,21 @@ mark.search-highlight-current {
     overflow: hidden;
 }
 
+/* On narrow screens (iPhone, small browser windows) a fixed side column would
+   crush the content, so the annotations panel overlays from the right instead. */
+@media (max-width: 700px) {
+    .annotation-panel {
+        position: fixed;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        width: 100%;
+        max-width: 360px;
+        z-index: 600;
+        box-shadow: var(--shadow-lg);
+    }
+}
+
 .annotation-panel-header {
     display: flex;
     align-items: center;

--- a/tests/unit/comments.test.js
+++ b/tests/unit/comments.test.js
@@ -77,4 +77,26 @@ describe('HTML comments', () => {
     expect(block.textContent).toContain('hidden body');
     expect(document.getElementById('comments-toggle').style.display).not.toBe('none');
   });
+
+  describe('iOS More-sheet controls', () => {
+    it('Toggle Comments button flips comment visibility', () => {
+      const mc = document.getElementById('markdown-content');
+      mc.innerHTML = '<div class="html-comment-block">a</div>';
+      refreshCommentsUI();
+      expect(mc.classList.contains('comments-hidden')).toBe(false);
+
+      document.getElementById('ios-comments-button').dispatchEvent(new Event('click', { bubbles: true }));
+      expect(mc.classList.contains('comments-hidden')).toBe(true);
+    });
+
+    it('Annotations button opens the annotations panel', () => {
+      localStorage.setItem('specdown-annotations', JSON.stringify({ 'doc.md': { 0: 'n' } }));
+      const mc = document.getElementById('markdown-content');
+      mc.innerHTML = '<p>Zero</p>';
+      renderAnnotations('doc.md');
+
+      document.getElementById('ios-annotations-button').dispatchEvent(new Event('click', { bubbles: true }));
+      expect(document.getElementById('annotation-panel').classList.contains('open')).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## What

The HTML-comment reveal + toggle already merged to `main` (via #153, v0.0.136). This PR is now **only the stranded follow-up**: surfacing those controls in the iOS interface (the iOS commit didn't make it in with #153).

I reset this branch to current `main` and re-applied just the iOS commit, so the diff is small and conflict-free (**4 files, +55**) — no duplicated comments feature, no `package.json`/dependabot collisions.

## Changes

On iPhone the desktop toolbar (`.content-header-actions`) is hidden in favor of the bottom action bar, so the **Comments** toggle and **Annotations** panel had no surfaced control there (they worked, just weren't reachable).

- Add **Toggle Comments** and **Annotations** buttons to the iOS **More** action sheet, wired to `toggleComments()` / `openAnnotationPanel()`.
- On narrow screens (iPhone + small browser windows) the annotations panel now **overlays from the right** (`position: fixed`, max 360px) instead of crushing the content column.

## Verification

- `tests/unit/comments.test.js` (+2): the iOS sheet buttons toggle comments / open the panel.
- Rebased on current `main` (v0.0.138). `npm run build` ✓, `npm run lint` ✓ (0 errors), `npm run typecheck` ✓, `npm test` → **448 passed**.

> Reminder: iOS picks this up only on a fresh from-source Xcode build (no TestFlight/App Store channel yet).

https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA