### PR TITLE
iOS: fix iPad print presentation + Xcode settings prompt

### DIFF
--- a/ios/SpecDown/WebBridge.swift
+++ b/ios/SpecDown/WebBridge.swift
@@ -237,7 +237,14 @@ final class WebBridge: NSObject, ObservableObject, WKScriptMessageHandler {
             print("[Bridge] Missing printable content for printDocument")
             return
         }
-        controller.present(animated: true) { _, completed, error in
+        // Present from the top view controller's view so the print sheet anchors
+        // correctly on iPad (where `present(animated:)` alone is a no-op — it needs
+        // an anchor for the popover). On iPhone the anchor is ignored and it shows
+        // full-screen as before. This also uses `presenter`, which was otherwise
+        // unused.
+        let anchorView = presenter.view ?? webView ?? UIView()
+        let anchorRect = CGRect(x: anchorView.bounds.midX, y: anchorView.bounds.midY, width: 0, height: 0)
+        controller.present(from: anchorRect, in: anchorView, animated: true) { _, completed, error in
             if let error {
                 print("[Bridge] Print controller error: \(error)")
                 return

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -9,6 +9,10 @@ options:
 
 settings:
   SWIFT_VERSION: "5.9"
+  # Apple-recommended hardening (Xcode's "validate settings" prompt). Safe here:
+  # there are no shell-script build phases for the sandbox to constrain. Setting
+  # it in project.yml makes it persist across `xcodegen generate`.
+  ENABLE_USER_SCRIPT_SANDBOXING: "YES"
 
 targets:
   SpecDown:


### PR DESCRIPTION
From your Xcode notes.

## 1. The Swift warning was a real iPad bug

`presentPrintController` bound `presenter` but then called `UIPrintInteractionController.present(animated:)` — which on **iPad** is effectively a no-op (it needs an anchor via `present(from:in:animated:)` or the print sheet never appears). Hence "`presenter` defined but never used."

Fix: present from the top view controller's view, which anchors the popover on iPad (ignored on iPhone — unchanged there) and uses `presenter`, clearing the warning. So this both **fixes iPad printing** and silences the warning.

## 2. Xcode "validate settings" prompt

Added `ENABLE_USER_SCRIPT_SANDBOXING: "YES"` to `ios/project.yml`. It's the Apple-recommended hardening, safe here (no shell-script build phases to constrain), and putting it in the XcodeGen config makes it **persist across `xcodegen generate`** so the prompt stops re-appearing.

> The other two prompts I left alone on purpose: "Inherit Development Team" is signing-related (per-user, not needed for the simulator CI build), and "String Catalog Symbol Generation" applies only if we adopt String Catalogs (we don't). The runtime `Could not create a sandbox extension …` line is a benign WKWebView console message, not an app bug.

## Verification

I can't run Xcode here, so the **iOS Simulator CI build** verifies the Swift compiles and the project generates with the new setting. (No JS changed, so the web test suite is unaffected.)

https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkY7GmEvGm8sBDxQmMLoyA)_