### PR TITLE
Add desktop auto-update via electron-updater

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -55,7 +55,11 @@ jobs:
       # password and APPLE_TEAM_ID from the env below.
       - name: Build DMG (signed + notarized)
         if: env.HAS_SIGNING == 'true'
-        run: npm run desktop:build -- --mac dmg --universal -c.mac.notarize=true
+        # `zip` is built alongside `dmg` because electron-updater downloads the
+        # zip (not the dmg) for macOS auto-updates. `--publish never` keeps
+        # electron-builder from uploading: it still generates the latest-mac.yml
+        # update feed locally, and the softprops step below uploads everything.
+        run: npm run desktop:build -- --mac dmg zip --universal -c.mac.notarize=true --publish never
         env:
           CSC_LINK: ${{ secrets.MAC_CERT_P12 }}
           CSC_KEY_PASSWORD: ${{ secrets.MAC_CERT_PASSWORD }}
@@ -69,15 +73,22 @@ jobs:
       # the real distribution build.
       - name: Build DMG (unsigned fallback)
         if: env.HAS_SIGNING != 'true'
-        run: npm run desktop:build -- --mac dmg --universal
+        run: npm run desktop:build -- --mac dmg zip --universal --publish never
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Upload DMG to GitHub Release
+      # Upload the installer (dmg), the auto-update artifact (zip), their
+      # blockmaps, and the latest-mac.yml update feed so electron-updater can
+      # discover and download new versions.
+      - name: Upload macOS artifacts to GitHub Release
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.get_tag.outputs.tag }}
-          files: dist/*.dmg
+          files: |
+            dist/*.dmg
+            dist/*.zip
+            dist/*.blockmap
+            dist/latest-mac.yml
 
   # -------------------------------------------------------
   # Windows: NSIS installer (.exe)
@@ -114,15 +125,20 @@ jobs:
         run: npm install
 
       - name: Build Windows installer
-        run: npm run desktop:build -- --win nsis
+        run: npm run desktop:build -- --win nsis --publish never
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Upload installer to GitHub Release
+      # Upload the NSIS installer, its blockmap, and the latest.yml update feed
+      # for electron-updater on Windows.
+      - name: Upload Windows artifacts to GitHub Release
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.get_tag.outputs.tag }}
-          files: dist/*.exe
+          files: |
+            dist/*.exe
+            dist/*.blockmap
+            dist/latest.yml
 
   # -------------------------------------------------------
   # Linux: AppImage
@@ -161,12 +177,16 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libnss3-dev libatk-bridge2.0-dev libdrm-dev libxkbcommon-dev libgbm-dev
 
       - name: Build AppImage
-        run: npm run desktop:build -- --linux AppImage
+        run: npm run desktop:build -- --linux AppImage --publish never
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Upload AppImage to GitHub Release
+      # Upload the AppImage and the latest-linux.yml update feed for
+      # electron-updater on Linux.
+      - name: Upload Linux artifacts to GitHub Release
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.get_tag.outputs.tag }}
-          files: dist/*.AppImage
+          files: |
+            dist/*.AppImage
+            dist/latest-linux.yml

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -59,6 +59,59 @@ function logInfo(msg) {
 }
 
 // ===========================
+// Auto-update (electron-updater)
+// ===========================
+// Checks GitHub Releases for a newer version; if found, downloads it in the
+// background and installs on the next quit, with a native OS notification when
+// the download is ready (checkForUpdatesAndNotify). Only meaningful in a
+// packaged, code-signed build: skipped in dev (electron-updater has no update
+// feed) and when SPECDOWN_DISABLE_UPDATER=1. electron-updater is lazy-required
+// so it never loads during unit tests (which mock electron but not the updater)
+// or when updates are disabled.
+function initAutoUpdater() {
+  if (!app.isPackaged) {
+    logInfo('Auto-update skipped (not a packaged build).');
+    return;
+  }
+  if (process.env.SPECDOWN_DISABLE_UPDATER === '1') {
+    logInfo('Auto-update disabled via SPECDOWN_DISABLE_UPDATER.');
+    return;
+  }
+
+  let autoUpdater;
+  try {
+    ({ autoUpdater } = require('electron-updater'));
+  } catch (err) {
+    logError('electron-updater unavailable; skipping auto-update', err);
+    return;
+  }
+
+  // Route updater logs into our user-accessible log file so update failures in
+  // shipped builds are recoverable.
+  autoUpdater.logger = {
+    info: (m) => logInfo(`updater: ${m}`),
+    warn: (m) => logInfo(`updater WARN: ${m}`),
+    error: (m) => logError('updater', m),
+    debug: () => {},
+  };
+  autoUpdater.autoDownload = true;
+  autoUpdater.autoInstallOnAppQuit = true;
+
+  autoUpdater.on('error', (err) => logError('Auto-update error', err));
+  autoUpdater.on('update-available', (info) =>
+    logInfo(`Update available: ${info && info.version}`)
+  );
+  autoUpdater.on('update-not-available', () => logInfo('No update available.'));
+  autoUpdater.on('update-downloaded', (info) =>
+    logInfo(`Update downloaded: ${info && info.version} (installs on quit)`)
+  );
+
+  autoUpdater
+    .checkForUpdatesAndNotify()
+    .catch((err) => logError('checkForUpdatesAndNotify failed', err));
+}
+
+// ===========================
 // Store (simple JSON persistence)
 // ===========================
 // Replaces electron-store v11, which is ESM-only and has a history of
@@ -825,6 +878,7 @@ process.on('unhandledRejection', (reason) => {
     initStore();
     buildMenu();
     createWindow();
+    initAutoUpdater();
 
     // Global shortcut: Cmd+Shift+M brings SpecDown to front and prompts open
     globalShortcut.register('CommandOrControl+Shift+M', () => {

--- a/docs/project-desktop/2026-06-21-tasks-session-06-auto-update.md
+++ b/docs/project-desktop/2026-06-21-tasks-session-06-auto-update.md
@@ -1,0 +1,61 @@
+# Session 06 — Desktop auto-update (electron-updater)
+
+**Date:** 2026-06-21
+**Type:** tasks
+**Surface:** desktop (Electron) — macOS / Windows / Linux.
+
+## Goal
+
+Turn the already-published signed DMG / NSIS / AppImage into self-updating apps
+by wiring `electron-updater` to the GitHub Releases the pipeline already
+produces. No new distribution infra — just the update feed + app-side check.
+
+## Changes
+
+- **`desktop/main.js`** — `initAutoUpdater()`: lazy-requires `electron-updater`
+  (so unit tests, which mock electron but not the updater, never load it), routes
+  updater logs into the existing user-accessible log file, and calls
+  `checkForUpdatesAndNotify()` after the window is created. Guarded by
+  `app.isPackaged` (no update feed in dev) and an `SPECDOWN_DISABLE_UPDATER=1`
+  escape hatch. Downloads in the background; installs on next quit with a native
+  OS notification when ready.
+- **`package.json`** —
+  - added `electron-updater` (`^6.8.9`, pairs with electron-builder 26),
+  - added a `publish` provider (`github` cbremer/specdown) so electron-builder
+    generates the `latest*.yml` update feeds,
+  - macOS target is now `["dmg", "zip"]` — electron-updater downloads the **zip**
+    (not the dmg) for macOS updates.
+- **`.github/workflows/desktop.yml`** — builds the mac `zip` alongside the dmg,
+  passes `--publish never` (electron-builder generates the feed but doesn't
+  upload; softprops stays the sole uploader), and the upload steps now include
+  `latest*.yml`, `*.zip`, and `*.blockmap` so the update feed lands in the
+  release.
+
+## Why this shape
+
+The release is created up front by `version-bump.yml`, and `desktop.yml`
+attaches artifacts to it via `softprops/action-gh-release`. Keeping softprops as
+the only uploader (rather than switching to electron-builder's publisher) means
+the existing, working release flow is unchanged in its core behavior — the only
+addition is more files in the release. Worst case (if a feed file isn't
+produced) auto-update is simply inert; nothing breaks.
+
+## Gates
+
+- `npm ci` / `npm audit` — 0 vulnerabilities
+- `npm run lint` — 0 errors
+- `npm run typecheck` — clean
+- `npm test` — 448/448 pass (updater code is lazy + packaged-only, so tests
+  don't load it)
+- `npm run build` — succeeds
+
+## Follow-ups / verification
+
+- **Can't be verified from CI/agent:** the full download→install cycle needs a
+  signed packaged build on a real OS across two versions. First real release
+  should confirm `latest-mac.yml` (+ zip) lands in the GitHub Release and that an
+  older install picks up the update.
+- macOS auto-update requires the **signed** build path (the `HAS_SIGNING` lane);
+  an unsigned fallback build won't self-update (Gatekeeper).
+- Optional next step: surface update status in-app (toast via the
+  `window.specdown` bridge) instead of relying on the native notification.

--- a/docs/project-desktop/README.md
+++ b/docs/project-desktop/README.md
@@ -41,6 +41,7 @@ Three frameworks were evaluated (Tauri, Electron, Swift + WKWebView). Electron w
 | Feb 23, 2026 | Tasks | [2026-02-23-tasks-session-03-file-watching.md](2026-02-23-tasks-session-03-file-watching.md) | Session 3 implementation checklist — File watching (chokidar, per-tab toggle) |
 | Mar 02, 2026 | Tasks | [2026-03-02-tasks-session-04-product-ideas.md](2026-03-02-tasks-session-04-product-ideas.md) | Session 4 — All 15 product ideas implemented (search, TOC, split view, diagram export, shareable links, minimap, annotations, GitHub browser, custom CSS, session restore, recent files, global shortcut, Windows/Linux CI) |
 | Mar 03, 2026 | Tasks | [2026-03-03-tasks-session-05-verification-checklist.md](2026-03-03-tasks-session-05-verification-checklist.md) | Session 5 verification checklist — what shipped in last 48 hours, what remains, and QA sign-off list |
+| Jun 21, 2026 | Tasks | [2026-06-21-tasks-session-06-auto-update.md](2026-06-21-tasks-session-06-auto-update.md) | Session 6 — Desktop auto-update via electron-updater (GitHub Releases feed, mac zip target, background download + install on quit) |
 
 ---
 
@@ -72,6 +73,7 @@ Three frameworks were evaluated (Tauri, Electron, Swift + WKWebView). Electron w
 | Diagram minimap (fullscreen) | ✅ Implemented |
 | GitHub repo file browser | ✅ Implemented |
 | Annotation mode | ✅ Implemented |
+| Auto-update (electron-updater via GitHub Releases) | ✅ Implemented |
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "specdown",
-  "version": "0.0.142",
+  "version": "0.0.143",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "specdown",
-      "version": "0.0.142",
+      "version": "0.0.143",
       "license": "MIT",
       "dependencies": {
         "@panzoom/panzoom": "4.6.2",
         "chokidar": "^5.0.0",
         "dompurify": "3.4.11",
+        "electron-updater": "^6.8.9",
         "highlight.js": "11.11.1",
         "marked": "18.0.5",
         "mermaid": "11.15.0"
@@ -4144,7 +4145,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/aria-query": {
@@ -4499,7 +4499,6 @@
       "version": "9.7.0",
       "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
       "integrity": "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
@@ -5466,7 +5465,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -5894,6 +5892,34 @@
       "integrity": "sha512-M3yhbAlilnwqC8D21t28UCDGHyitShTmmLRU/H+b74P6Ski16Nb9HONYEaVpMj/pwC7BEo5B95FpjODLCWbtfA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/electron-updater": {
+      "version": "6.8.9",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.9.tgz",
+      "integrity": "sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==",
+      "license": "MIT",
+      "dependencies": {
+        "builder-util-runtime": "9.7.0",
+        "fs-extra": "^10.1.0",
+        "js-yaml": "^4.1.0",
+        "lazy-val": "^1.0.5",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isequal": "^4.5.0",
+        "semver": "~7.7.3",
+        "tiny-typed-emitter": "^2.1.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/electron-winstaller": {
       "version": "5.4.0",
@@ -6715,7 +6741,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -7009,7 +7034,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/hachure-fill": {
@@ -8764,7 +8788,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
       "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -8889,7 +8912,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
       "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -8948,7 +8970,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
       "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/leven": {
@@ -9006,6 +9027,19 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
       "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
       "license": "MIT"
     },
     "node_modules/lowercase-keys": {
@@ -9298,7 +9332,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -10516,7 +10549,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
       "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -11120,6 +11152,12 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
@@ -11317,7 +11355,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"

--- a/package.json
+++ b/package.json
@@ -84,8 +84,18 @@
       "node_modules/chokidar/**",
       "**/*.node"
     ],
