### PR TITLE
Group the changelog from descriptive commit subjects

### DIFF
--- a/docs/project-modernization/2026-06-21-tasks-changelog-infer-types.md
+++ b/docs/project-modernization/2026-06-21-tasks-changelog-infer-types.md
@@ -1,0 +1,45 @@
+# Tasks — Group the changelog from descriptive commit subjects
+
+**Date:** 2026-06-21
+**Type:** tasks
+**Roadmap item:** §3.5 of the [retrospective](2026-06-19-retrospective-handoff.md) —
+the changelog generator groups by `feat:`/`fix:`/… but the repo writes
+descriptive subjects, so it always fell back to a flat list.
+
+## What
+
+`scripts/generate-changelog.js` now infers a Conventional-Commit type from a
+descriptive subject's **leading verb**, so the grouped changelog ("Features",
+"Bug Fixes", …) lights up for this repo's actual commit style — no need to adopt
+the `type:` prefix or add a commit-lint hook.
+
+## Implementation
+
+- **`inferType(subject)`** — a conservative, anchored leading-verb → type map:
+  - `Add/Introduce/Implement/Support/Enable/New…` → **feat**
+  - `Fix/Resolve/Correct/Prevent/Stop/Patch…` → **fix**
+  - `Refactor/Simplify/Rename/Extract/Consolidate…` → **refactor**
+  - `Doc(s)/Document…` → **docs**; `Test(s)` → **test**; `Optimize/Perf` → **perf**
+  - `Bump/Upgrade/Pin` → **build**; `CI/Workflow/Pipeline` → **ci**;
+    `Style/Format/Lint/Prettier` → **style**
+  - Ambiguous verbs (`Update`, `Remove`, `Tweak`, …) deliberately return `''` and
+    land under **Other Changes** rather than being mislabeled.
+- **`formatSection`** — each entry's type is its explicit CC type when present,
+  else the inferred type. Grouping/ordering is unchanged; the flat-list fallback
+  now triggers only when *nothing* (explicit or inferred) can be categorized.
+  Explicit CC entries still render their stripped description; inferred entries
+  keep their full subject as the bullet.
+
+## Tests / gates
+
+- Added `inferType` tests + grouped/Other/flat-fallback `formatSection` cases;
+  rewrote the old "flat list for descriptive commits" expectation to assert the
+  new grouping. `npm test` → **452 pass**.
+- lint 0 errors, build green; `generate-changelog.js --latest` CLI smoke-tested.
+
+## Notes
+
+- Existing `CHANGELOG.md` sections are untouched (the release pipeline regenerates
+  going forward); the next release's notes will be grouped.
+- A commit-lint hook (the other option in the retro) was intentionally **not**
+  added — inference gives the grouped output without adding contributor friction.

--- a/scripts/generate-changelog.js
+++ b/scripts/generate-changelog.js
@@ -16,9 +16,13 @@
  *                                                 # body).
  *
  * Commit subjects are grouped by Conventional-Commit type when present
