### PR TITLE
Open a folder dragged onto the web app as a workspace

### DIFF
--- a/docs/project-modernization/2026-06-21-tasks-workspace-drag-folder.md
+++ b/docs/project-modernization/2026-06-21-tasks-workspace-drag-folder.md
@@ -1,0 +1,47 @@
+# Tasks — Drag a folder onto the web app to open a workspace
+
+**Date:** 2026-06-21
+**Type:** tasks
+**Roadmap item:** §4 of the [retrospective](2026-06-19-retrospective-handoff.md) —
+"Workspace polish … drag-a-folder-to-open on the web."
+
+## What
+
+On the web, dropping a **folder** onto the app now opens it as a workspace
+(folder sidebar + relative-link navigation), matching the existing "Open Folder"
+button. Dropping **files** still opens them as tabs, exactly as before.
+
+## Implementation
+
+- **`markdown-viewer/src/features/workspace.js`**
+  - `tryOpenDroppedFolder(dataTransfer)` — uses the File System Access
+    drag-and-drop entry point (`DataTransferItem.getAsFileSystemHandle`,
+    Chromium). The handle promises are captured **synchronously** in the sync
+    portion of the async function (drop items are invalidated after the event
+    tick), then a directory handle is resolved, scanned with the existing
+    `scanDirectoryHandle` (same ignore-list/limits as the picker), and adopted
+    via `applyWorkspace`. Resolves `true` when a folder was handled.
+  - `isFolderDragDropSupported()` — exported capability check so callers keep a
+    synchronous file-drop path on browsers without the API.
+- **`markdown-viewer/src/main.js`** — both the drop-zone and document-level drop
+  handlers now: if folder drag-drop is supported, try the folder path first and
+  fall back to file opens if it wasn't a folder; otherwise open files
+  synchronously (unchanged behavior on non-Chromium browsers — preserves the
+  existing synchronous drop contract the tests rely on).
+
+## Tests / gates
+
+- +3 unit tests (open dropped folder; a dropped file is not treated as a folder;
+  empty/no-items drop returns false). `npm test` → **451 pass**.
+- lint 0 errors, typecheck clean, build succeeds.
+
+## Scope notes / not done
+
+The retro's workspace bullet also lists **persist/reopen the last workspace** and
+**search across a folder**. Those are deferred:
+- *Persist/reopen* on the web means storing a `FileSystemDirectoryHandle` in
+  IndexedDB and re-requesting permission on launch (a permission-prompt UX
+  decision); on desktop it means persisting the root path + re-scan via the
+  bridge. Worth a dedicated session.
+- *Folder-wide search* is a new search surface across files — also its own
+  session.

--- a/markdown-viewer/src/features/workspace.js
+++ b/markdown-viewer/src/features/workspace.js
@@ -80,6 +80,16 @@ function isWebFolderSupported() {
     typeof /** @type {any} */ (window).showDirectoryPicker === 'function';
 }
 
