### PR TITLE
Add "Open in SpecDown" / file associations (web + desktop + iOS)

### DIFF
--- a/docs/project-modernization/2026-06-21-tasks-open-with-file-associations.md
+++ b/docs/project-modernization/2026-06-21-tasks-open-with-file-associations.md
@@ -1,0 +1,57 @@
+# Tasks — "Open in SpecDown" / file associations (web + desktop + iOS)
+
+**Date:** 2026-06-21
+**Type:** tasks
+**Roadmap item:** §4 of the [retrospective](2026-06-19-retrospective-handoff.md) —
+"Open in SpecDown" from the OS share sheet / Open-With.
+
+Lets a `.md`/`.markdown` file in another app be opened straight into SpecDown,
+on all three surfaces. Each surface routes the opened file into the existing
+single load path.
+
+## Web (installed PWA)
+
+- **`markdown-viewer/public/manifest.webmanifest`** — added `file_handlers`
+  declaring `text/markdown` → `.md`/`.markdown`, `action: "./"`. This is what
+  makes an installed PWA an "Open with" target on Chromium desktop.
+- **`markdown-viewer/src/features/pwa.js`** — `registerFileHandlerLaunchConsumer(onFile)`
+  uses the File Handling API (`window.launchQueue.setConsumer`) to receive the
+  launched file handle(s), resolve each to a `File`, and hand it to `onFile`.
+  Web-only + capability-gated (same guards as the service worker).
+- **`markdown-viewer/src/main.js`** — wires the consumer to the existing
+  `handleFile`, so a launched file opens in a tab like any drag/drop/browse.
+
+## Desktop (Electron / macOS)
+
+- **`package.json`** — added electron-builder `fileAssociations` for `md` +
+  `markdown` (role Viewer, `text/markdown`). On macOS this generates the
+  `CFBundleDocumentTypes` so double-click / "Open With → SpecDown" works; the
+  existing `app.on('open-file')` handler in `desktop/main.js` already delivers
+  the file to the renderer.
+
+## iOS / iPadOS
+
+- **`ios/project.yml`** — declared `CFBundleDocumentTypes` (Viewer, rank
+  Alternate) + an imported `net.daringfireball.markdown` UTI (extensions
+  md/markdown, mime text/markdown) + `LSSupportsOpeningDocumentsInPlace`, so
+  SpecDown appears in the share sheet / "Open With…" and can open files in place
+  from the Files app.
+- **`ios/SpecDown/WebBridge.swift`** — extracted the document picker's read
+  logic into a reusable `openDocument(at:)` (security-scoped read → `loadFile`).
+- **`ios/SpecDown/ContentView.swift`** — `.onOpenURL { bridge.openDocument(at:) }`
+  handles externally-opened URLs.
+
+## Tests / gates
+
+- Added 4 unit tests (launchQueue consumer no-op / forwarding / empty-launch;
+  manifest `file_handlers` shape). `npm test` → **452 pass**.
+- `lint` 0 errors, `typecheck` clean, `build` succeeds.
+
+## Verification gaps (need a human/device)
+
+- **PWA**: requires installing the PWA and an OS "Open with" — `launchQueue` is
+  Chromium-desktop only (no Safari/Firefox). Logic is unit-tested.
+- **Desktop**: file association registration is verifiable only from a packaged
+  install (double-click / Open With).
+- **iOS**: the share-sheet / open-in-place flow needs a device build; CI's
+  simulator build confirms the Swift compiles but not the runtime open.