- * (`feat:`, `fix:`, `docs(scope):`, `feat!:` …); when none of the commits use
- * that convention the section is just a flat bullet list of the subjects, which
- * suits this repo's descriptive commit style.
+ * (`feat:`, `fix:`, `docs(scope):`, `feat!:` …). This repo writes *descriptive*
+ * subjects ("Fix diagram controls…", "Add desktop auto-update"), so when a
+ * subject isn't a conventional commit its leading verb is mapped to a type via
+ * `inferType` — so the grouped changelog lights up without anyone having to
+ * adopt the `type:` prefix. Subjects whose verb is ambiguous fall to "Other
+ * Changes"; only when nothing can be categorized at all does the section fall
+ * back to a flat bullet list.
  */
 
 const CC_TYPE_LABELS = {
@@ -55,6 +59,35 @@ function parseCommitSubject(subject) {
     breaking: Boolean(m[3]),
     description: m[4].trim(),
   };
+}
+
+// High-confidence leading-verb → type mappings for descriptive subjects. Kept
+// conservative on purpose: an ambiguous verb (e.g. "Update", "Remove", "Tweak")
+// is left uncategorized so it lands in "Other Changes" rather than being
+// mislabeled. Each pattern is anchored to the start of the subject.
+const INFERENCE_RULES = [
+  [/^(add|adds|added|introduce[sd]?|implement[sed]*|support[sed]*|enable[sd]?|new)\b/i, 'feat'],
+  [/^(fix|fixe[sd]|resolve[sd]?|correct[sed]*|prevent[sed]*|stop[sed]*|repair[sed]*|patch(e[sd])?)\b/i, 'fix'],
+  [/^(refactor(e[sd])?|simplif(y|ies|ied)|rename[sd]?|reorganize[sd]?|extract[sed]*|consolidate[sd]?)\b/i, 'refactor'],
+  [/^(doc|docs|document[sed]*)\b/i, 'docs'],
+  [/^(test|tests|spec)\b/i, 'test'],
+  [/^(optimi[sz]e[sd]?|perf)\b/i, 'perf'],
+  [/^(bump|upgrade[sd]?|pin(ned|s)?)\b/i, 'build'],
+  [/^(ci|workflow|pipeline)\b/i, 'ci'],
+  [/^(style|format[sed]*|lint|prettier)\b/i, 'style'],
+];
+
+/**
+ * Infer a Conventional-Commit type from a descriptive subject's leading verb.
+ * @param {string} subject
+ * @returns {string} a CC type key, or '' when none matches confidently.
+ */
+function inferType(subject) {
+  const s = String(subject || '').trim();
+  for (const [re, type] of INFERENCE_RULES) {
+    if (re.test(s)) return type;
+  }
+  return '';
 }
 
 /**
@@ -97,17 +130,23 @@ function formatSection(commits, version, date) {
     return lines.join('\n');
   }
 
-  const entries = clean.map((subject) => ({ subject, cc: parseCommitSubject(subject) }));
-  const anyConventional = entries.some((e) => e.cc && CC_TYPE_LABELS[e.cc.type]);
+  // Each entry's type is its explicit Conventional-Commit type when present,
+  // otherwise an inferred type from the descriptive subject's leading verb.
+  const entries = clean.map((subject) => {
+    const cc = parseCommitSubject(subject);
+    const type = cc && CC_TYPE_LABELS[cc.type] ? cc.type : inferType(subject);
+    return { subject, cc, type };
+  });
+  const anyCategorized = entries.some((e) => CC_TYPE_LABELS[e.type]);
 
-  // Descriptive (non-conventional) history: a flat list reads best.
-  if (!anyConventional) {
+  // Nothing could be categorized (explicit or inferred): a flat list reads best.
+  if (!anyCategorized) {
     for (const e of entries) lines.push(renderEntry(e));
     lines.push('');
     return lines.join('\n');
   }
 
-  // Conventional history: group by type, breaking changes first.
+  // Group by type, breaking changes (explicit `!`) first.
   const breaking = entries.filter((e) => e.cc && e.cc.breaking);
   if (breaking.length) {
     lines.push('### ⚠ Breaking Changes', '');
@@ -119,8 +158,8 @@ function formatSection(commits, version, date) {
   const groups = {};
   const other = [];
   for (const e of entries) {
-    if (e.cc && CC_TYPE_LABELS[e.cc.type]) {
-      (groups[e.cc.type] = groups[e.cc.type] || []).push(e);
+    if (CC_TYPE_LABELS[e.type]) {
+      (groups[e.type] = groups[e.type] || []).push(e);
     } else {
       other.push(e);
     }
@@ -190,6 +229,7 @@ function extractLatestSection(changelog) {
 
 module.exports = {
   parseCommitSubject,
+  inferType,
   isReleaseNoise,
   formatSection,
   prependSection,

--- a/tests/unit/changelog.test.js
+++ b/tests/unit/changelog.test.js
@@ -6,6 +6,7 @@
 
 const {
   parseCommitSubject,
+  inferType,
   isReleaseNoise,
   formatSection,
   prependSection,
@@ -41,13 +42,47 @@ describe('isReleaseNoise', () => {
   });
 });
 
+describe('inferType', () => {
+  it('maps high-confidence leading verbs to types', () => {
+    expect(inferType('Add desktop auto-update')).toBe('feat');
+    expect(inferType('Fix diagram controls covering the diagram')).toBe('fix');
+    expect(inferType('Refactor the bridge seam')).toBe('refactor');
+    expect(inferType('Document the release pipeline')).toBe('docs');
+    expect(inferType('Bump dompurify from 3.4.10 to 3.4.11')).toBe('build');
+  });
+
+  it('leaves ambiguous verbs uncategorized', () => {
+    expect(inferType('Update the thing')).toBe('');
+    expect(inferType('Remove dead code')).toBe('');
+    expect(inferType('Tweak spacing')).toBe('');
+  });
+});
+
 describe('formatSection', () => {
-  it('renders a flat list for descriptive (non-conventional) commits', () => {
+  it('groups descriptive commits by inferred type (Add→Features, Fix→Bug Fixes)', () => {
     const out = formatSection(['Add workspace mode', 'Fix a crash'], '0.1.0', '2026-06-15');
     expect(out).toContain('## v0.1.0 — 2026-06-15');
+    expect(out).toContain('### Features');
     expect(out).toContain('- Add workspace mode');
+    expect(out).toContain('### Bug Fixes');
     expect(out).toContain('- Fix a crash');
-    expect(out).not.toContain('###'); // no type headers
+    // Inferred entries keep their full subject (no type prefix to strip).
+    expect(out.indexOf('### Features')).toBeLessThan(out.indexOf('### Bug Fixes'));
+  });
+
+  it('puts uncategorizable descriptive commits under Other Changes', () => {
+    const out = formatSection(['Add a feature', 'Tweak some spacing'], '0.1.0', '2026-06-15');
+    expect(out).toContain('### Features');
+    expect(out).toContain('- Add a feature');
+    expect(out).toContain('### Other Changes');
+    expect(out).toContain('- Tweak some spacing');
+  });
+
+  it('falls back to a flat list when nothing can be categorized', () => {
+    const out = formatSection(['Tweak spacing', 'Whatever happened here'], '0.1.0', '2026-06-15');
+    expect(out).toContain('- Tweak spacing');
+    expect(out).toContain('- Whatever happened here');
+    expect(out).not.toContain('###');
   });
 
   it('groups conventional commits by type, with scopes', () => {


### PR DESCRIPTION
## What & why

The changelog generator groups by Conventional-Commit type, but this repo writes **descriptive** subjects ("Fix diagram controls…", "Add desktop auto-update"), so it always fell back to a flat list. This makes the grouped changelog ("Features", "Bug Fixes", …) light up for the repo's actual style — without adopting the `type:` prefix or adding a commit-lint hook.

## Changes (`scripts/generate-changelog.js`)

- **`inferType(subject)`** — conservative, anchored leading-verb → type map: `Add/Implement/Support…`→**feat**, `Fix/Resolve/Prevent…`→**fix**, `Refactor/Simplify/Rename…`→**refactor**, `Doc(s)`→**docs**, `Test(s)`→**test**, `Optimize`→**perf**, `Bump/Upgrade/Pin`→**build**, `CI/Workflow`→**ci**, `Style/Format/Lint`→**style**. Ambiguous verbs (`Update`, `Remove`, `Tweak`) deliberately return `''` → **Other Changes**, never mislabeled.
- **`formatSection`** — entry type is the explicit CC type when present, else inferred. Flat-list fallback now only triggers when *nothing* can be categorized. Explicit CC entries still render stripped; inferred entries keep their full subject.

## Tests / gates

- `inferType` tests + grouped/Other/flat-fallback cases; rewrote the old "flat list" expectation to assert grouping → **452 pass**.
- lint 0 errors, build green, CLI smoke-tested.

## Notes

- Existing `CHANGELOG.md` is untouched (the pipeline regenerates going forward); the next release's notes will be grouped.
- A commit-lint hook (the other retro option) was intentionally **not** added — inference avoids contributor friction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GeGQZEA1iJ8yHWuPuZzayv)_