### PR TITLE
Fix diagram controls overlap and double-tap zoom on mobile

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ Each project gets its own subdirectory:
 | [project-ios/](project-ios/) | iOS & iPad app — brainstorms, specs, session task checklists |
 | [project-url/](project-url/) | URL-based file opening — load markdown from GitHub or any web URL |
 | [project-modernization/](project-modernization/) | Cross-platform modernization — product/UX/engineering evaluation, vision, phased roadmap |
+| [project-bugfix-wave/](project-bugfix-wave/) | Post-modernization bug fixes & UX polish across web, desktop, and iOS |
 
 ## Naming Conventions
 

--- a/docs/project-bugfix-wave/2026-06-21-tasks-session-01-diagram-controls-overlap.md
+++ b/docs/project-bugfix-wave/2026-06-21-tasks-session-01-diagram-controls-overlap.md
@@ -1,0 +1,55 @@
+# Session 01 — Diagram controls overlap the diagram on phones
+
+**Date:** 2026-06-21
+**Type:** tasks
+**Surfaces:** iOS (WKWebView shell) + mobile web — both phone-width layouts.
+
+## Problem
+
+On a phone, the Mermaid diagram control cluster (zoom −/+, zoom slider, reset,
+SVG, PNG, share, fullscreen) floated **over** the top-right of the diagram and
+covered a large part of it — the user reported it on iOS and suspected mobile
+web too. Confirmed: it affects both.
+
+### Root cause
+
+`.diagram-controls` is `position: absolute; top: 10px; right: 10px` so it floats
+over the `.diagram-wrapper` (a fixed `height: 500px` box). That's fine on a wide
+screen, but on a phone the cluster is wide (the zoom slider + eight ~44px
+touch-sized buttons) and the existing `@media (max-width: 768px)` rule let it
+`flex-wrap`, turning the overlay into a tall multi-row block that obscured the
+diagram content beneath it. Because the breakpoint is width-based, it hit the
+iOS WKWebView shell and mobile Safari/Chrome identically.
+
+## Fix
+
+CSS-only, in the existing `@media (max-width: 768px)` block of
+`markdown-viewer/styles.css`:
+
+- Take `.diagram-controls` out of the absolute overlay (`position: static`,
+  clear `top`/`right`) so it sits in normal flow as a toolbar **above** the
+  diagram. The controls already precede `.diagram-wrapper` in the DOM
+  (`createDiagramContainer` appends controls then wrapper), so static stacking
+  puts them on top without any DOM/JS change.
+- Square off the floating-chip look on the bar (no radius/shadow, a
+  `border-bottom` divider, secondary background) so it reads as a toolbar.
+- Constrain the zoom slider (`flex: 1 1 120px`, full-width range) so it doesn't
+  blow the toolbar width out on narrow screens.
+
+No change to fullscreen controls' overlay behavior (the fullscreen surface has
+room and a dedicated layout).
+
+## Gates
+
+- `npm run lint` — 0 errors (pre-existing warnings only)
+- `npm run typecheck` — clean
+- `npm test` — 448/448 pass
+- `npm run build` — succeeds
+
+## Notes / follow-ups
+
+- This is shared-app CSS, so the single change reaches all three surfaces; no
+  iOS action-sheet wiring was needed because the controls are in-document, not a
+  toolbar button.
+- Verified by reading the render path + CSS; a device/browser visual check on a
+  real phone is the remaining confirmation (agent can't drive the iOS runtime).

--- a/docs/project-bugfix-wave/2026-06-21-tasks-session-02-diagram-double-tap-zoom.md
+++ b/docs/project-bugfix-wave/2026-06-21-tasks-session-02-diagram-double-tap-zoom.md
@@ -1,0 +1,40 @@
+# Session 02 — Double-tap on a diagram zoom button zooms the whole page
+
+**Date:** 2026-06-21
+**Type:** tasks
+**Surfaces:** iOS (WKWebView shell) + mobile web — touch devices.
+
+## Problem
+
+Double-tapping the `+` (zoom-in) button on a diagram *sometimes* zoomed the
+entire interface instead of just zooming the diagram.
+
+### Root cause
+
+On touch devices, mobile Safari / WKWebView treats a fast double-tap as the
+page's built-in **double-tap-to-zoom** gesture. When the two taps landed on the
+zoom button quickly enough, the browser ran its own page-zoom gesture (scaling
+the whole UI) instead of — or on top of — firing two button clicks. The viewport
+intentionally still allows user scaling (`width=device-width, initial-scale=1.0`,
+no `user-scalable=no`), so the gesture was live on every interactive element.
+
+## Fix
+
+CSS-only, in `markdown-viewer/styles.css`: add `touch-action: manipulation` to
+`.diagram-controls button` and `.fullscreen-controls button`. `manipulation`
+keeps single tap, panning, and pinch-zoom but removes the browser's double-tap
+zoom (and the associated ~300 ms click delay) on those controls — so a rapid
+double-tap on `+` now just zooms in twice on the diagram. Pinch-to-zoom on the
+page at large is untouched (we did not add `user-scalable=no`).
+
+## Gates
+
+- `npm run lint` — 0 errors (pre-existing warnings only)
+- `npm test` — 448/448 pass
+- `npm run build` — succeeds
+
+## Notes / follow-ups
+
+- Shared-app CSS, so the fix reaches all three surfaces in one change.
+- Device confirmation on a real phone is the remaining check (agent can't drive
+  the iOS runtime).

--- a/docs/project-bugfix-wave/2026-06-21-tasks-session-03-jsyaml-dos-advisory.md
+++ b/docs/project-bugfix-wave/2026-06-21-tasks-session-03-jsyaml-dos-advisory.md
@@ -1,0 +1,71 @@
+# Session 03 — Resolve the js-yaml DoS Dependabot advisory
+
+**Date:** 2026-06-21
+**Type:** tasks
+**Surface:** tooling / supply chain (dev-only dependency).
+
+## Problem
+
+A push to the branch surfaced a Dependabot alert: **1 moderate** vulnerability
+on the default branch — [GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68),
+a quadratic-complexity DoS in **js-yaml** merge-key handling (`js-yaml <= 4.1.1`).
+
+### Assessment
+
+The vulnerable copy was **`js-yaml@3.14.2`**, reached only through a **dev-only**
+chain:
+
+```
+jest → @jest/core → @jest/transform → babel-plugin-istanbul
+     → @istanbuljs/load-nyc-config → js-yaml@3.14.2
+```
+
+`@istanbuljs/load-nyc-config` uses js-yaml solely to parse local, developer-authored
+`.nycrc(.yaml)` coverage config — never untrusted input — so real-world exposure
+was effectively nil. But it's worth clearing: the alert is noise on every push,
+and a patched js-yaml exists.
+
+(The other js-yaml in the tree, via `electron-builder`, was already `4.2.0` —
+patched — and not flagged.)
+
+## Why not `npm audit fix --force`
+
+`audit fix --force` wanted to **downgrade jest to 25.0.0** (a major breaking
+change) — wrong tool for a deep transitive. Rejected.
+
+## Fix
+
+There is **no patched 3.x release** (3.14.2 is the last 3.x); the fix lands in
+`js-yaml@4.2.0`. `@istanbuljs/load-nyc-config` declares `js-yaml@^3.13.1` but its
+code calls only `require('js-yaml').load(...)`, and `.load()` exists in **both**
+v3 and v4 (in v4 it's the safe loader) — so bumping it to v4 is API-safe.
+
+Added a **scoped npm `overrides`** in `package.json`:
+
+```json
+"overrides": {
+  "@istanbuljs/load-nyc-config": { "js-yaml": "^4.2.0" }
+}
+```
+
+Scoped (not a global js-yaml override) so it touches only the one vulnerable
+path. The lockfile was updated **surgically** — removed the nested
+`js-yaml@3.14.2` and its now-orphaned transitives (`argparse@1`, `esprima`,
+`sprintf-js`); `load-nyc-config` now dedupes to the root `js-yaml@4.2.0`. Net
+lock diff is ~47 lines, no unrelated dependency churn.
+
+## Gates
+
+- `npm ci` — clean install, **0 vulnerabilities** (`npm audit`)
+- `npm run lint` — 0 errors
+- `npm run typecheck` — clean
+- `npm test` — 448/448 pass
+- `npm run test:coverage` — passes (exercises the `load-nyc-config` → js-yaml
+  path, confirming the v4 bump doesn't break coverage instrumentation)
+- `npm run build` — succeeds
+
+## Notes / follow-ups
+
+- Pure dev/tooling change; production runtime deps (pinned exact) untouched.
+- The override can be dropped once `@istanbuljs/load-nyc-config` (upstream)
+  moves off js-yaml 3.x on its own.

--- a/docs/project-bugfix-wave/README.md
+++ b/docs/project-bugfix-wave/README.md
@@ -11,6 +11,7 @@ folder tracks the smaller fixes that follow.
 |---|---|---|
 | 2026-06-21 | [tasks-session-01](2026-06-21-tasks-session-01-diagram-controls-overlap.md) | Diagram control toolbar overlapped/covered the diagram on phones (iOS + mobile web) |
 | 2026-06-21 | [tasks-session-02](2026-06-21-tasks-session-02-diagram-double-tap-zoom.md) | Double-tap on a diagram zoom button zoomed the whole page instead of the diagram |
+| 2026-06-21 | [tasks-session-03](2026-06-21-tasks-session-03-jsyaml-dos-advisory.md) | Cleared the js-yaml DoS Dependabot advisory (dev-only transitive) via a scoped override |
 
 ## Status
 

--- a/docs/project-bugfix-wave/README.md
+++ b/docs/project-bugfix-wave/README.md
@@ -1,0 +1,22 @@
+# project-bugfix-wave
+
+A rolling wave of post-modernization bug fixes and small UX polish across the
+three SpecDown surfaces (web, desktop, iOS). The phased modernization roadmap is
+complete (see [`../project-modernization/`](../project-modernization/)); this
+folder tracks the smaller fixes that follow.
+
+## Timeline
+
+| Date | Doc | Summary |
+|---|---|---|
+| 2026-06-21 | [tasks-session-01](2026-06-21-tasks-session-01-diagram-controls-overlap.md) | Diagram control toolbar overlapped/covered the diagram on phones (iOS + mobile web) |
+
+## Status
+
+Active.
+
+## Naming Conventions
+
+Files follow the repo-wide pattern `YYYY-MM-DD-<type>-<detail>.md` with types
+`brainstorm` / `spec` / `tasks` (numbered, one per working session). See
+[`../README.md`](../README.md).

--- a/docs/project-bugfix-wave/README.md
+++ b/docs/project-bugfix-wave/README.md
@@ -10,6 +10,7 @@ folder tracks the smaller fixes that follow.
 | Date | Doc | Summary |
 |---|---|---|
 | 2026-06-21 | [tasks-session-01](2026-06-21-tasks-session-01-diagram-controls-overlap.md) | Diagram control toolbar overlapped/covered the diagram on phones (iOS + mobile web) |
+| 2026-06-21 | [tasks-session-02](2026-06-21-tasks-session-02-diagram-double-tap-zoom.md) | Double-tap on a diagram zoom button zoomed the whole page instead of the diagram |
 
 ## Status
 

--- a/markdown-viewer/styles.css
+++ b/markdown-viewer/styles.css
@@ -1201,7 +1201,25 @@ body {
         padding: 1rem;
     }
 
-    .diagram-controls,
+    /* On phones the control cluster is too wide/tall to float over the diagram
+       without covering it (the zoom slider + touch-sized buttons wrap into a
+       large block). Drop it out of the absolute overlay and into normal flow as
+       a toolbar above the diagram so it never obscures the content. The controls
+       already precede .diagram-wrapper in the DOM, so static positioning stacks
+       them on top. Applies to mobile web and the iOS WKWebView shell alike. */
+    .diagram-controls {
+        position: static;
+        top: auto;
+        right: auto;
+        flex-wrap: wrap;
+        justify-content: flex-start;
+        align-items: center;
+        border-radius: 0;
+        box-shadow: none;
+        background-color: var(--bg-secondary);
+        border-bottom: 1px solid var(--border-color);
+    }
+
     .fullscreen-controls {
         flex-wrap: wrap;
     }
@@ -1210,6 +1228,17 @@ body {
     .fullscreen-controls button {
         padding: 0.4rem 0.6rem;
         font-size: 0.9rem;
+    }
+
+    /* Keep the zoom slider from forcing the toolbar absurdly wide on phones. */
+    .diagram-controls .zoom-range-label {
+        flex: 1 1 120px;
+        min-width: 100px;
+    }
+
+    .diagram-controls .zoom-range {
+        width: 100%;
+        min-width: 0;
     }
 }
 

--- a/markdown-viewer/styles.css
+++ b/markdown-viewer/styles.css
@@ -996,6 +996,11 @@ body {
     font-weight: 600;
     min-width: 44px;
     min-height: 44px;
+    /* A fast double-tap on a zoom button (e.g. +) was being read by mobile
+       Safari/WKWebView as the page's double-tap-to-zoom gesture, zooming the
+       whole interface. `manipulation` keeps tap/pan/pinch but drops double-tap
+       zoom on the control itself. */
+    touch-action: manipulation;
 }
 
 .diagram-controls button:hover {
@@ -1080,6 +1085,8 @@ body {
     font-weight: 600;
     min-width: 44px;
     min-height: 44px;
+    /* See .diagram-controls button — avoid double-tap-to-zoom on the page. */
+    touch-action: manipulation;
 }
 
 .zoom-range-label {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "specdown",
-  "version": "0.0.136",
+  "version": "0.0.142",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "specdown",
-      "version": "0.0.136",
+      "version": "0.0.142",
       "license": "MIT",
       "dependencies": {
         "@panzoom/panzoom": "4.6.2",
@@ -1868,30 +1868,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@istanbuljs/schema": {
@@ -6413,20 +6389,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/esquery": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
@@ -10818,13 +10780,6 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",

--- a/package.json
+++ b/package.json
@@ -110,6 +110,11 @@
       "icon": "build/icon-square.png"
     }
   },
+  "overrides": {
+    "@istanbuljs/load-nyc-config": {
+      "js-yaml": "^4.2.0"
+    }
+  },
   "dependencies": {
     "@panzoom/panzoom": "4.6.2",
     "chokidar": "^5.0.0",


### PR DESCRIPTION
## Summary

Resolves two mobile UX issues affecting diagram interaction on phones (iOS WKWebView shell and mobile web):

1. **Diagram controls overlay** — The control cluster (zoom buttons, slider, etc.) was positioned absolutely over the diagram, covering content on narrow screens.
2. **Double-tap zoom gesture** — Rapid double-taps on zoom buttons triggered the browser's page-zoom gesture instead of diagram zoom.

Also clears a Dependabot advisory for a dev-only js-yaml transitive vulnerability.

## Changes

### CSS fixes in `markdown-viewer/styles.css`

- **Touch-action on diagram controls** — Added `touch-action: manipulation` to `.diagram-controls button` and `.fullscreen-controls button` to prevent the browser's double-tap-to-zoom gesture on those controls while preserving pinch-zoom on the page.

- **Diagram controls layout on phones** — In the `@media (max-width: 768px)` block:
  - Changed `.diagram-controls` from `position: absolute` to `position: static` so it sits above the diagram in normal flow instead of overlaying it.
  - Styled it as a toolbar with `background-color: var(--bg-secondary)` and `border-bottom: 1px solid var(--border-color)`.
  - Constrained the zoom slider with `flex: 1 1 120px` to prevent it from forcing the toolbar absurdly wide on narrow screens.

### Supply chain fix in `package.json`

- Added a scoped npm `overrides` entry to bump `js-yaml` from 3.14.2 to 4.2.0 within the `@istanbuljs/load-nyc-config` dependency chain, resolving a moderate DoS vulnerability (GHSA-h67p-54hq-rp68). The override is scoped to avoid global churn; the API (`js-yaml.load()`) is compatible across v3 and v4.

### Documentation

- Added `docs/project-bugfix-wave/` folder with a `README.md` timeline and three session task documents detailing each fix.

## Testing

All gates pass:
- `npm ci` — 0 vulnerabilities
- `npm run lint` — 0 errors
- `npm run typecheck` — clean
- `npm test` — 448/448 pass
- `npm run test:coverage` — passes (exercises the coverage instrumentation path)
- `npm run build` — succeeds

The changes are CSS-only (shared app) and a dev-only dependency override, so they reach all three surfaces (web, desktop, iOS) in one commit.

https://claude.ai/code/session_01GeGQZEA1iJ8yHWuPuZzayv