+/**
+ * Whether dragging a folder onto the page can open it (Chromium File System
+ * Access). Lets callers keep a synchronous file-drop path on browsers without
+ * the API instead of always deferring through the async folder check.
+ * @returns {boolean}
+ */
+export function isFolderDragDropSupported() {
+  return isWebFolderSupported();
+}
+
 /** Open a folder: native picker on desktop, File System Access on the web. */
 export function openWorkspaceFolder() {
   if (isDesktop) {
@@ -131,6 +141,61 @@ async function pickWebFolder() {
     showToast('No markdown files found in that folder.', { type: 'warning' });
   }
   applyWorkspace({ root: dirHandle.name || '', files });
+}
+
+/**
+ * Open a folder dragged onto the web app as a workspace. Uses the File System
+ * Access drag-and-drop entry point (`DataTransferItem.getAsFileSystemHandle`,
+ * Chromium): the handle promises must be captured *synchronously* within the
+ * drop event (the items are invalidated after the event tick), which is why the
+ * sync portion of this async function pulls them before the first `await`.
+ * Resolves to `true` when a directory was found and adopted (so the caller skips
+ * its normal file-drop handling), `false` otherwise.
+ * @param {DataTransfer | null} dataTransfer
+ * @returns {Promise<boolean>}
+ */
+export async function tryOpenDroppedFolder(dataTransfer) {
+  if (!isWebFolderSupported() || !dataTransfer) return false;
+  const items = dataTransfer.items;
+  if (!items || items.length === 0) return false;
+
+  // Synchronous: grab the handle promises before the event is consumed.
+  const handlePromises = [];
+  for (const item of items) {
+    if (item.kind === 'file' && typeof (/** @type {any} */ (item).getAsFileSystemHandle) === 'function') {
+      handlePromises.push(/** @type {any} */ (item).getAsFileSystemHandle());
+    }
+  }
+  if (handlePromises.length === 0) return false;
+
+  let dirHandle = null;
+  for (const p of handlePromises) {
+    try {
+      const h = await p;
+      if (h && h.kind === 'directory') {
+        dirHandle = h;
+        break;
+      }
+    } catch (e) {
+      // ignore an unreadable item; keep checking the rest
+    }
+  }
+  if (!dirHandle) return false;
+
+  /** @type {WorkspaceFile[]} */
+  const files = [];
+  try {
+    await scanDirectoryHandle(dirHandle, '', files, 0);
+  } catch (e) {
+    showToast('Could not read the folder.', { type: 'error' });
+    return true; // it was a folder — handled, albeit with an error
+  }
+  files.sort((a, b) => a.relPath.localeCompare(b.relPath));
+  if (files.length === 0) {
+    showToast('No markdown files found in that folder.', { type: 'warning' });
+  }
+  applyWorkspace({ root: dirHandle.name || '', files });
+  return true;
 }
 
 /**

--- a/markdown-viewer/src/main.js
+++ b/markdown-viewer/src/main.js
@@ -132,6 +132,8 @@ import {
   openWorkspaceFolder,
   hasWorkspace,
   configureWorkspace,
+  tryOpenDroppedFolder,
+  isFolderDragDropSupported,
 } from './features/workspace.js';
 import {
   setupDesktopIPC,
@@ -755,10 +757,22 @@ function setupEventListeners() {
     // content area (when the drop zone is hidden).
     document.addEventListener('drop', (e) => {
         e.preventDefault();
-        if (state.tabs.length > 0 && e.dataTransfer && e.dataTransfer.files.length > 0) {
-            for (let i = 0; i < e.dataTransfer.files.length; i++) {
-                handleFile(e.dataTransfer.files[i]);
+        if (!e.dataTransfer) return;
+        // Capture files synchronously — the FileList is invalidated after the event.
+        const droppedFiles = Array.from(e.dataTransfer.files || []);
+        const openDroppedFiles = () => {
+            if (state.tabs.length > 0) {
+                for (const file of droppedFiles) handleFile(file);
             }
+        };
+        // Folder drag-and-drop is Chromium-only and async; elsewhere open files
+        // directly (keeps the synchronous drop path on other browsers).
+        if (isFolderDragDropSupported()) {
+            tryOpenDroppedFolder(e.dataTransfer).then((handled) => {
+                if (!handled) openDroppedFiles();
+            });
+        } else {
+            openDroppedFiles();
         }
     });
 
@@ -802,9 +816,19 @@ function handleDrop(e) {
     dropZone.classList.remove('drag-over');
 
     if (!e.dataTransfer) return;
-    const files = e.dataTransfer.files;
-    for (let i = 0; i < files.length; i++) {
-        handleFile(files[i]);
+    // Capture files synchronously — the FileList is invalidated after the event.
+    const droppedFiles = Array.from(e.dataTransfer.files || []);
+    const openDroppedFiles = () => {
+        for (const file of droppedFiles) handleFile(file);
+    };
+    // A dropped folder opens as a workspace (Chromium, async); otherwise — and on
+    // browsers without the API — fall back to opening the dropped files directly.
+    if (isFolderDragDropSupported()) {
+        tryOpenDroppedFolder(e.dataTransfer).then((handled) => {
+            if (!handled) openDroppedFiles();
+        });
+    } else {
+        openDroppedFiles();
     }
 }
 

--- a/tests/unit/workspace.test.js
+++ b/tests/unit/workspace.test.js
@@ -211,6 +211,38 @@ describe('Workspace (folder) mode — web', () => {
     expect(handleA.getFile).toHaveBeenCalled();
   });
 
+  it('opens a folder dragged onto the page as a workspace', async () => {
+    const dropped = dirHandle('dragged', [
+      fileHandle('a.md', '# A'),
+      dirHandle('docs', [fileHandle('b.md', '# B')]),
+      fileHandle('notes.txt', 'ignored'),
+    ]);
+    const dataTransfer = {
+      files: [],
+      items: [{ kind: 'file', getAsFileSystemHandle: jest.fn(async () => dropped) }],
+    };
+
+    const handled = await tryOpenDroppedFolder(dataTransfer);
+    expect(handled).toBe(true);
+    await flush();
+
+    const files = [...document.querySelectorAll('.workspace-file-item')].map((b) => b.textContent).sort();
+    expect(files).toEqual(['a.md', 'b.md']);
+  });
+
+  it('does not treat a dropped file as a folder', async () => {
+    const dataTransfer = {
+      files: [],
+      items: [{ kind: 'file', getAsFileSystemHandle: jest.fn(async () => fileHandle('a.md', '# A')) }],
+    };
+    expect(await tryOpenDroppedFolder(dataTransfer)).toBe(false);
+  });
+
+  it('returns false for a drop with no items', async () => {
+    expect(await tryOpenDroppedFolder({ files: [], items: [] })).toBe(false);
+    expect(await tryOpenDroppedFolder(null)).toBe(false);
+  });
+
   it('follows a relative link within the loaded web workspace', async () => {
     const handleA = fileHandle('a.md', '# A');
     const handleB = fileHandle('b.md', '# B');


### PR DESCRIPTION
## What & why

On the web, dropping a **folder** onto the app now opens it as a workspace (folder sidebar + relative-link navigation), matching the existing "Open Folder" button. Dropping **files** still opens them as tabs, unchanged.

Implements the "drag-a-folder-to-open on the web" part of the retrospective's workspace-polish item.

## Implementation

- **`workspace.js`**
  - `tryOpenDroppedFolder(dataTransfer)` — uses the File System Access drag-and-drop entry point (`DataTransferItem.getAsFileSystemHandle`, Chromium). Handle promises are captured **synchronously** (drop items are invalidated after the event tick), the directory handle is resolved, then scanned with the existing `scanDirectoryHandle` (same ignore-list/limits as the picker) and adopted via `applyWorkspace`.
  - `isFolderDragDropSupported()` — exported capability check so callers keep a synchronous file-drop path where the API is absent.
- **`main.js`** — drop-zone + document-level drop handlers try the folder path first when supported, falling back to file opens; **non-Chromium browsers keep the original synchronous behavior** (preserves the existing drop contract).

## Tests / gates

- +3 unit tests (open dropped folder; a dropped file is *not* a folder; empty drop → false) → **451 pass**.
- lint 0 errors, typecheck clean, build succeeds.

## Not in this PR (deferred from the workspace bullet)

- **Persist/reopen last workspace** — needs IndexedDB-stored `FileSystemDirectoryHandle` + permission re-grant UX (web) and root-path persistence + re-scan (desktop).
- **Folder-wide search** — a new cross-file search surface.

Both are their own sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GeGQZEA1iJ8yHWuPuZzayv)_