### PR TITLE
CI: surface Swift warnings hidden by xcpretty

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -51,6 +51,12 @@ jobs:
 
       - name: Build for iOS Simulator
         run: |
+          # Tee the full xcodebuild output to a log before xcpretty prettifies
+          # it. xcpretty collapses Swift compiler warnings, which previously hid
+          # issues (e.g. an unused-binding warning) until they showed up in a
+          # local Xcode build. pipefail keeps a real build failure failing the
+          # step; the raw log is mined for warnings in the next step.
+          set -o pipefail
           xcodebuild \
             -project ios/SpecDown.xcodeproj \
             -scheme SpecDown \
@@ -58,7 +64,24 @@ jobs:
             -configuration Debug \
             ONLY_ACTIVE_ARCH=NO \
             CODE_SIGNING_ALLOWED=NO \
-            build | xcpretty
+            build 2>&1 | tee "$RUNNER_TEMP/xcodebuild.log" | xcpretty
+
+      - name: Surface Swift warnings
+        if: always()
+        run: |
+          log="$RUNNER_TEMP/xcodebuild.log"
+          if [ ! -f "$log" ]; then
+            echo "No xcodebuild log found; skipping warning scan."
+            exit 0
+          fi
+          # Match the compiler's "file:line:col: warning: message" format.
+          if grep -nE '^[^[:space:]].*: warning: ' "$log" > "$RUNNER_TEMP/warnings.txt"; then
+            count=$(wc -l < "$RUNNER_TEMP/warnings.txt" | tr -d ' ')
+            echo "::warning::$count Swift/compiler warning(s) in the iOS build (xcpretty hides these):"
+            sort -u "$RUNNER_TEMP/warnings.txt"
+          else
+            echo "No Swift/compiler warnings."
+          fi
 
       - name: Build (raw output on failure)
         if: failure()


### PR DESCRIPTION
## What & why

The iOS simulator build pipes `xcodebuild` through `xcpretty`, which collapses Swift compiler warnings. That's a documented blind spot in this repo — warnings (e.g. an unused-binding) only surfaced later in a local Xcode build, never in CI.

## Change

In `.github/workflows/ios.yml`:
- `tee` the full `xcodebuild` output to a log **before** `xcpretty` prettifies it, behind `set -o pipefail` so a real build failure still fails the step.
- A new **Surface Swift warnings** step (`if: always()`) scans the raw log for `file:line:col: warning:` lines and emits a GitHub `::warning::` annotation with a de-duplicated list.

Non-fatal by design: warnings are reported, not promoted to errors (no `-warnings-as-errors`), so existing green builds stay green but warnings are now visible.

## Validation

YAML parse-checked. Behavior is CI-only; exercised on this PR's iOS build run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GeGQZEA1iJ8yHWuPuZzayv)_