### PR TITLE
Scaffold iOS TestFlight release lane (inert until secrets added)

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -1,0 +1,146 @@
+name: iOS Release (TestFlight)
+
+# Tag-triggered TestFlight lane. Mirrors desktop.yml: the signing/upload steps
+# run only when the App Store Connect API-key secrets are configured. Until then
+# the job still validates that the Release configuration archives-cleanly for the
+# simulator, so the workflow is wired up and green before any secrets exist.
+#
+# Required secrets (see docs/project-ios/2026-06-21-spec-ios-distribution-setup.md):
+#   APPSTORE_API_KEY_ID     - App Store Connect API Key ID
+#   APPSTORE_API_ISSUER_ID  - App Store Connect API Issuer ID
+#   APPSTORE_API_KEY_P8     - base64 of the AuthKey_XXXX.p8
+#   APPLE_TEAM_ID           - Apple Developer Team ID (reused from the macOS lane)
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  testflight:
+    name: Archive + upload to TestFlight
+    runs-on: macos-latest
+    env:
+      # True only when the API key secret is present. Gates the device archive
+      # + upload; a fork or a pre-secrets repo falls back to a Release-config
+      # simulator validation build instead of hard-failing.
+      HAS_IOS_SIGNING: ${{ secrets.APPSTORE_API_KEY_P8 != '' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Determine version
+        id: version
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            TAG="${GITHUB_REF#refs/tags/}"
+          else
+            TAG="$(git describe --tags --abbrev=0 2>/dev/null || echo v0.0.0)"
+          fi
+          # Marketing version is the tag without the leading "v" (e.g. 0.0.143).
+          echo "marketing=${TAG#v}" >> "$GITHUB_OUTPUT"
+          # Build number must increase on every upload; the run number is
+          # monotonic and unique per workflow.
+          echo "build=${{ github.run_number }}" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build web app
+        run: npm run build
+
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      - name: Generate Xcode project
+        working-directory: ios
+        run: xcodegen generate
+
+      # ----------------------------------------------------------------
+      # No signing secrets: validate the Release config compiles, then stop.
+      # ----------------------------------------------------------------
+      - name: Validate Release build (no signing secrets)
+        if: env.HAS_IOS_SIGNING != 'true'
+        run: |
+          echo "::notice::App Store Connect API-key secrets not configured; skipping device archive + TestFlight upload. Running a Release-configuration simulator validation build instead. See docs/project-ios/2026-06-21-spec-ios-distribution-setup.md to enable uploads."
+          xcodebuild \
+            -project ios/SpecDown.xcodeproj \
+            -scheme SpecDown \
+            -sdk iphonesimulator \
+            -configuration Release \
+            ONLY_ACTIVE_ARCH=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            MARKETING_VERSION="${{ steps.version.outputs.marketing }}" \
+            CURRENT_PROJECT_VERSION="${{ steps.version.outputs.build }}" \
+            build | xcpretty
+
+      # ----------------------------------------------------------------
+      # Signing secrets present: archive, export, and upload to TestFlight.
+      # ----------------------------------------------------------------
+      - name: Install App Store Connect API key
+        if: env.HAS_IOS_SIGNING == 'true'
+        run: |
+          mkdir -p ~/private_keys
+          echo "${{ secrets.APPSTORE_API_KEY_P8 }}" | base64 --decode \
+            > ~/private_keys/AuthKey_${{ secrets.APPSTORE_API_KEY_ID }}.p8
+
+      - name: Inject Team ID into ExportOptions.plist
+        if: env.HAS_IOS_SIGNING == 'true'
+        run: |
+          /usr/libexec/PlistBuddy -c \
+            "Set :teamID ${{ secrets.APPLE_TEAM_ID }}" ios/ExportOptions.plist
+
+      - name: Archive (Release, device)
+        if: env.HAS_IOS_SIGNING == 'true'
+        run: |
+          xcodebuild \
+            -project ios/SpecDown.xcodeproj \
+            -scheme SpecDown \
+            -sdk iphoneos \
+            -configuration Release \
+            -archivePath "$RUNNER_TEMP/SpecDown.xcarchive" \
+            -allowProvisioningUpdates \
+            -authenticationKeyID "${{ secrets.APPSTORE_API_KEY_ID }}" \
+            -authenticationKeyIssuerID "${{ secrets.APPSTORE_API_ISSUER_ID }}" \
+            -authenticationKeyPath ~/private_keys/AuthKey_${{ secrets.APPSTORE_API_KEY_ID }}.p8 \
+            DEVELOPMENT_TEAM="${{ secrets.APPLE_TEAM_ID }}" \
+            CODE_SIGN_STYLE=Automatic \
+            MARKETING_VERSION="${{ steps.version.outputs.marketing }}" \
+            CURRENT_PROJECT_VERSION="${{ steps.version.outputs.build }}" \
+            archive
+
+      - name: Export .ipa
+        if: env.HAS_IOS_SIGNING == 'true'
+        run: |
+          xcodebuild -exportArchive \
+            -archivePath "$RUNNER_TEMP/SpecDown.xcarchive" \
+            -exportOptionsPlist ios/ExportOptions.plist \
+            -exportPath "$RUNNER_TEMP/export" \
+            -allowProvisioningUpdates \
+            -authenticationKeyID "${{ secrets.APPSTORE_API_KEY_ID }}" \
+            -authenticationKeyIssuerID "${{ secrets.APPSTORE_API_ISSUER_ID }}" \
+            -authenticationKeyPath ~/private_keys/AuthKey_${{ secrets.APPSTORE_API_KEY_ID }}.p8
+
+      - name: Upload to TestFlight
+        if: env.HAS_IOS_SIGNING == 'true'
+        run: |
+          xcrun altool --upload-app \
+            --type ios \
+            --file "$(ls "$RUNNER_TEMP"/export/*.ipa | head -n1)" \
+            --apiKey "${{ secrets.APPSTORE_API_KEY_ID }}" \
+            --apiIssuer "${{ secrets.APPSTORE_API_ISSUER_ID }}"
+
+      - name: Clean up API key
+        if: always()
+        run: rm -f ~/private_keys/AuthKey_*.p8

--- a/docs/project-ios/2026-06-21-spec-ios-distribution-setup.md
+++ b/docs/project-ios/2026-06-21-spec-ios-distribution-setup.md
@@ -1,0 +1,77 @@
+# Setup Guide: iOS TestFlight Distribution
+
+**Date:** 2026-06-21
+**Type:** spec (setup checklist for activating the TestFlight lane)
+**Builds on:** [`../project-modernization/2026-06-16-spec-ios-distribution.md`](../project-modernization/2026-06-16-spec-ios-distribution.md)
+
+The TestFlight release lane is now **scaffolded and committed** — see
+[`.github/workflows/ios-release.yml`](../../.github/workflows/ios-release.yml) and
+[`ios/ExportOptions.plist`](../../ios/ExportOptions.plist). It is **inert until the
+four App Store Connect secrets below are configured**: with no secrets the
+tag-triggered workflow runs a Release-configuration simulator validation build
+and stops (no archive, no upload), so the lane is green and ready ahead of time.
+
+This document is the one-time, browser-side checklist **you** complete to switch
+it on. None of it can be done from CI/agents (it needs Apple ID auth + the App
+Store Connect UI).
+
+---
+
+## What's already done (in-repo, no secrets needed)
+
+- **`ios-release.yml`** — tag-triggered (`v*`) + manual `workflow_dispatch`.
+  Archives for device, exports an `.ipa`, and uploads to TestFlight **when
+  secrets exist**; otherwise validates the Release build. Stamps a monotonic
+  `CFBundleVersion` from the workflow run number and `MARKETING_VERSION` from the
+  tag, so uploads never collide.
+- **`ios/ExportOptions.plist`** — `method = app-store`, `signingStyle =
+  automatic`. The `teamID` is a placeholder that CI overwrites from the
+  `APPLE_TEAM_ID` secret (so it's never committed).
+- **`ITSAppUsesNonExemptEncryption = false`** in `ios/project.yml` — skips the
+  per-upload export-compliance question (SpecDown uses only standard HTTPS/TLS).
+- The existing **`ios.yml`** simulator build stays as the fast PR check.
+
+## One-time Apple setup (you, in the browser)
+
+1. **Apple Developer Program** — already covered (same membership as the macOS
+   Developer ID cert). Individual is fine.
+2. **App record** — appstoreconnect.apple.com → Apps → **+** → bundle id
+   `com.cbremer.SpecDown`, name **SpecDown**, primary language, SKU. (You can let
+   this step register the App ID, or pre-create it under Identifiers.)
+3. **App Store Connect API key** — App Store Connect → Users and Access →
+   **Integrations → App Store Connect API → +**, role **App Manager**. Download
+   the **`.p8`** (one-time download) and note the **Key ID** and **Issuer ID**.
+
+## GitHub secrets to add
+
+Repo → Settings → Secrets and variables → Actions → New repository secret:
+
+| Secret | Value |
+|---|---|
+| `APPSTORE_API_KEY_ID` | the Key ID from step 3 |
+| `APPSTORE_API_ISSUER_ID` | the Issuer ID from step 3 |
+| `APPSTORE_API_KEY_P8` | base64 of the `.p8`: `base64 -i AuthKey_XXXX.p8 \| pbcopy` |
+| `APPLE_TEAM_ID` | your Apple Developer Team ID (reused from the macOS lane) |
+
+The moment `APPSTORE_API_KEY_P8` is present, the next `v*` tag (or a manual
+**Run workflow**) will archive, sign with cloud-managed automatic signing, and
+upload to TestFlight.
+
+## First run
+
+1. Add the four secrets.
+2. Actions → **iOS Release (TestFlight)** → **Run workflow** (manual dispatch is
+   the safest first test; it uses the latest tag for the marketing version).
+3. Watch for the upload step to succeed, then check App Store Connect →
+   TestFlight for the processing build (a few minutes).
+4. For **external** testers later, add a public link + complete the one-time Beta
+   App Review (Phase B in the distribution spec).
+
+## Gotchas (carried from the distribution spec)
+
+- **Build numbers must increase** every upload — handled here via the run number.
+- **Automatic signing** needs `-allowProvisioningUpdates` (set) and the API key;
+  no profiles are checked in.
+- TestFlight builds **expire after 90 days**; re-tag to refresh.
+- The first upload of a new app id can take longer to appear while App Store
+  Connect provisions it.

--- a/docs/project-ios/README.md
+++ b/docs/project-ios/README.md
@@ -35,6 +35,7 @@ The web version works in mobile Safari but isn't optimized for touch. The deskto
 | Mar 16, 2026 | Tasks | [2026-03-16-tasks-session-01-project-setup.md](2026-03-16-tasks-session-01-project-setup.md) | Session 1 checklist — Xcode project, WKWebView shell, web assets bundled, JS bridge skeleton, CI workflow |
 | May 15, 2026 | Spec | [2026-05-15-spec-ios-v2.md](2026-05-15-spec-ios-v2.md) | Adaptive shell revision for iPadOS: native split layout, layout-mode bridge, shared viewer retained in detail pane |
 | May 15, 2026 | Tasks | [2026-05-15-tasks-session-02-ipados-shell.md](2026-05-15-tasks-session-02-ipados-shell.md) | Session 2 checklist — iPad regular-width split shell, sidebar actions, shared viewer layout-mode switching |
+| Jun 21, 2026 | Spec | [2026-06-21-spec-ios-distribution-setup.md](2026-06-21-spec-ios-distribution-setup.md) | TestFlight lane scaffolded (workflow + ExportOptions); one-time App Store Connect setup checklist to activate it |
 
 ---
 

--- a/ios/ExportOptions.plist
+++ b/ios/ExportOptions.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Export options for the App Store / TestFlight archive (used by
+  `xcodebuild -exportArchive` in .github/workflows/ios-release.yml).
+
+  The <teamID> below is a placeholder; CI overwrites it with the
+  APPLE_TEAM_ID secret via PlistBuddy before exporting, so the real team id is
+  never committed. With automatic cloud signing + an App Store Connect API key,
+  no provisioning profiles need to be checked in.
+-->
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>app-store</string>
+
+    <key>signingStyle</key>
+    <string>automatic</string>
+
+    <key>teamID</key>
+    <string>REPLACE_WITH_APPLE_TEAM_ID</string>
+
+    <!-- Upload the build's symbols so App Store Connect can symbolicate crashes. -->
+    <key>uploadSymbols</key>
+    <true/>
+
+    <!-- We upload to TestFlight as a separate altool step, not from export. -->
+    <key>destination</key>
+    <string>export</string>
+
+    <!-- Let App Store Connect manage the app's build version automatically is
+         off; CI stamps CFBundleVersion explicitly so uploads stay monotonic. -->
+    <key>manageAppVersionAndBuildNumber</key>
+    <false/>
+</dict>
+</plist>

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -42,6 +42,10 @@ targets:
         CFBundleDisplayName: Specdown
         CFBundleShortVersionString: "1.0"
         CFBundleVersion: "1"
+        # SpecDown uses only standard HTTPS/TLS, so it is exempt from U.S. export
+        # compliance. Declaring this skips the per-upload encryption question in
+        # App Store Connect / TestFlight.
+        ITSAppUsesNonExemptEncryption: false
         LSRequiresIPhoneOS: true
         UILaunchScreen: {}
         UISupportedInterfaceOrientations:


### PR DESCRIPTION
## What & why

Sets up the iOS TestFlight distribution lane with everything that **doesn't** require Apple secrets, so the pipeline is wired up and green ahead of the one-time App Store Connect setup. This is the highest-value roadmap gap (no way to install the iOS app today beyond building from source).

The lane is **inert until four secrets are added** — no behavior change until then.

## Changes

- **`.github/workflows/ios-release.yml`** — tag-triggered (`v*`) + manual `workflow_dispatch`. Mirrors `desktop.yml`'s `HAS_SIGNING` pattern via `HAS_IOS_SIGNING`:
  - **With** the App Store Connect API-key secrets → archive for device, export `.ipa`, upload to TestFlight (cloud-managed automatic signing, `-allowProvisioningUpdates`).
  - **Without** them → runs a Release-configuration simulator validation build and stops (never hard-fails).
  - Stamps a **monotonic** `CFBundleVersion` from the run number + `MARKETING_VERSION` from the tag, so uploads never collide.
- **`ios/ExportOptions.plist`** — `method = app-store`, `signingStyle = automatic`. `teamID` is a placeholder CI overwrites from `APPLE_TEAM_ID` (never committed).
- **`ios/project.yml`** — `ITSAppUsesNonExemptEncryption = false` (standard HTTPS/TLS only; skips the per-upload export-compliance prompt).
- **docs/project-ios** — setup checklist for the four secrets, plus README timeline entry.

The existing `ios.yml` simulator build stays as the fast PR check.

## To activate (you, later)

Add `APPSTORE_API_KEY_ID`, `APPSTORE_API_ISSUER_ID`, `APPSTORE_API_KEY_P8`, `APPLE_TEAM_ID` — see `docs/project-ios/2026-06-21-spec-ios-distribution-setup.md`. Then the next `v*` tag (or a manual run) uploads to TestFlight.

## Validation

YAML + plist parse-checked. No JS/CSS touched, so app gates are unaffected; CI's iOS build exercises the project generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GeGQZEA1iJ8yHWuPuZzayv)_