### PR TITLE
Durable annotation anchoring (store schema v2)

### DIFF
--- a/docs/project-modernization/2026-06-22-tasks-annotation-durable-anchoring.md
+++ b/docs/project-modernization/2026-06-22-tasks-annotation-durable-anchoring.md
@@ -1,0 +1,67 @@
+# Tasks — Durable annotation anchoring (store schema v2)
+
+**Date:** 2026-06-22
+**Type:** tasks
+**Roadmap item:** §4 of the [retrospective](2026-06-19-retrospective-handoff.md) —
+"Annotation robustness: annotations anchor by positional block index, which
+drifts if the document is edited/reordered."
+
+## Problem
+
+Notes were keyed by raw positional block index (`{ file: { idx: text } }`), so
+editing or reordering a document silently moved every note to the wrong block.
+
+## Approach (hybrid anchor, graceful fallback)
+
+Each note now stores a durable `anchor`:
+
+- **`fp`** — a hash of the block's normalized text (the primary signal; survives
+  reordering and edits elsewhere).
+- **`path`** — a hash of the enclosing heading trail, to disambiguate blocks with
+  identical text.
+- **`ordinal`** — occurrence index within the same-fingerprint bucket, as a final
+  tiebreak.
+- **`legacyIdx`** — the positional index, kept only as a last-resort fallback.
+
+Resolution degrades predictably: unique fingerprint → fingerprint within matching
+heading-path → ordinal → stored index. When the fingerprint is gone (the block's
+text was edited), the note falls back to its last index and is flagged
+**orphaned** — a muted/dashed badge and a "(moved or edited)" panel cue — rather
+than silently misplacing it.
+
+## Migration (no data loss, durable export)
+
+- **One versioned store** (`{ version: 2, files: { file: Note[] } }`), not a
+  sidecar. Legacy v1 (`{ file: { idx: text } }`) is **read transparently** and
+  migrated in memory; the first render of a doc upgrades its notes to real
+  anchors and persists them. Nothing is ever dropped — a not-yet-anchored note
+  just uses its index until its block is seen.
+- **Export/import** is v2 but **still accepts v1 JSON** on import, so previously
+  exported files keep working. Because anchors live in the single store, export
+  is durable.
+- When a fingerprint relocates a note, its `legacyIdx` fallback is refreshed so
+  it stays useful.
+
+## Files
+
+- `markdown-viewer/src/features/annotations.js` — rewritten around the v2 store +
+  anchor resolver. The note **id** (not an index) is now the UI currency:
+  annotated blocks carry `data-annot-id`, so edit/delete/jump operate on the
+  note, and adding a note computes its anchor from the target block.
+- `markdown-viewer/styles.css` — muted/dashed orphaned-badge + italic orphaned
+  panel-context styles.
+- `tests/unit/annotations.test.js` — rewritten for v2: store/migration, the
+  reorder-follows-content case, heading-path disambiguation, the edited→orphaned
+  fallback, editor/panel, and v1+v2 import.
+
+## Gates
+
+- `npm test` → **460 pass** (was 456; +durability/migration cases).
+- lint 0 errors, typecheck clean, build green.
+
+## Notes
+
+- Module-private helpers are uniquely named (`annHash`, `annContext`, `annResolve`,
+  `annReadStore`, …) to avoid the eval test-harness's identifier-collision trap.
+- The hash is FNV-1a (non-cryptographic) — collisions are tolerable because the
+  heading-path + ordinal disambiguate and the index is a final fallback.

--- a/markdown-viewer/src/features/annotations.js
+++ b/markdown-viewer/src/features/annotations.js
@@ -1,69 +1,278 @@
 // @ts-check
-// Lightweight sticky-note annotations stored in localStorage, keyed by
-// filename. Users can double-click any paragraph or heading to add/edit one.
-// State is private to this module.
+// Sticky-note annotations stored in localStorage, keyed by filename. Users
+// double-click any paragraph/heading to add a note. State is private to this
+// module.
+//
+// Durable anchoring (store schema v2): each note records a content
+// *fingerprint* (hash of the block's normalized text) plus a heading-path hash
+// and an occurrence ordinal, with the positional block index kept only as a
+// last-resort fallback. So a note follows its block when the document is edited
+// or reordered, instead of drifting with a raw index. Legacy v1 stores
+// (`{ file: { idx: text } }`) are read transparently and upgraded in place the
+// first time their blocks resolve.
 
 import { showToast } from './toast.js';
 
 const ANNOTATIONS_KEY = 'specdown-annotations';
+const STORE_VERSION = 2;
+
+/** @typedef {{ fp: string, path: string, ordinal: number }} Anchor */
+/** @typedef {{ id: string, text: string, anchor: Anchor | null, legacyIdx: number }} Note */
+/** @typedef {{ version: number, files: Record<string, Note[]> }} Store */
+/** @typedef {{ root: HTMLElement, blocks: Element[], fps: string[], byFp: Map<string, number[]> }} BlockContext */
 
 let annotationMode = false;
 let annotationKey = '';
+let annNoteSeq = 0;
 
 const content = () => document.getElementById('markdown-content');
 
+// All block types a note can attach to. Rendering and the double-click handlers
+// index by this exact selector, so element positions line up.
+const ANNOTATABLE_SELECTOR = 'p, h1, h2, h3, h4, h5, h6, li, blockquote';
+
+// ===========================
+// Hashing + ids
+// ===========================
 /**
- * @param {string} key
- * @returns {Record<string, string>}
+ * FNV-1a 32-bit hash → base36. Small + stable; collisions are tolerable because
+ * the heading-path + ordinal disambiguate and the index is a final fallback.
+ * @param {string} str
  */
-function loadAnnotations(key) {
-  try {
-    const raw = localStorage.getItem(ANNOTATIONS_KEY);
-    const all = raw ? JSON.parse(raw) : {};
-    return all[key] || {};
-  } catch (e) {
-    return {};
+function annHash(str) {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i);
+    h = (h + ((h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24))) >>> 0;
   }
+  return (h >>> 0).toString(36);
+}
+
+function annNoteId() {
+  annNoteSeq += 1;
+  return `an-${Date.now().toString(36)}-${annNoteSeq}`;
 }
 
 /**
- * @param {string} key
- * @param {Record<string, string>} annotations
+ * A block's text with whitespace collapsed and any appended badge removed —
+ * the basis for its content fingerprint.
+ * @param {Element} element
  */