--- a/ios/SpecDown/ContentView.swift
+++ b/ios/SpecDown/ContentView.swift
@@ -34,6 +34,11 @@ struct ContentView: View {
             .onChange(of: horizontalSizeClass) { _ in
                 bridge.applyLayoutMode(usesPadShell ? "pad" : "phone")
             }
+            // Markdown files opened from outside the app — Files "Open in place",
+            // the share sheet, or "Open With… Specdown" — arrive here.
+            .onOpenURL { url in
+                bridge.openDocument(at: url)
+            }
     }
 
     private var viewerSurface: some View {

--- a/ios/SpecDown/WebBridge.swift
+++ b/ios/SpecDown/WebBridge.swift
@@ -145,6 +145,30 @@ final class WebBridge: NSObject, ObservableObject, WKScriptMessageHandler {
         presentDocumentPicker()
     }
 
+    /// Read a markdown file URL (security-scoped) and hand its content to the
+    /// web layer. Shared by the document picker and by external opens — Files
+    /// "Open in place", the share sheet, and "Open With… Specdown" — routed here
+    /// via SwiftUI's `.onOpenURL`.
+    func openDocument(at url: URL) {
+        let granted = url.startAccessingSecurityScopedResource()
+        defer {
+            if granted {
+                url.stopAccessingSecurityScopedResource()
+            }
+        }
+
+        do {
+            let data = try Data(contentsOf: url)
+            guard let content = String(data: data, encoding: .utf8) else {
+                print("[Bridge] Unsupported file encoding for \(url.lastPathComponent)")
+                return
+            }
+            loadFile(name: url.lastPathComponent, content: content)
+        } catch {
+            print("[Bridge] Failed to read file: \(error)")
+        }
+    }
+
     func openBundledSampleFromSidebar(named fileName: String) {
         loadBundledSample(named: fileName)
     }
@@ -294,22 +318,6 @@ final class WebBridge: NSObject, ObservableObject, WKScriptMessageHandler {
 extension WebBridge: UIDocumentPickerDelegate {
     func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
         guard let url = urls.first else { return }
-        let granted = url.startAccessingSecurityScopedResource()
-        defer {
-            if granted {
-                url.stopAccessingSecurityScopedResource()
-            }
-        }
-
-        do {
-            let data = try Data(contentsOf: url)
-            guard let content = String(data: data, encoding: .utf8) else {
-                print("[Bridge] Unsupported file encoding for \(url.lastPathComponent)")
-                return
-            }
-            loadFile(name: url.lastPathComponent, content: content)
-        } catch {
-            print("[Bridge] Failed to read file: \(error)")
-        }
+        openDocument(at: url)
     }
 }

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -63,3 +63,25 @@ targets:
         NSAppTransportSecurity:
           NSAllowsArbitraryLoads: false
           NSAllowsArbitraryLoadsInWebContent: true
+        # Register SpecDown as a viewer for Markdown files so it appears in the
+        # share sheet and "Open With…", and can open files in place from the
+        # Files app. Incoming URLs are handled in ContentView via .onOpenURL.
+        LSSupportsOpeningDocumentsInPlace: true
+        CFBundleDocumentTypes:
+          - CFBundleTypeName: Markdown Document
+            CFBundleTypeRole: Viewer
+            LSHandlerRank: Alternate
+            LSItemContentTypes:
+              - net.daringfireball.markdown
+              - public.plain-text
+        UTImportedTypeDeclarations:
+          - UTTypeIdentifier: net.daringfireball.markdown
+            UTTypeDescription: Markdown Document
+            UTTypeConformsTo:
+              - public.plain-text
+            UTTypeTagSpecification:
+              public.filename-extension:
+                - md
+                - markdown
+              public.mime-type:
+                - text/markdown

--- a/markdown-viewer/public/manifest.webmanifest
+++ b/markdown-viewer/public/manifest.webmanifest
@@ -20,5 +20,13 @@
       "type": "image/png",
       "purpose": "any"
     }
+  ],
+  "file_handlers": [
+    {
+      "action": "./",
+      "accept": {
+        "text/markdown": [".md", ".markdown"]
+      }
+    }
   ]
 }

--- a/markdown-viewer/src/features/pwa.js
+++ b/markdown-viewer/src/features/pwa.js
@@ -19,6 +19,34 @@ export function shouldRegisterServiceWorker() {
   return protocol === 'http:' || protocol === 'https:';
 }
 