+    "publish": [
+      {
+        "provider": "github",
+        "owner": "cbremer",
+        "repo": "specdown"
+      }
+    ],
     "mac": {
-      "target": "dmg",
+      "target": [
+        "dmg",
+        "zip"
+      ],
       "category": "public.app-category.developer-tools",
       "icon": "build/icon.png",
       "hardenedRuntime": true,
@@ -119,6 +129,7 @@
     "@panzoom/panzoom": "4.6.2",
     "chokidar": "^5.0.0",
     "dompurify": "3.4.11",
+    "electron-updater": "^6.8.9",
     "highlight.js": "11.11.1",
     "marked": "18.0.5",
     "mermaid": "11.15.0"


### PR DESCRIPTION
## What & why

Turns the signed DMG / NSIS / AppImage into **self-updating** apps by wiring `electron-updater` to the GitHub Releases the pipeline already publishes. No new distribution infra — just the update feed + an app-side check.

## Changes

- **`desktop/main.js`** — `initAutoUpdater()`:
  - **lazy-requires** `electron-updater` so unit tests (which mock electron but not the updater) never load it,
  - routes updater logs into the existing user-accessible log file,
  - runs `checkForUpdatesAndNotify()` after the window is created,
  - guarded by `app.isPackaged` (no feed in dev) + an `SPECDOWN_DISABLE_UPDATER=1` escape hatch,
  - downloads in the background, installs on next quit, native OS notification when ready.
- **`package.json`** — adds `electron-updater@^6.8.9`, a `github` `publish` provider (so electron-builder generates the `latest*.yml` feeds), and a macOS **`["dmg","zip"]`** target (electron-updater downloads the *zip* on mac, not the dmg).
- **`.github/workflows/desktop.yml`** — builds the mac `zip` alongside the dmg, passes `--publish never` (feed generated, not uploaded by electron-builder), and the upload steps now include `latest*.yml` / `*.zip` / `*.blockmap`. **softprops stays the sole uploader**, so the existing release flow is otherwise unchanged — worst case auto-update is simply inert, nothing breaks.

## Validation

- `npm ci` / `npm audit` → 0 vulnerabilities
- lint (0 errors), typecheck, **448/448 tests**, build — all green
- YAML parse-checked

## Can't be verified from CI (needs a human)

The full download→install cycle requires a **signed** packaged build on a real OS across two versions. The first real release should confirm `latest-mac.yml` (+ zip) lands in the Release and that an older install picks up the update. macOS auto-update only works on the signed (`HAS_SIGNING`) path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GeGQZEA1iJ8yHWuPuZzayv)_