-function saveAnnotations(key, annotations) {
-  try {
-    const raw = localStorage.getItem(ANNOTATIONS_KEY);
-    const all = raw ? JSON.parse(raw) : {};
-    if (Object.keys(annotations).length === 0) {
-      delete all[key];
-    } else {
-      all[key] = annotations;
+function annBlockText(element) {
+  const clone = /** @type {Element} */ (element.cloneNode(true));
+  clone.querySelectorAll('.annotation-badge').forEach((b) => b.remove());
+  return (clone.textContent || '').replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * The trail of enclosing headings above an element (e.g. "Intro / Setup"),
+ * hashed by the caller. Disambiguates blocks that share identical text.
+ * @param {Element} target
+ * @param {Element} root
+ */
+function annHeadingTrail(target, root) {
+  const headings = root.querySelectorAll('h1, h2, h3, h4, h5, h6');
+  /** @type {{ level: number, text: string }[]} */
+  const stack = [];
+  for (const h of headings) {
+    if (h === target) break;
+    // Only headings positioned before the target contribute to its path.
+    if (!(target.compareDocumentPosition(h) & Node.DOCUMENT_POSITION_PRECEDING)) continue;
+    const level = Number(h.tagName.charAt(1));
+    while (stack.length && stack[stack.length - 1].level >= level) stack.pop();
+    stack.push({ level, text: annBlockText(h) });
+  }
+  return stack.map((s) => s.text).join(' / ');
+}
+
+// ===========================
+// Block context + anchoring
+// ===========================
+/**
+ * Snapshot the annotatable blocks once per operation: assign positional
+ * `data-annot-idx`, fingerprint each, and bucket indices by fingerprint.
+ * @param {Element} root
+ * @returns {BlockContext}
+ */
+function annContext(root) {
+  const blocks = Array.from(root.querySelectorAll(ANNOTATABLE_SELECTOR));
+  /** @type {string[]} */
+  const fps = [];
+  /** @type {Map<string, number[]>} */
+  const byFp = new Map();
+  blocks.forEach((element, idx) => {
+    element.setAttribute('data-annot-idx', String(idx));
+    const fp = annHash(annBlockText(element));
+    fps[idx] = fp;
+    const bucket = byFp.get(fp);
+    if (bucket) bucket.push(idx);
+    else byFp.set(fp, [idx]);
+  });
+  return { root: /** @type {HTMLElement} */ (root), blocks, fps, byFp };
+}
+
+/**
+ * Build the durable anchor for the block at `idx`.
+ * @param {BlockContext} ctx
+ * @param {number} idx
+ * @returns {Anchor}
+ */
+function annAnchorFor(ctx, idx) {
+  const fp = ctx.fps[idx];
+  const bucket = ctx.byFp.get(fp) || [idx];
+  return {
+    fp,
+    path: annHash(annHeadingTrail(ctx.blocks[idx], ctx.root)),
+    ordinal: Math.max(0, bucket.indexOf(idx)),
+  };
+}
+
+/**
+ * Resolve a note to a block index using its anchor, degrading gracefully:
+ *  - 'fp'       matched by fingerprint (durable hit)
+ *  - 'legacy'   no anchor yet (v1 note) → positioned by stored index
+ *  - 'fallback' had an anchor but the text changed → best-guess by index
+ *  - 'missing'  could not resolve to any block
+ * @param {BlockContext} ctx
+ * @param {Note} note
+ * @returns {{ idx: number, reason: 'fp' | 'legacy' | 'fallback' | 'missing' }}
+ */
+function annResolve(ctx, note) {
+  const a = note.anchor;
+  if (a && a.fp) {
+    const bucket = ctx.byFp.get(a.fp);
+    if (bucket && bucket.length) {
+      if (bucket.length === 1) return { idx: bucket[0], reason: 'fp' };
+      // Several blocks share the text — narrow by heading path, then ordinal.
+      const pathMatches = bucket.filter(
+        (i) => annHash(annHeadingTrail(ctx.blocks[i], ctx.root)) === a.path
+      );
+      const pool = pathMatches.length ? pathMatches : bucket;
+      if (typeof a.ordinal === 'number' && a.ordinal >= 0 && a.ordinal < pool.length) {
+        return { idx: pool[a.ordinal], reason: 'fp' };
+      }
+      return { idx: pool[0], reason: 'fp' };
     }
-    localStorage.setItem(ANNOTATIONS_KEY, JSON.stringify(all));
-  } catch (e) {
-    // localStorage quota exceeded — silently ignore
+    // Anchor existed but the fingerprint is gone — the block's text was edited.
+    if (annValidIdx(ctx, note.legacyIdx)) return { idx: note.legacyIdx, reason: 'fallback' };
+    return { idx: -1, reason: 'missing' };
   }
+  // v1 note (no anchor): position it, then renderAnnotations upgrades it.
+  if (annValidIdx(ctx, note.legacyIdx)) return { idx: note.legacyIdx, reason: 'legacy' };
+  return { idx: -1, reason: 'missing' };
 }
 
 /**
- * The full annotation store: filename → { elementIndex → note }.
- * @returns {Record<string, Record<string, string>>}
+ * @param {BlockContext} ctx
+ * @param {number} idx
  */
-function getAllAnnotations() {
+function annValidIdx(ctx, idx) {
+  return typeof idx === 'number' && idx >= 0 && idx < ctx.blocks.length;
+}
+
+// ===========================
+// Storage (schema v2 + v1 migration)
+// ===========================
+/**
+ * Read the whole annotation store, transparently migrating a legacy v1 map to
+ * the v2 shape in memory (persisted on the next write).
+ * @returns {Store}
+ */
+function annReadStore() {
+  let raw;
   try {
-    const raw = localStorage.getItem(ANNOTATIONS_KEY);
-    return raw ? JSON.parse(raw) : {};
+    raw = localStorage.getItem(ANNOTATIONS_KEY);
   } catch (e) {
-    return {};
+    return { version: STORE_VERSION, files: {} };
+  }
+  if (!raw) return { version: STORE_VERSION, files: {} };
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    return { version: STORE_VERSION, files: {} };
+  }
+  if (parsed && parsed.version === STORE_VERSION && parsed.files && typeof parsed.files === 'object') {
+    return /** @type {Store} */ (parsed);
+  }
+  return annMigrate(parsed);
+}
+
+/**
+ * Convert a legacy v1 store (`{ file: { idx: text } }`) to v2.
+ * @param {any} parsed
+ * @returns {Store}
+ */
+function annMigrate(parsed) {
+  /** @type {Store} */
+  const store = { version: STORE_VERSION, files: {} };
+  if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+    for (const [file, notes] of Object.entries(parsed)) {
+      if (!notes || typeof notes !== 'object') continue;
+      const arr = annLegacyToNotes(/** @type {Record<string, string>} */ (notes));
+      if (arr.length) store.files[file] = arr;
+    }
+  }
+  return store;
+}
+
+/**
+ * @param {Record<string, string>} obj v1 `{ idx: text }`
+ * @returns {Note[]}
+ */
+function annLegacyToNotes(obj) {
+  /** @type {Note[]} */
+  const out = [];
+  for (const [idx, text] of Object.entries(obj)) {
+    const n = Number(idx);
+    const t = String(text || '');
+    if (Number.isNaN(n) || !t) continue;
+    out.push({ id: annNoteId(), text: t, anchor: null, legacyIdx: n });
+  }
+  out.sort((a, b) => a.legacyIdx - b.legacyIdx);
+  return out;
+}
+
+/** @param {Store} store */
+function annWriteStore(store) {
+  try {
+    /** @type {Record<string, Note[]>} */
+    const files = {};
+    for (const [file, notes] of Object.entries(store.files || {})) {
+      if (Array.isArray(notes) && notes.length) files[file] = notes;
+    }
+    localStorage.setItem(ANNOTATIONS_KEY, JSON.stringify({ version: STORE_VERSION, files }));
+  } catch (e) {
+    // localStorage quota exceeded — silently ignore.
   }
 }
 
 /**
- * Pretty-printed JSON of the entire annotation store (for export / inspection).
- * @returns {string}
+ * @param {string} key
+ * @returns {Note[]}
  */
+function annFileNotes(key) {
+  const store = annReadStore();
+  return Array.isArray(store.files[key]) ? store.files[key] : [];
+}
+
+/**
+ * @param {string} key
+ * @param {Note[]} notes
+ */
+function annPutFileNotes(key, notes) {
+  const store = annReadStore();
+  if (!notes || notes.length === 0) delete store.files[key];
+  else store.files[key] = notes;
+  annWriteStore(store);
+}
+
+// ===========================
+// Export / import
+// ===========================
+/** Pretty-printed JSON of the entire annotation store (v2). */
 export function getAnnotationsJSON() {
-  return JSON.stringify(getAllAnnotations(), null, 2);
+  return JSON.stringify(annReadStore(), null, 2);
 }
 
 /** Download all annotations as a JSON file. */
@@ -81,9 +290,41 @@ export function exportAnnotations() {
 }
 
 /**
- * Merge imported annotations into the store. Per file, incoming notes win on a
- * key (element-index) conflict; other files/notes are preserved. Re-renders the
- * current document's badges. Returns whether the import succeeded.
+ * @param {any} raw
+ * @returns {Note | null}
+ */
+function annNormalizeImportedNote(raw) {
+  if (!raw || typeof raw.text !== 'string' || !raw.text) return null;
+  const anchor =
+    raw.anchor && typeof raw.anchor.fp === 'string'
+      ? {
+          fp: String(raw.anchor.fp),
+          path: String(raw.anchor.path || ''),
+          ordinal: Number(raw.anchor.ordinal) || 0,
+        }
+      : null;
+  return {
+    id: typeof raw.id === 'string' ? raw.id : annNoteId(),
+    text: raw.text,
+    anchor,
+    legacyIdx: Number.isFinite(raw.legacyIdx) ? Number(raw.legacyIdx) : -1,
+  };
+}
+
+/**
+ * @param {Note} a
+ * @param {Note} b
+ */
+function annSameNote(a, b) {
+  if (a.text !== b.text) return false;
+  if (a.anchor && b.anchor) return a.anchor.fp === b.anchor.fp && a.anchor.ordinal === b.anchor.ordinal;
+  return a.legacyIdx === b.legacyIdx;
+}
+
+/**
+ * Merge imported annotations into the store. Accepts both v2 (`{ version, files }`)
+ * and legacy v1 (`{ file: { idx: text } }`) payloads. Existing notes are kept;
+ * incoming notes are appended unless an exact duplicate already exists.
  * @param {string} jsonText
  * @returns {boolean}
  */
@@ -100,16 +341,27 @@ export function importAnnotations(jsonText) {
     return false;
   }
 
-  const existing = getAllAnnotations();
+  const incomingFiles =
+    incoming.version === STORE_VERSION && incoming.files && typeof incoming.files === 'object'
+      ? incoming.files
+      : annMigrate(incoming).files;
+
+  const store = annReadStore();
   let fileCount = 0;
-  for (const [file, notes] of Object.entries(incoming)) {
-    if (!notes || typeof notes !== 'object') continue;
-    existing[file] = Object.assign({}, existing[file] || {}, notes);
+  for (const [file, notes] of Object.entries(incomingFiles)) {
+    if (!Array.isArray(notes)) continue;
+    const merged = Array.isArray(store.files[file]) ? store.files[file].slice() : [];
+    for (const candidate of notes) {
+      const note = annNormalizeImportedNote(candidate);
+      if (!note) continue;
+      if (!merged.some((m) => annSameNote(m, note))) merged.push(note);
+    }
+    store.files[file] = merged;
     fileCount += 1;
   }
 
   try {
-    localStorage.setItem(ANNOTATIONS_KEY, JSON.stringify(existing));
+    annWriteStore(store);
   } catch (e) {
     showToast('Import failed: could not save (storage full?).', { type: 'error' });
     return false;
@@ -136,9 +388,12 @@ export function importAnnotationsFromFile() {
   input.click();
 }
 
+// ===========================
+// Mode toggle + handlers
+// ===========================
 /**
- * Toggle annotation mode. Callers are responsible for any platform chrome
- * sync (e.g. the iOS action bar) after toggling.
+ * Toggle annotation mode. Callers handle any platform chrome sync (e.g. the iOS
+ * action bar) after toggling.
  */
 export function toggleAnnotationMode() {
   annotationMode = !annotationMode;
@@ -147,8 +402,6 @@ export function toggleAnnotationMode() {
 
   if (annotationMode && annotationKey) {
     attachAnnotationHandlers();
-    // The interaction (double-click a block) isn't discoverable on its own, so
-    // tell the user how to use the mode they just turned on.
     showToast('Annotation mode on — double-click any paragraph or heading to add a note.', {
       type: 'info',
     });
@@ -157,121 +410,109 @@ export function toggleAnnotationMode() {
   }
 }
 
-// All block types a note can attach to. Both rendering and the double-click
-// handlers index by this exact selector, so element positions line up.
-const ANNOTATABLE_SELECTOR = 'p, h1, h2, h3, h4, h5, h6, li, blockquote';
-
-/**
- * Assign a stable positional `data-annot-idx` to every annotatable block. Done
- * on every render (not just in annotation mode) so saved badges can resolve
- * their anchor element even when the user isn't actively annotating.
- * @param {Element} root
- * @returns {NodeListOf<Element>}
- */
-function indexAnnotatableElements(root) {
-  const els = root.querySelectorAll(ANNOTATABLE_SELECTOR);
-  els.forEach((el, idx) => el.setAttribute('data-annot-idx', String(idx)));
-  return els;
-}
-
-/**
- * Render saved annotation badges for a document, keyed by filename.
- * @param {string} key
- */
-export function renderAnnotations(key) {
-  const markdownContent = content();
-  annotationKey = key;
-  if (!markdownContent) return;
-  // Remove old annotation badges
-  markdownContent.querySelectorAll('.annotation-badge').forEach((b) => b.remove());
-
-  // Index the blocks first so badges render whether or not annotation mode is
-  // on (previously badges only appeared while actively annotating).
-  indexAnnotatableElements(markdownContent);
-
-  const annotations = loadAnnotations(key);
-  Object.entries(annotations).forEach(([idx, text]) => {
-    const el = markdownContent.querySelectorAll('[data-annot-idx]')[parseInt(idx, 10)];
-    if (el) attachAnnotationBadge(el, parseInt(idx, 10), text);
-  });
-
-  // Re-arm double-click handlers if the user is currently annotating.
-  if (annotationMode) attachAnnotationHandlers();
-
-  // Refresh the side panel + toolbar toggle for this document.
-  renderAnnotationPanel();
-}
-
 function attachAnnotationHandlers() {
   const root = content();
   if (!root) return;
-  // Index (idempotent) then make each block interactive.
-  const els = indexAnnotatableElements(root);
-  els.forEach((el) => {
-    el.classList.add('annotatable');
-    el.addEventListener('dblclick', handleAnnotationDblClick);
+  const blocks = Array.from(root.querySelectorAll(ANNOTATABLE_SELECTOR));
+  blocks.forEach((element, idx) => {
+    element.setAttribute('data-annot-idx', String(idx));
+    element.classList.add('annotatable');
+    element.addEventListener('dblclick', handleAnnotationDblClick);
   });
 }
 
 function detachAnnotationHandlers() {
   const root = content();
   if (!root) return;
-  root.querySelectorAll('.annotatable').forEach((el) => {
-    el.removeEventListener('dblclick', handleAnnotationDblClick);
-    el.classList.remove('annotatable');
+  root.querySelectorAll('.annotatable').forEach((element) => {
+    element.removeEventListener('dblclick', handleAnnotationDblClick);
+    element.classList.remove('annotatable');
   });
 }
 
 /** @param {Event} e */
 function handleAnnotationDblClick(e) {
   if (!annotationMode) return;
-  const el = /** @type {HTMLElement} */ (e.currentTarget);
-  const idx = parseInt(el.getAttribute('data-annot-idx') || '', 10);
-  if (!Number.isNaN(idx)) openAnnotationEditor(idx);
+  const element = /** @type {HTMLElement} */ (e.currentTarget);
+  const id = element.getAttribute('data-annot-id');
+  if (id) openAnnotationEditor({ id });
+  else openAnnotationEditor({ element });
 }
 
+// ===========================
+// Rendering
+// ===========================
 /**
- * The annotatable block at a given positional index, or null.
- * @param {number} idx
+ * Render saved annotation badges for a document, keyed by filename.
+ * @param {string} key
  */
-function annotatedElement(idx) {
+export function renderAnnotations(key) {
   const root = content();
-  if (!root) return null;
-  const el = root.querySelectorAll('[data-annot-idx]')[idx];
-  return el || null;
+  annotationKey = key;
+  if (!root) return;
+
+  root.querySelectorAll('.annotation-badge').forEach((b) => b.remove());
+  root.querySelectorAll('[data-annot-id]').forEach((element) => {
+    element.removeAttribute('data-annot-id');
+    element.classList.remove('has-annotation', 'annotation-orphaned');
+  });
+
+  const ctx = annContext(root);
+  const notes = annFileNotes(key);
+  let dirty = false;
+
+  for (const note of notes) {
+    const { idx, reason } = annResolve(ctx, note);
+    if (idx < 0) continue;
+    // Upgrade a v1 note to a durable anchor, and keep the positional fallback
+    // current whenever the fingerprint relocates the note.
+    if (reason === 'legacy') {
+      note.anchor = annAnchorFor(ctx, idx);
+      note.legacyIdx = idx;
+      dirty = true;
+    } else if (reason === 'fp' && note.legacyIdx !== idx) {
+      note.legacyIdx = idx;
+      dirty = true;
+    }
+    attachAnnotationBadge(ctx.blocks[idx], note, reason === 'fallback');
+  }
+
+  if (dirty) annPutFileNotes(key, notes);
+  if (annotationMode) attachAnnotationHandlers();
+  renderAnnotationPanel();
 }
 
 /**
- * Add / edit / remove the note at `idx` and refresh the badge + panel.
- * @param {number} idx
- * @param {string} rawText
+ * @param {Element} element
+ * @param {Note} note
+ * @param {boolean} orphaned The text changed; this is a best-guess location.
  */
-function commitAnnotation(idx, rawText) {
-  const text = String(rawText || '').trim();
-  const el = annotatedElement(idx);
-  const annotations = loadAnnotations(annotationKey);
+function attachAnnotationBadge(element, note, orphaned) {
+  const existing = element.querySelector('.annotation-badge');
+  if (existing) existing.remove();
 
-  if (!text) {
-    delete annotations[idx];
-    if (el) {
-      const badge = el.querySelector('.annotation-badge');
-      if (badge) badge.remove();
-      el.classList.remove('has-annotation');
-    }
-  } else {
-    annotations[idx] = text;
-    if (el) attachAnnotationBadge(el, idx, text);
-  }
-  saveAnnotations(annotationKey, annotations);
-  renderAnnotationPanel();
+  element.setAttribute('data-annot-id', note.id);
+  element.classList.add('has-annotation');
+  element.classList.toggle('annotation-orphaned', orphaned);
+
+  const badge = document.createElement('span');
+  badge.className = 'annotation-badge' + (orphaned ? ' annotation-badge-orphaned' : '');
+  badge.title = orphaned
+    ? `${note.text}\n(the anchored text changed — best-guess location)`
+    : note.text;
+  badge.textContent = '✎';
+  badge.addEventListener('click', (e) => {
+    e.stopPropagation();
+    showAnnotationPopover(badge, note.text);
+  });
+  element.appendChild(badge);
 }
 
 // ===========================
 // In-app note editor
 // ===========================
-// Replaces window.prompt(), which Electron does not implement (so desktop
-// annotation editing silently did nothing). A small modal works on every
-// surface and is nicer than a native prompt.
+// Replaces window.prompt(), which the native shells don't implement. A small
+// modal works on every surface.
 
 /** @type {(() => void) | null} */
 let editorCleanup = null;
@@ -297,18 +538,19 @@ function ensureEditor() {
 }
 
 /**
- * Open the note editor for the block at `idx`.
- * @param {number} idx
+ * Open the note editor for an existing note (`{ id }`) or a new note on a block
+ * (`{ element }`).
+ * @param {{ id?: string, element?: HTMLElement }} target
  */
-function openAnnotationEditor(idx) {
+function openAnnotationEditor(target) {
   const backdrop = ensureEditor();
   const textarea = /** @type {HTMLTextAreaElement} */ (backdrop.querySelector('.annotation-editor-input'));
   const deleteBtn = /** @type {HTMLButtonElement} */ (backdrop.querySelector('.annotation-editor-delete'));
   const saveBtn = /** @type {HTMLButtonElement} */ (backdrop.querySelector('.annotation-editor-save'));
   const cancelBtn = /** @type {HTMLButtonElement} */ (backdrop.querySelector('.annotation-editor-cancel'));
 
-  const existing = loadAnnotations(annotationKey)[idx] || '';
-  textarea.value = existing;
+  const existing = target.id ? annFileNotes(annotationKey).find((n) => n.id === target.id) : null;
+  textarea.value = existing ? existing.text : '';
   deleteBtn.style.display = existing ? '' : 'none';
   backdrop.style.display = 'flex';
   setTimeout(() => textarea.focus(), 0);
@@ -319,11 +561,11 @@ function openAnnotationEditor(idx) {
     editorCleanup = null;
   };
   const save = () => {
-    commitAnnotation(idx, textarea.value);
+    commitAnnotation(target, textarea.value);
     close();
   };
   const remove = () => {
-    commitAnnotation(idx, '');
+    commitAnnotation(target, '');
     close();
   };
   /** @param {KeyboardEvent} e */
@@ -356,20 +598,58 @@ function openAnnotationEditor(idx) {
   };
 }
 
+/**
+ * Add / edit / remove a note, then re-render badges + panel.
+ * @param {{ id?: string, element?: HTMLElement }} target
+ * @param {string} rawText
+ */
+function commitAnnotation(target, rawText) {
+  const text = String(rawText || '').trim();
+  const notes = annFileNotes(annotationKey);
+
+  if (target.id) {
+    const note = notes.find((n) => n.id === target.id);
+    if (!note) return;
+    if (!text) {
+      notes.splice(notes.indexOf(note), 1);
+    } else {
+      note.text = text;
+    }
+  } else if (target.element && text) {
+    const root = content();
+    const ctx = root ? annContext(root) : null;
+    const idx = ctx ? ctx.blocks.indexOf(target.element) : -1;
+    notes.push({
+      id: annNoteId(),
+      text,
+      anchor: ctx && idx >= 0 ? annAnchorFor(ctx, idx) : null,
+      legacyIdx: idx,
+    });
+  }
+
+  annPutFileNotes(annotationKey, notes);
+  renderAnnotations(annotationKey);
+}
+
 // ===========================
 // Annotations panel (list)
 // ===========================
-
 /**
- * Scroll to the annotated block and briefly flash it.
- * @param {number} idx
+ * Scroll to a note's block and briefly flash it.
+ * @param {string} id
  */
-function jumpToAnnotation(idx) {
-  const el = /** @type {HTMLElement | null} */ (annotatedElement(idx));
-  if (!el) return;
-  el.scrollIntoView({ behavior: 'smooth', block: 'center' });
-  el.classList.add('annotation-flash');
-  setTimeout(() => el.classList.remove('annotation-flash'), 1200);
+function jumpToAnnotation(id) {
+  const root = content();
+  if (!root) return;
+  const ctx = annContext(root);
+  const note = annFileNotes(annotationKey).find((n) => n.id === id);
+  if (!note) return;
+  const { idx } = annResolve(ctx, note);
+  if (idx < 0) return;
+  const target = /** @type {HTMLElement} */ (ctx.blocks[idx]);
+  target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  target.classList.add('annotation-flash');
+  setTimeout(() => target.classList.remove('annotation-flash'), 1200);
 }
 
 /**
@@ -379,20 +659,18 @@ function jumpToAnnotation(idx) {
 export function renderAnnotationPanel() {
   const list = document.getElementById('annotation-list');
   const toggle = document.getElementById('annotation-list-toggle');
-  const annotations = loadAnnotations(annotationKey);
-  const indexes = Object.keys(annotations)
-    .map((k) => parseInt(k, 10))
-    .filter((n) => !Number.isNaN(n))
-    .sort((a, b) => a - b);
+  const root = content();
+  const notes = annFileNotes(annotationKey);
+  const ctx = root ? annContext(root) : null;
 
   if (toggle) {
-    toggle.style.display = indexes.length ? '' : 'none';
+    toggle.style.display = notes.length ? '' : 'none';
     const count = toggle.querySelector('.annotation-list-count');
-    if (count) count.textContent = String(indexes.length);
+    if (count) count.textContent = String(notes.length);
   }
 
   // An open-but-now-empty panel should close itself.
-  if (indexes.length === 0) {
+  if (notes.length === 0) {
     const panel = document.getElementById('annotation-panel');
     if (panel) {
       panel.style.display = 'none';
@@ -403,15 +681,19 @@ export function renderAnnotationPanel() {
 
   if (!list) return;
   list.innerHTML = '';
-  for (const idx of indexes) {
-    const el = annotatedElement(idx);
+
+  // Resolve each note to a block, then order rows by document position
+  // (unresolved notes sink to the bottom).
+  const rows = notes.map((note) => {
+    const r = ctx ? annResolve(ctx, note) : { idx: -1, reason: /** @type {const} */ ('missing') };
+    return { note, idx: r.idx, reason: r.reason };
+  });
+  rows.sort((a, b) => (a.idx < 0 ? Infinity : a.idx) - (b.idx < 0 ? Infinity : b.idx));
+
+  for (const row of rows) {
+    const { note, idx, reason } = row;
     let snippet = '';
-    if (el) {
-      // Read the block's text without the appended ✎ badge.
-      const clone = /** @type {HTMLElement} */ (el.cloneNode(true));
-      clone.querySelectorAll('.annotation-badge').forEach((b) => b.remove());
-      snippet = (clone.textContent || '').replace(/\s+/g, ' ').trim().slice(0, 80);
-    }
+    if (ctx && idx >= 0) snippet = annBlockText(ctx.blocks[idx]).slice(0, 80);
 
     const li = document.createElement('li');
     li.className = 'annotation-list-item';
@@ -419,14 +701,15 @@ export function renderAnnotationPanel() {
     const jump = document.createElement('button');
     jump.type = 'button';
     jump.className = 'annotation-list-jump';
-    const note = document.createElement('span');
-    note.className = 'annotation-list-note';
-    note.textContent = annotations[idx];
-    const ctx = document.createElement('span');
-    ctx.className = 'annotation-list-context';
-    ctx.textContent = snippet || '(text not found)';
-    jump.append(note, ctx);
-    jump.addEventListener('click', () => jumpToAnnotation(idx));
+    const note_ = document.createElement('span');
+    note_.className = 'annotation-list-note';
+    note_.textContent = note.text;
+    const ctxEl = document.createElement('span');
+    ctxEl.className = 'annotation-list-context';
+    ctxEl.textContent = snippet || (reason === 'missing' ? '(text not found)' : '(moved or edited)');
+    if (reason === 'fallback' || reason === 'missing') ctxEl.classList.add('annotation-list-context-orphaned');
+    jump.append(note_, ctxEl);
+    jump.addEventListener('click', () => jumpToAnnotation(note.id));
 
     const edit = document.createElement('button');
     edit.type = 'button';
@@ -436,7 +719,7 @@ export function renderAnnotationPanel() {
     edit.textContent = '✎';
     edit.addEventListener('click', (e) => {
       e.stopPropagation();
-      openAnnotationEditor(idx);
+      openAnnotationEditor({ id: note.id });
     });
 
     const del = document.createElement('button');
@@ -447,7 +730,7 @@ export function renderAnnotationPanel() {
     del.textContent = '✕';
     del.addEventListener('click', (e) => {
       e.stopPropagation();
-      commitAnnotation(idx, '');
+      commitAnnotation({ id: note.id }, '');
     });
 
     li.append(jump, edit, del);
@@ -481,30 +764,6 @@ export function openAnnotationPanel() {
   panel.style.display = '';
   const toggle = document.getElementById('annotation-list-toggle');
   if (toggle) toggle.classList.add('active');
-}
-
-/**
- * @param {Element} el
- * @param {number} idx
- * @param {string} text
- */
-function attachAnnotationBadge(el, idx, text) {
-  // Remove existing badge first
-  const existing = el.querySelector('.annotation-badge');
-  if (existing) existing.remove();
-
-  el.setAttribute('data-annot-idx', String(idx));
-  el.classList.add('has-annotation');
-
-  const badge = document.createElement('span');
-  badge.className = 'annotation-badge';
-  badge.title = text;
-  badge.textContent = '✎';
-  badge.addEventListener('click', (e) => {
-    e.stopPropagation();
-    showAnnotationPopover(badge, text);
-  });
-  el.appendChild(badge);
 }
 
 /**

--- a/markdown-viewer/styles.css
+++ b/markdown-viewer/styles.css
@@ -2446,6 +2446,22 @@ mark.search-highlight-current {
     background-color: #e67e22;
 }
 
+/* Best-guess placement: the anchored block's text changed, so the note fell
+   back to its last-known position. Muted + dashed to signal "approximate". */
+.annotation-badge-orphaned {
+    background-color: #95a5a6;
+    border: 1px dashed rgba(255, 255, 255, 0.85);
+}
+
+.annotation-badge-orphaned:hover {
+    background-color: #7f8c8d;
+}
+
+.annotation-list-context-orphaned {
+    font-style: italic;
+    opacity: 0.75;
+}
+
 .annotation-popover {
     position: fixed;
     background-color: var(--bg-primary);

--- a/tests/unit/annotations.test.js
+++ b/tests/unit/annotations.test.js
@@ -1,5 +1,5 @@
 /**
- * Unit tests for annotation mode
+ * Unit tests for annotation mode (durable anchoring, schema v2).
  */
 
 const { loadHTML, loadApp } = require('../helpers/loadApp');
@@ -18,69 +18,44 @@ describe('Annotation Mode', () => {
   });
 
   // ===========================
-  // loadAnnotations
+  // Storage (v2 + v1 migration)
   // ===========================
-  describe('loadAnnotations', () => {
-    it('returns an empty object when localStorage has no annotations', () => {
-      const result = loadAnnotations('test.md');
-      expect(result).toEqual({});
+  describe('store helpers', () => {
+    it('returns an empty v2 store when localStorage is empty', () => {
+      expect(annReadStore()).toEqual({ version: 2, files: {} });
     });
 
-    it('returns the stored annotations for the given key', () => {
-      const data = { 'test.md': { 0: 'Note A', 3: 'Note B' } };
-      localStorage.setItem(ANNOTATIONS_KEY, JSON.stringify(data));
-
-      const result = loadAnnotations('test.md');
-      expect(result).toEqual({ 0: 'Note A', 3: 'Note B' });
+    it('reads a legacy v1 store as migrated v2 notes (anchor null, index kept)', () => {
+      localStorage.setItem(ANNOTATIONS_KEY, JSON.stringify({ 'a.md': { 0: 'x', 2: 'y' } }));
+      const store = annReadStore();
+      expect(store.version).toBe(2);
+      expect(store.files['a.md'].map((n) => n.text)).toEqual(['x', 'y']);
+      expect(store.files['a.md'][0].legacyIdx).toBe(0);
+      expect(store.files['a.md'][1].legacyIdx).toBe(2);
+      expect(store.files['a.md'][0].anchor).toBeNull();
     });
 
-    it('returns empty object for a key that does not exist', () => {
-      const data = { 'other.md': { 0: 'Note' } };
-      localStorage.setItem(ANNOTATIONS_KEY, JSON.stringify(data));
-
-      const result = loadAnnotations('missing.md');
-      expect(result).toEqual({});
-    });
-
-    it('returns empty object on malformed JSON', () => {
+    it('returns an empty v2 store on malformed JSON', () => {
       localStorage.setItem(ANNOTATIONS_KEY, 'NOT_JSON');
-      expect(() => loadAnnotations('test.md')).not.toThrow();
-      const result = loadAnnotations('test.md');
-      expect(result).toEqual({});
-    });
-  });
-
-  // ===========================
-  // saveAnnotations
-  // ===========================
-  describe('saveAnnotations', () => {
-    it('persists annotations to localStorage', () => {
-      saveAnnotations('test.md', { 0: 'Hello' });
-
-      const raw = localStorage.getItem(ANNOTATIONS_KEY);
-      const all = JSON.parse(raw);
-      expect(all['test.md']).toEqual({ 0: 'Hello' });
+      expect(() => annReadStore()).not.toThrow();
+      expect(annReadStore()).toEqual({ version: 2, files: {} });
     });
 
-    it('merges with existing annotations for other keys', () => {
-      localStorage.setItem(ANNOTATIONS_KEY, JSON.stringify({ 'other.md': { 1: 'Existing' } }));
-
-      saveAnnotations('test.md', { 0: 'New' });
-
-      const raw = localStorage.getItem(ANNOTATIONS_KEY);
-      const all = JSON.parse(raw);
-      expect(all['other.md']).toEqual({ 1: 'Existing' });
-      expect(all['test.md']).toEqual({ 0: 'New' });
+    it('annFileNotes returns the notes array for a key', () => {
+      localStorage.setItem(ANNOTATIONS_KEY, JSON.stringify({ 'a.md': { 0: 'x' } }));
+      expect(annFileNotes('a.md').map((n) => n.text)).toEqual(['x']);
+      expect(annFileNotes('missing.md')).toEqual([]);
     });
 
-    it('removes the key from storage when annotations object is empty', () => {
-      localStorage.setItem(ANNOTATIONS_KEY, JSON.stringify({ 'test.md': { 0: 'Old note' } }));
+    it('annPutFileNotes writes v2 and drops empty files', () => {
+      annPutFileNotes('a.md', [{ id: 'n', text: 't', anchor: null, legacyIdx: 0 }]);
+      let store = JSON.parse(localStorage.getItem(ANNOTATIONS_KEY));
+      expect(store.version).toBe(2);
+      expect(store.files['a.md'][0].text).toBe('t');
 
-      saveAnnotations('test.md', {});
-
-      const raw = localStorage.getItem(ANNOTATIONS_KEY);
-      const all = JSON.parse(raw);
-      expect(all['test.md']).toBeUndefined();
+      annPutFileNotes('a.md', []);
+      store = JSON.parse(localStorage.getItem(ANNOTATIONS_KEY));
+      expect(store.files['a.md']).toBeUndefined();
     });
   });
 
@@ -100,15 +75,10 @@ describe('Annotation Mode', () => {
       expect(annotationMode).toBe(false);
     });
 
-    it('adds active class to the annotation-toggle button when enabled', () => {
+    it('adds/removes active class on the annotation-toggle button', () => {
       const btn = document.getElementById('annotation-toggle');
       toggleAnnotationMode();
       expect(btn.classList.contains('active')).toBe(true);
-    });
-
-    it('removes active class from the annotation-toggle button when disabled', () => {
-      const btn = document.getElementById('annotation-toggle');
-      toggleAnnotationMode();
       toggleAnnotationMode();
       expect(btn.classList.contains('active')).toBe(false);
     });
@@ -118,17 +88,12 @@ describe('Annotation Mode', () => {
   // renderAnnotations
   // ===========================
   describe('renderAnnotations', () => {
-    beforeEach(async () => {
-      await renderMarkdown('# Title\n\nFirst paragraph.\n\nSecond paragraph.', 'test.md');
-    });
-
     it('sets annotationKey to the given key', () => {
       renderAnnotations('test.md');
       expect(annotationKey).toBe('test.md');
     });
 
     it('removes old annotation badges before rendering', () => {
-      // Manually insert a stale badge
       const mc = document.getElementById('markdown-content');
       const stale = document.createElement('span');
       stale.className = 'annotation-badge';
@@ -139,38 +104,93 @@ describe('Annotation Mode', () => {
       expect(mc.querySelectorAll('.annotation-badge').length).toBe(0);
     });
 
-    it('renders badges for stored annotations', () => {
-      const data = { 'test.md': { 0: 'My note' } };
-      localStorage.setItem(ANNOTATIONS_KEY, JSON.stringify(data));
-
-      // Insert elements with data-annot-idx directly so renderAnnotations
-      // can find them (marked mock doesn't produce block elements)
-      const mc = document.getElementById('markdown-content');
-      mc.innerHTML = '<p data-annot-idx="0">Para 0</p><p data-annot-idx="1">Para 1</p>';
-
-      renderAnnotations('test.md');
-
-      const badges = document.querySelectorAll('.annotation-badge');
-      expect(badges.length).toBeGreaterThanOrEqual(1);
-    });
-
     it('renders saved badges when annotation mode is OFF (indexes blocks itself)', () => {
-      // Regression: previously badges only resolved their anchor while
-      // annotation mode was active, so saved notes were invisible on load.
-      const data = { 'doc.md': { 1: 'second-block note' } };
-      localStorage.setItem(ANNOTATIONS_KEY, JSON.stringify(data));
-
+      localStorage.setItem(ANNOTATIONS_KEY, JSON.stringify({ 'doc.md': { 1: 'second-block note' } }));
       const mc = document.getElementById('markdown-content');
-      // No data-annot-idx attributes, not in annotation mode.
       mc.innerHTML = '<p>Block zero</p><p>Block one</p>';
 
       renderAnnotations('doc.md');
 
       const badges = mc.querySelectorAll('.annotation-badge');
       expect(badges.length).toBe(1);
-      // The badge attaches to the second paragraph (index 1).
       expect(mc.querySelectorAll('p')[1].querySelector('.annotation-badge')).not.toBeNull();
       expect(mc.querySelectorAll('p')[0].querySelector('.annotation-badge')).toBeNull();
+    });
+
+    it('migrates a legacy v1 note and upgrades it to a durable anchor on render', () => {
+      localStorage.setItem(ANNOTATIONS_KEY, JSON.stringify({ 'm.md': { 1: 'legacy note' } }));
+      const mc = document.getElementById('markdown-content');
+      mc.innerHTML = '<p>Zero</p><p>One</p>';
+
+      renderAnnotations('m.md');
+
+      const store = JSON.parse(localStorage.getItem(ANNOTATIONS_KEY));
+      expect(store.version).toBe(2);
+      const note = store.files['m.md'][0];
+      expect(note.text).toBe('legacy note');
+      expect(note.anchor).not.toBeNull();
+      expect(typeof note.anchor.fp).toBe('string');
+      expect(note.legacyIdx).toBe(1);
+    });
+  });
+
+  // ===========================
+  // Durable re-anchoring (the point of this feature)
+  // ===========================
+  describe('durable anchoring', () => {
+    it('follows the note to its content when blocks are reordered', () => {
+      const mc = document.getElementById('markdown-content');
+      mc.innerHTML = '<p>Alpha</p><p>Beta</p><p>Gamma</p>';
+      renderAnnotations('reorder.md');
+
+      const beta = [...mc.querySelectorAll('p')].find((p) => p.textContent === 'Beta');
+      commitAnnotation({ element: beta }, 'note on beta');
+      expect(beta.querySelector('.annotation-badge')).not.toBeNull();
+
+      // Move Beta from index 1 to index 2.
+      mc.innerHTML = '<p>Gamma</p><p>Alpha</p><p>Beta</p>';
+      renderAnnotations('reorder.md');
+
+      const ps = [...mc.querySelectorAll('p')];
+      const badged = ps.filter((p) => p.querySelector('.annotation-badge'));
+      expect(badged.length).toBe(1);
+      // The single badge is on the "Beta" block (textContent includes the ✎ badge).
+      expect(badged[0].textContent.replace('✎', '').trim()).toBe('Beta');
+      // The block now sitting at Beta's *old* index 1 is Alpha — no badge there.
+      expect(ps[1].textContent).toBe('Alpha');
+    });
+
+    it('disambiguates duplicate text by heading path', () => {
+      const mc = document.getElementById('markdown-content');
+      mc.innerHTML =
+        '<h2>First</h2><p>same text</p><h2>Second</h2><p>same text</p>';
+      renderAnnotations('dupe.md');
+
+      // Annotate the "same text" under the "Second" heading (the 2nd paragraph).
+      const secondPara = mc.querySelectorAll('p')[1];
+      commitAnnotation({ element: secondPara }, 'second one');
+
+      // Re-render; the badge must stay on the paragraph under "Second".
+      renderAnnotations('dupe.md');
+      const paras = mc.querySelectorAll('p');
+      expect(paras[0].querySelector('.annotation-badge')).toBeNull();
+      expect(paras[1].querySelector('.annotation-badge')).not.toBeNull();
+    });
+
+    it('falls back to the stored index and flags the note when its text is edited', () => {
+      const mc = document.getElementById('markdown-content');
+      mc.innerHTML = '<p>Alpha</p><p>Beta</p>';
+      renderAnnotations('edited.md');
+      const beta = [...mc.querySelectorAll('p')].find((p) => p.textContent === 'Beta');
+      commitAnnotation({ element: beta }, 'n');
+
+      // Rewrite Beta's text so the fingerprint no longer matches.
+      mc.innerHTML = '<p>Alpha</p><p>Beta, heavily rewritten now</p>';
+      renderAnnotations('edited.md');
+
+      const second = mc.querySelectorAll('p')[1];
+      expect(second.querySelector('.annotation-badge')).not.toBeNull();
+      expect(second.classList.contains('annotation-orphaned')).toBe(true);
     });
   });
 
@@ -178,6 +198,7 @@ describe('Annotation Mode', () => {
   // attachAnnotationBadge
   // ===========================
   describe('attachAnnotationBadge', () => {
+    const note = (text, id = 'n1') => ({ id, text, anchor: null, legacyIdx: 0 });
     function makeParagraph() {
       const mc = document.getElementById('markdown-content');
       const p = document.createElement('p');
@@ -186,122 +207,113 @@ describe('Annotation Mode', () => {
       return p;
     }
 
-    it('appends a badge element to the target element', () => {
+    it('appends a badge and tags the element with the note id', () => {
       const p = makeParagraph();
-
-      attachAnnotationBadge(p, 0, 'Test note');
-
-      const badge = p.querySelector('.annotation-badge');
-      expect(badge).not.toBeNull();
+      attachAnnotationBadge(p, note('Test note'), false);
+      expect(p.querySelector('.annotation-badge')).not.toBeNull();
+      expect(p.getAttribute('data-annot-id')).toBe('n1');
+      expect(p.classList.contains('has-annotation')).toBe(true);
     });
 
     it('sets the badge title to the annotation text', () => {
       const p = makeParagraph();
-
-      attachAnnotationBadge(p, 0, 'My annotation');
-
-      const badge = p.querySelector('.annotation-badge');
-      expect(badge.title).toBe('My annotation');
-    });
-
-    it('adds has-annotation class to the element', () => {
-      const p = makeParagraph();
-
-      attachAnnotationBadge(p, 0, 'Note');
-
-      expect(p.classList.contains('has-annotation')).toBe(true);
+      attachAnnotationBadge(p, note('My annotation'), false);
+      expect(p.querySelector('.annotation-badge').title).toBe('My annotation');
     });
 
     it('replaces an existing badge rather than adding a second one', () => {
       const p = makeParagraph();
-
-      attachAnnotationBadge(p, 0, 'First');
-      attachAnnotationBadge(p, 0, 'Second');
-
+      attachAnnotationBadge(p, note('First'), false);
+      attachAnnotationBadge(p, note('Second'), false);
       const badges = p.querySelectorAll('.annotation-badge');
       expect(badges.length).toBe(1);
       expect(badges[0].title).toBe('Second');
     });
+
+    it('marks an orphaned (best-guess) badge', () => {
+      const p = makeParagraph();
+      attachAnnotationBadge(p, note('x'), true);
+      expect(p.classList.contains('annotation-orphaned')).toBe(true);
+      expect(p.querySelector('.annotation-badge').classList.contains('annotation-badge-orphaned')).toBe(true);
+    });
   });
 
   // ===========================
-  // attachAnnotationHandlers / detachAnnotationHandlers
+  // attach / detach handlers
   // ===========================
-  describe('attachAnnotationHandlers', () => {
+  describe('attachAnnotationHandlers / detachAnnotationHandlers', () => {
     beforeEach(() => {
-      // Insert annotatable elements directly since the marked mock
-      // doesn't produce semantic block elements
       const mc = document.getElementById('markdown-content');
       mc.innerHTML = '<h1>Heading</h1><p>Para one.</p><p>Para two.</p>';
     });
 
-    it('adds annotatable class to paragraphs and headings', () => {
+    it('adds annotatable class and data-annot-idx', () => {
       attachAnnotationHandlers();
-
-      const annotatable = document.querySelectorAll('.annotatable');
-      expect(annotatable.length).toBeGreaterThan(0);
-    });
-
-    it('assigns data-annot-idx attributes starting from 0', () => {
-      attachAnnotationHandlers();
-
+      expect(document.querySelectorAll('.annotatable').length).toBeGreaterThan(0);
       const els = document.querySelectorAll('[data-annot-idx]');
-      expect(els.length).toBeGreaterThan(0);
       expect(els[0].getAttribute('data-annot-idx')).toBe('0');
     });
-  });
 
-  describe('detachAnnotationHandlers', () => {
-    beforeEach(() => {
-      const mc = document.getElementById('markdown-content');
-      mc.innerHTML = '<h1>Heading</h1><p>Para one.</p>';
+    it('removes annotatable class on detach', () => {
       attachAnnotationHandlers();
-    });
-
-    it('removes annotatable class from all elements', () => {
       detachAnnotationHandlers();
-
-      const annotatable = document.querySelectorAll('.annotatable');
-      expect(annotatable.length).toBe(0);
+      expect(document.querySelectorAll('.annotatable').length).toBe(0);
     });
   });
 });
 
 describe('Annotation export / import', () => {
-  const KEY = 'specdown-annotations';
-
   beforeEach(() => {
     localStorage.clear();
     loadHTML(document);
     loadApp(document);
   });
 
-  it('exports the full store as pretty JSON', () => {
-    localStorage.setItem(KEY, JSON.stringify({ 'a.md': { 0: 'note' } }));
+  it('exports the store as v2 (migrating legacy data)', () => {
+    localStorage.setItem(ANNOTATIONS_KEY, JSON.stringify({ 'a.md': { 0: 'note' } }));
     const parsed = JSON.parse(getAnnotationsJSON());
-    expect(parsed).toEqual({ 'a.md': { 0: 'note' } });
+    expect(parsed.version).toBe(2);
+    expect(parsed.files['a.md'][0].text).toBe('note');
   });
 
-  it('returns an empty object JSON when there are no annotations', () => {
-    expect(JSON.parse(getAnnotationsJSON())).toEqual({});
+  it('returns an empty v2 store JSON when there are no annotations', () => {
+    expect(JSON.parse(getAnnotationsJSON())).toEqual({ version: 2, files: {} });
   });
 
-  it('merges imported annotations across files', () => {
-    localStorage.setItem(KEY, JSON.stringify({ 'a.md': { 0: 'keep' } }));
-    const ok = importAnnotations(JSON.stringify({ 'a.md': { 1: 'add' }, 'b.md': { 0: 'new' } }));
-
+  it('imports a v2 payload, merging across files', () => {
+    annPutFileNotes('a.md', [{ id: 'x', text: 'keep', anchor: null, legacyIdx: 0 }]);
+    const ok = importAnnotations(
+      JSON.stringify({
+        version: 2,
+        files: {
+          'a.md': [{ id: 'y', text: 'add', anchor: null, legacyIdx: 1 }],
+          'b.md': [{ id: 'z', text: 'new', anchor: null, legacyIdx: 0 }],
+        },
+      })
+    );
     expect(ok).toBe(true);
-    const store = JSON.parse(localStorage.getItem(KEY));
-    expect(store).toEqual({
-      'a.md': { 0: 'keep', 1: 'add' },
-      'b.md': { 0: 'new' },
-    });
+    const store = JSON.parse(localStorage.getItem(ANNOTATIONS_KEY));
+    expect(store.files['a.md'].map((n) => n.text).sort()).toEqual(['add', 'keep']);
+    expect(store.files['b.md'][0].text).toBe('new');
   });
 
-  it('lets incoming notes win on a key conflict', () => {
-    localStorage.setItem(KEY, JSON.stringify({ 'a.md': { 0: 'old' } }));
-    importAnnotations(JSON.stringify({ 'a.md': { 0: 'new' } }));
-    expect(JSON.parse(localStorage.getItem(KEY))['a.md']['0']).toBe('new');
+  it('imports a legacy v1 payload by migrating it', () => {
+    const ok = importAnnotations(JSON.stringify({ 'a.md': { 0: 'from v1' } }));
+    expect(ok).toBe(true);
+    const store = JSON.parse(localStorage.getItem(ANNOTATIONS_KEY));
+    expect(store.version).toBe(2);
+    expect(store.files['a.md'][0].text).toBe('from v1');
+  });
+
+  it('does not duplicate an identical re-import', () => {
+    const payload = JSON.stringify({
+      version: 2,
+      files: { 'a.md': [{ id: 'x', text: 'once', anchor: null, legacyIdx: 0 }] },
+    });
+    importAnnotations(payload);
+    importAnnotations(payload);
+    const store = JSON.parse(localStorage.getItem(ANNOTATIONS_KEY));
+    expect(store.files['a.md'].length).toBe(1);
   });
 
   it('rejects invalid JSON with an error toast', () => {
@@ -340,11 +352,13 @@ describe('Annotation editor + panel', () => {
     backdrop.querySelector('.annotation-editor-save').dispatchEvent(new Event('click', { bubbles: true }));
 
     expect(mc.querySelector('p').querySelector('.annotation-badge')).not.toBeNull();
-    expect(JSON.parse(localStorage.getItem('specdown-annotations'))['doc.md']['0']).toBe('My note');
+    const store = JSON.parse(localStorage.getItem('specdown-annotations'));
+    expect(store.files['doc.md'][0].text).toBe('My note');
+    expect(store.files['doc.md'][0].anchor).not.toBeNull();
     expect(backdrop.style.display).toBe('none');
   });
 
-  it('renders the panel rows + toolbar count', () => {
+  it('renders the panel rows + toolbar count, in document order', () => {
     localStorage.setItem('specdown-annotations', JSON.stringify({ 'doc.md': { 0: 'note A', 1: 'note B' } }));
     const mc = document.getElementById('markdown-content');
     mc.innerHTML = '<p>Zero</p><p>One</p>';


### PR DESCRIPTION
## What & why

The last open roadmap item. Notes were keyed by **raw positional block index** (`{ file: { idx: text } }`), so editing or reordering a document silently moved every note to the wrong block. This makes them **follow their content**.

## Anchoring (hybrid, graceful fallback)

Each note stores a durable `anchor`:
- **`fp`** — hash of the block's normalized text (primary; survives reordering + edits elsewhere)
- **`path`** — hash of the enclosing heading trail (disambiguates identical text)
- **`ordinal`** — occurrence index within the same-fingerprint bucket (final tiebreak)
- **`legacyIdx`** — positional index, kept only as a last-resort fallback

Resolution: unique fingerprint → fingerprint within matching heading-path → ordinal → stored index. When the fingerprint is gone (block text edited), the note falls back to its last index and is flagged **orphaned** (muted/dashed badge + "(moved or edited)" panel cue) instead of being silently misplaced.

## Migration (no data loss, durable export)

- **One versioned store** (`{ version: 2, files: { file: Note[] } }`), not a sidecar. Legacy **v1 is read transparently and migrated in memory**; the first render upgrades a doc's notes to real anchors and persists them — nothing is ever dropped.
- **Export/import is v2 but still accepts v1 JSON**, so previously exported files keep working. Anchors live in the single store, so export stays durable.

## Files

- `annotations.js` — rewritten around the v2 store + resolver; the note **id** (carried on `data-annot-id`) is now the UI currency.
- `styles.css` — orphaned badge/context cues.
- `annotations.test.js` — rewritten for v2; adds **reorder-follows-content**, **heading-path disambiguation**, **edited→orphaned fallback**, and **v1+v2 import** cases.

## Gates

- `npm test` → **460 pass** (+durability/migration cases). lint 0 errors, typecheck clean, build green.

## Notes

- Module-private helpers are uniquely named (`annHash`, `annResolve`, …) to avoid the eval test-harness identifier-collision trap.
- Hash is FNV-1a (non-crypto) — collisions are fine because heading-path + ordinal disambiguate and the index is a final fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GeGQZEA1iJ8yHWuPuZzayv)_