+/**
+ * Wire the File Handling API so an installed PWA can be the "Open with" target
+ * for .md/.markdown files (Chromium desktop). The manifest's `file_handlers`
+ * advertises the association; this consumer receives the launched files and
+ * hands each one to `onFile`. Web-only and capability-gated, like the SW.
+ * @param {(file: File) => void} onFile
+ */
+export function registerFileHandlerLaunchConsumer(onFile) {
+  if (isDesktop || isIOSNative) return;
+  if (typeof window === 'undefined' || !('launchQueue' in window)) return;
+
+  try {
+    /** @type {any} */ (window).launchQueue.setConsumer(async (/** @type {any} */ launchParams) => {
+      if (!launchParams || !launchParams.files || launchParams.files.length === 0) return;
+      for (const handle of launchParams.files) {
+        try {
+          const file = await handle.getFile();
+          onFile(file);
+        } catch (err) {
+          console.warn('Failed to open launched file:', err);
+        }
+      }
+    });
+  } catch (err) {
+    console.warn('launchQueue consumer registration failed:', err);
+  }
+}
+
 /** Register the service worker (once the page has loaded), web surface only. */
 export function registerServiceWorker() {
   if (!shouldRegisterServiceWorker()) return;

--- a/markdown-viewer/src/main.js
+++ b/markdown-viewer/src/main.js
@@ -107,7 +107,7 @@ import {
   closeOverflowMenu,
   isOverflowMenuOpen,
 } from './features/toolbar-overflow.js';
-import { registerServiceWorker } from './features/pwa.js';
+import { registerServiceWorker, registerFileHandlerLaunchConsumer } from './features/pwa.js';
 import {
   startPresentation,
   exitPresentation,
@@ -254,6 +254,8 @@ function init() {
     checkForUpdates();
     checkForDiagramLink();
     registerServiceWorker();
+    // Open .md/.markdown files launched via the OS "Open with" on an installed PWA.
+    registerFileHandlerLaunchConsumer((/** @type {File} */ file) => handleFile(file));
     // Session restore (web only): reopen the last document on launch, unless a
     // shared diagram link already opened something. The native shells manage
     // their own session, so they're excluded.

--- a/package.json
+++ b/package.json
@@ -91,6 +91,18 @@
         "repo": "specdown"
       }
     ],
+    "fileAssociations": [
+      {
+        "ext": [
+          "md",
+          "markdown"
+        ],
+        "name": "Markdown Document",
+        "description": "Markdown Document",
+        "role": "Viewer",
+        "mimeType": "text/markdown"
+      }
+    ],
     "mac": {
       "target": [
         "dmg",

--- a/tests/unit/pwa.test.js
+++ b/tests/unit/pwa.test.js
@@ -51,6 +51,54 @@ describe('PWA service worker', () => {
   });
 });
 
+describe('PWA file handler (launchQueue)', () => {
+  beforeEach(() => {
+    loadHTML(document);
+    loadApp(document);
+  });
+
+  afterEach(() => {
+    try {
+      delete window.launchQueue;
+    } catch (e) {
+      // ignore
+    }
+  });
+
+  it('is a harmless no-op when launchQueue is unavailable', () => {
+    expect('launchQueue' in window).toBe(false);
+    expect(() => registerFileHandlerLaunchConsumer(jest.fn())).not.toThrow();
+  });
+
+  it('registers a consumer and forwards launched files to the callback', async () => {
+    let consumer;
+    window.launchQueue = { setConsumer: (fn) => { consumer = fn; } };
+
+    const onFile = jest.fn();
+    registerFileHandlerLaunchConsumer(onFile);
+    expect(typeof consumer).toBe('function');
+
+    const file = { name: 'doc.md' };
+    const handle = { getFile: jest.fn(() => Promise.resolve(file)) };
+    await consumer({ files: [handle] });
+
+    expect(handle.getFile).toHaveBeenCalled();
+    expect(onFile).toHaveBeenCalledWith(file);
+  });
+
+  it('ignores an empty launch with no files', async () => {
+    let consumer;
+    window.launchQueue = { setConsumer: (fn) => { consumer = fn; } };
+    const onFile = jest.fn();
+    registerFileHandlerLaunchConsumer(onFile);
+
+    await consumer({ files: [] });
+    await consumer({});
+
+    expect(onFile).not.toHaveBeenCalled();
+  });
+});
+
 describe('PWA static assets', () => {
   const root = path.join(__dirname, '../../markdown-viewer');
 
@@ -69,6 +117,17 @@ describe('PWA static assets', () => {
     expect(manifest.display).toBe('standalone');
     expect(Array.isArray(manifest.icons)).toBe(true);
     expect(manifest.icons.length).toBeGreaterThan(0);
+  });
+
+  it('declares a file handler for .md/.markdown', () => {
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(root, 'public/manifest.webmanifest'), 'utf8')
+    );
+    expect(Array.isArray(manifest.file_handlers)).toBe(true);
+    const handler = manifest.file_handlers[0];
+    expect(handler.action).toBe('./');
+    const exts = handler.accept['text/markdown'];
+    expect(exts).toEqual(expect.arrayContaining(['.md', '.markdown']));
   });
 
   it('ships the service worker and icon assets', () => {


### PR DESCRIPTION
## What & why

Lets a `.md`/`.markdown` file from another app open straight into SpecDown — share sheet / "Open With…" / double-click — on **all three surfaces**, each routing into the existing single load path.

## Changes

**Web (installed PWA)**
- `manifest.webmanifest` — `file_handlers` declaring `text/markdown` → `.md`/`.markdown` (makes an installed PWA an "Open with" target on Chromium desktop).
- `pwa.js` — `registerFileHandlerLaunchConsumer()` uses the File Handling API (`launchQueue`) to receive launched file handles and forward each `File` to a callback. Web-only + capability-gated like the service worker.
- `main.js` — wires it to the existing `handleFile`.

**Desktop (Electron / macOS)**
- `package.json` — electron-builder `fileAssociations` (`md`/`markdown`, role Viewer). macOS generates `CFBundleDocumentTypes`; the existing `app.on('open-file')` handler already delivers the file.

**iOS / iPadOS**
- `project.yml` — `CFBundleDocumentTypes` + imported `net.daringfireball.markdown` UTI + `LSSupportsOpeningDocumentsInPlace`.
- `WebBridge.swift` — extracted the picker's read logic into reusable `openDocument(at:)`.
- `ContentView.swift` — `.onOpenURL { bridge.openDocument(at:) }`.

## Tests / gates

- +4 unit tests (launchQueue consumer no-op / forwarding / empty-launch; manifest `file_handlers` shape) → **452 pass**.
- lint 0 errors, typecheck clean, build succeeds.

## Verification gaps (need a human/device)

- **PWA**: needs an installed PWA + OS "Open with"; `launchQueue` is Chromium-desktop only. Logic is unit-tested.
- **Desktop**: association registration is verifiable only from a packaged install.
- **iOS**: share-sheet / open-in-place needs a device build; CI's simulator build confirms the Swift compiles, not the runtime open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GeGQZEA1iJ8yHWuPuZzayv)_