### PR TITLE
Add visible desktop update UX (Check for Updates + Restart now)

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -9,6 +9,11 @@ const MAX_RECENT_FILES = 15;
 let mainWindow = null;
 let store = null;
 let logFilePath = null;
+// electron-updater instance (set in packaged builds only) + a flag marking a
+// user-initiated "Check for Updates…" so its result is surfaced (a silent
+// background check stays silent).
+let autoUpdaterRef = null;
+let manualUpdateCheck = false;
 
 // Queue files requested before the window is ready (e.g. Finder double-click on launch)
 let pendingFilePaths = [];
@@ -85,6 +90,7 @@ function initAutoUpdater() {
     logError('electron-updater unavailable; skipping auto-update', err);
     return;
   }
+  autoUpdaterRef = autoUpdater;
 
   // Route updater logs into our user-accessible log file so update failures in
   // shipped builds are recoverable.
@@ -97,18 +103,69 @@ function initAutoUpdater() {
   autoUpdater.autoDownload = true;
   autoUpdater.autoInstallOnAppQuit = true;
 
-  autoUpdater.on('error', (err) => logError('Auto-update error', err));
+  autoUpdater.on('error', (err) => {
+    logError('Auto-update error', err);
+    if (manualUpdateCheck) {
+      manualUpdateCheck = false;
+      dialog.showMessageBox({
+        type: 'error',
+        message: 'Could not check for updates',
+        detail: err && err.message ? err.message : String(err),
+      });
+    }
+  });
   autoUpdater.on('update-available', (info) =>
     logInfo(`Update available: ${info && info.version}`)
   );
-  autoUpdater.on('update-not-available', () => logInfo('No update available.'));
-  autoUpdater.on('update-downloaded', (info) =>
-    logInfo(`Update downloaded: ${info && info.version} (installs on quit)`)
-  );
+  autoUpdater.on('update-not-available', () => {
+    logInfo('No update available.');
+    if (manualUpdateCheck) {
+      manualUpdateCheck = false;
+      dialog.showMessageBox({
+        type: 'info',
+        message: "You're up to date",
+        detail: `SpecDown ${app.getVersion()} is the latest version.`,
+      });
+    }
+  });
+  autoUpdater.on('update-downloaded', (info) => {
+    logInfo(`Update downloaded: ${info && info.version} (installs on quit)`);
+    manualUpdateCheck = false;
+    // Surface an in-app "Restart now" toast (the renderer wires the button to
+    // restart-to-update). The native OS notification from checkForUpdatesAndNotify
+    // still fires as a fallback when the window isn't focused.
+    if (mainWindow && mainWindow.webContents) {
+      mainWindow.webContents.send('update-downloaded', { version: info && info.version });
+    }
+  });
 
   autoUpdater
     .checkForUpdatesAndNotify()
     .catch((err) => logError('checkForUpdatesAndNotify failed', err));
+}
+
+// Menu-triggered update check. Result surfaces via the handlers above: a native
+// "you're up to date" / error dialog (guarded by manualUpdateCheck), or the
+// update-downloaded toast. In an unpackaged/dev build there is no updater.
+function checkForUpdatesManually() {
+  if (!autoUpdaterRef) {
+    dialog.showMessageBox({
+      type: 'info',
+      message: 'Updates are unavailable in this build',
+      detail: 'Automatic updates only run in the installed SpecDown app.',
+    });
+    return;
+  }
+  manualUpdateCheck = true;
+  autoUpdaterRef.checkForUpdates().catch((err) => {
+    manualUpdateCheck = false;
+    logError('Manual update check failed', err);
+    dialog.showMessageBox({
+      type: 'error',
+      message: 'Could not check for updates',
+      detail: err && err.message ? err.message : String(err),
+    });
+  });
 }
 
 // ===========================
@@ -647,6 +704,13 @@ ipcMain.on('save-session', (_event, tabs) => {
   saveSession(tabs);
 });
 
+// Renderer's "Restart now" toast asks the shell to install the downloaded update.
+ipcMain.on('restart-to-update', () => {
+  if (autoUpdaterRef) {
+    autoUpdaterRef.quitAndInstall();
+  }
+});
+
 // ===========================
 // Native Menu
 // ===========================
@@ -802,6 +866,11 @@ function buildMenu() {
     {
       label: 'Help',
       submenu: [
+        {
+          label: 'Check for Updates...',
+          click: () => checkForUpdatesManually(),
+        },
+        { type: 'separator' },
         {
           label: 'Open Log File',
           click: () => {

--- a/desktop/preload.js
+++ b/desktop/preload.js
@@ -94,4 +94,16 @@ contextBridge.exposeInMainWorld('specdown', {
       callback(cssContent);
     });
   },
+
+  // Auto-update: notified when a downloaded update is ready to install.
+  onUpdateDownloaded: (callback) => {
+    ipcRenderer.on('update-downloaded', (_event, info) => {
+      callback(info);
+    });
+  },
+
+  // Auto-update: ask the main process to quit and install the downloaded update.
+  restartToUpdate: () => {
+    ipcRenderer.send('restart-to-update');
+  },
 });

--- a/docs/project-desktop/2026-06-22-tasks-session-07-update-ui.md
+++ b/docs/project-desktop/2026-06-22-tasks-session-07-update-ui.md
@@ -1,0 +1,48 @@
+# Session 07 — Visible desktop update UX (check + restart)
+
+**Date:** 2026-06-22
+**Type:** tasks
+**Surface:** desktop (Electron).
+**Builds on:** [session 06 auto-update](2026-06-21-tasks-session-06-auto-update.md).
+
+## Why
+
+Auto-update (session 06) was silent: background download + install-on-quit + a
+native OS notification, with no visible control. This adds the two pieces a user
+expects: a way to **check** on demand, and a one-click **restart** when an update
+is ready.
+
+## Changes
+
+- **`desktop/main.js`**
+  - Holds the `autoUpdater` instance (`autoUpdaterRef`) + a `manualUpdateCheck`
+    flag so a user-initiated check surfaces a result while the silent on-launch
+    check stays quiet.
+  - **Help → "Check for Updates…"** menu item → `checkForUpdatesManually()`.
+    Result is a native dialog: "You're up to date" / "Could not check…", or — if
+    an update is found — it downloads and triggers the restart toast. In a
+    dev/unpackaged build it explains updates are install-only.
+  - On `update-downloaded`, sends `update-downloaded` IPC to the renderer (for
+    the toast). The native `checkForUpdatesAndNotify` OS notification still fires
+    as a fallback.
+  - `ipcMain.on('restart-to-update')` → `autoUpdater.quitAndInstall()`.
+- **`desktop/preload.js`** — exposes `onUpdateDownloaded(cb)` + `restartToUpdate()`.
+- **`globals.d.ts` / `platform/bridge.js`** — the two new bridge members behind
+  the `window.specdown` seam (`bridgeOnUpdateDownloaded`, `bridgeRestartToUpdate`).
+- **`platform/desktop.js`** — on update-downloaded, shows a persistent toast
+  ("An update (vX) is ready to install." + **Restart now**) wired to the bridge.
+- **`features/toast.js` (+ `styles.css`)** — `showToast` gains an optional
+  `action: { label, onClick }`, rendering a button (reusable, not update-specific).
+
+## Tests / gates
+
+- Added a toast action-button test (renders, runs handler, dismisses).
+  `npm test` → **456 pass**. lint 0 errors, typecheck clean, build green.
+
+## Verification gaps
+
+- The full check→download→restart cycle needs a **signed packaged build** across
+  two versions (same constraint as session 06). The menu item, dialogs, toast,
+  and quitAndInstall path are wired and unit-/type-checked, but the live update
+  feed can't be exercised from CI.
+- macOS self-update requires the signed build path (Gatekeeper).

--- a/markdown-viewer/src/features/toast.js
+++ b/markdown-viewer/src/features/toast.js
@@ -35,7 +35,7 @@ function getRegion() {
 /**
  * Show a toast notification.
  * @param {string} message
- * @param {{ type?: ToastType, duration?: number }} [options]
+ * @param {{ type?: ToastType, duration?: number, action?: { label: string, onClick: () => void } }} [options]
  * @returns {HTMLElement} the created toast element
  */
 export function showToast(message, options = {}) {
@@ -47,7 +47,28 @@ export function showToast(message, options = {}) {
   // role="alert" is assertive (interrupts); role="status" is polite. Errors
   // warrant an immediate announcement, everything else stays polite.
   toast.setAttribute('role', type === 'error' ? 'alert' : 'status');
-  toast.textContent = message;
+
+  const action = options.action;
+  if (action) {
+    // An actionable toast (e.g. "Update ready · Restart now") keeps the label in
+    // its own span so the button is a distinct, clickable target.
+    toast.classList.add('toast-has-action');
+    const text = document.createElement('span');
+    text.className = 'toast-message';
+    text.textContent = message;
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'toast-action';
+    button.textContent = action.label;
+    button.addEventListener('click', (e) => {
+      e.stopPropagation();
+      action.onClick();
+      dismissToast(toast);
+    });
+    toast.append(text, button);
+  } else {
+    toast.textContent = message;
+  }
   toast.addEventListener('click', () => dismissToast(toast));
   region.appendChild(toast);
 

--- a/markdown-viewer/src/platform/bridge.js
+++ b/markdown-viewer/src/platform/bridge.js
@@ -100,3 +100,13 @@ export function bridgeOnTriggerSearch(cb) {
 export function bridgeOnApplyCustomCss(cb) {
   nativeBridge()?.onApplyCustomCss?.(cb);
 }
+
+/** @param {Parameters<NonNullable<DesktopBridge['onUpdateDownloaded']>>[0]} cb */
+export function bridgeOnUpdateDownloaded(cb) {
+  nativeBridge()?.onUpdateDownloaded?.(cb);
+}
+
+/** Ask the shell to quit and install a downloaded update. */
+export function bridgeRestartToUpdate() {
+  nativeBridge()?.restartToUpdate?.();
+}

--- a/markdown-viewer/src/platform/desktop.js
+++ b/markdown-viewer/src/platform/desktop.js
@@ -15,6 +15,7 @@ import { createTab, closeTab, renderTabBar } from '../features/tabs.js';
 import { openSearch } from '../features/search.js';
 import { applyCustomCss } from '../features/custom-css.js';
 import { recordRecentFile, renderRecentFiles } from '../features/recent-files.js';
+import { showToast } from '../features/toast.js';
 import { performPrint } from './ios-chrome.js';
 import {
   hasDesktopBridge,
@@ -27,6 +28,8 @@ import {
   bridgeOnTriggerPrint,
   bridgeOnTriggerSearch,
   bridgeOnApplyCustomCss,
+  bridgeOnUpdateDownloaded,
+  bridgeRestartToUpdate,
 } from './bridge.js';
 
 const el = (/** @type {string} */ id) => document.getElementById(id);
@@ -215,6 +218,16 @@ export function setupDesktopIPC() {
   // Appearance menu: apply custom CSS theme
   bridgeOnApplyCustomCss(function (cssContent) {
     applyCustomCss(cssContent);
+  });
+
+  // Auto-update: a downloaded update is ready — offer a one-click restart.
+  bridgeOnUpdateDownloaded(function (info) {
+    const version = info && info.version ? ` (v${info.version})` : '';
+    showToast(`An update${version} is ready to install.`, {
+      type: 'success',
+      duration: 0, // persist until the user acts
+      action: { label: 'Restart now', onClick: () => bridgeRestartToUpdate() },
+    });
   });
 }
 

--- a/markdown-viewer/src/types/globals.d.ts
+++ b/markdown-viewer/src/types/globals.d.ts
@@ -53,6 +53,8 @@ interface SpecdownDesktopBridge {
   onTriggerSearch?: (cb: () => void) => void;
   onApplyCustomCss?: (cb: (cssContent: string) => void) => void;
   saveSession?: (tabs: SpecdownSessionTab[]) => void;
+  onUpdateDownloaded?: (cb: (info: { version?: string }) => void) => void;
+  restartToUpdate?: () => void;
 }
 
 /** A single WKScriptMessageHandler bridge on the iOS side. */

--- a/markdown-viewer/styles.css
+++ b/markdown-viewer/styles.css
@@ -1881,6 +1881,31 @@ mark.search-highlight-current {
     border-left-color: var(--color-danger);
 }
 
+/* An actionable toast lays its message and button out in a row. */
+.toast-has-action {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.75rem;
+    text-align: left;
+}
+
+.toast-action {
+    flex-shrink: 0;
+    background-color: rgba(255, 255, 255, 0.15);
+    color: #fff;
+    border: 1px solid rgba(255, 255, 255, 0.4);
+    border-radius: var(--radius-sm);
+    padding: 0.3rem 0.7rem;
+    font-size: 0.85rem;
+    font-weight: 600;
+    cursor: pointer;
+    white-space: nowrap;
+}
+
+.toast-action:hover {
+    background-color: rgba(255, 255, 255, 0.28);
+}
+
 /* ===========================
    Skip Link (accessibility)
    =========================== */

--- a/tests/unit/toast.test.js
+++ b/tests/unit/toast.test.js
@@ -78,4 +78,19 @@ describe('Toast notifications', () => {
     toast.dispatchEvent(new Event('click', { bubbles: true }));
     expect(document.querySelector('.toast')).toBeNull();
   });
+
+  it('renders an action button that runs its handler and dismisses', () => {
+    const onClick = jest.fn();
+    showToast('Update ready', { duration: 0, action: { label: 'Restart now', onClick } });
+
+    const toast = document.querySelector('.toast');
+    expect(toast.querySelector('.toast-message').textContent).toBe('Update ready');
+    const button = toast.querySelector('.toast-action');
+    expect(button).not.toBeNull();
+    expect(button.textContent).toBe('Restart now');
+
+    button.dispatchEvent(new Event('click', { bubbles: true }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(document.querySelector('.toast')).toBeNull();
+  });
 });


### PR DESCRIPTION
## What & why

Follow-up to #166. Auto-update was **silent** (background download → install-on-quit → OS notification), with no visible control — which is why you couldn't find an "update" button. This adds the two pieces you asked for:

1. **Help → "Check for Updates…"** menu item — runs a manual check. Result is a native dialog ("You're up to date" / "Could not check…"), or, if an update is found, it downloads and shows the restart toast. In a dev/unpackaged build it explains updates are install-only.
2. **"Restart now" toast** — when an update finishes downloading, the renderer shows a persistent toast with a **Restart now** button that calls `quitAndInstall()`.

## How (kept behind the `window.specdown` seam)

- **`main.js`** — holds the updater instance + a `manualUpdateCheck` flag (so the silent on-launch check stays quiet); the menu item; `ipcMain.on('restart-to-update')` → `quitAndInstall()`; sends `update-downloaded` to the renderer.
- **`preload.js`** — `onUpdateDownloaded(cb)` + `restartToUpdate()`.
- **`globals.d.ts` / `bridge.js`** — the two new bridge members.
- **`desktop.js`** — shows the toast wired to the bridge.
- **`toast.js` (+ `styles.css`)** — `showToast` gains a reusable optional `action: { label, onClick }` button.

## Tests / gates

- Toast action-button test added → **456 pass**. lint 0 errors, typecheck clean, build green.

## Verification gap

The live check→download→restart cycle needs a **signed packaged build across two versions** (same constraint as #166). All UI/IPC paths are wired + unit/type-checked, but CI can't exercise a real update feed. macOS self-update requires the signed build path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GeGQZEA1iJ8yHWuPuZzayv)_