### PR TITLE
Surface presentation mode on iPhone via the action sheet

### DIFF
--- a/docs/project-bugfix-wave/2026-06-22-tasks-session-04-ios-present-action-sheet.md
+++ b/docs/project-bugfix-wave/2026-06-22-tasks-session-04-ios-present-action-sheet.md
@@ -1,0 +1,38 @@
+# Session 04 — Surface presentation mode on iPhone
+
+**Date:** 2026-06-22
+**Type:** tasks
+**Surface:** iOS (WKWebView) + mobile web — phone-width layouts.
+
+## Problem
+
+Diagram **presentation mode** (`presentation.js` — full-screen step-through of a
+document's Mermaid diagrams) was **unreachable on iPhone**. Its only entry point,
+the `#present-button`, lives in `.content-header-actions`, which is hidden at
+phone width (and on the iOS native shell, except iPad). It was never wired into
+the iPhone bottom **action sheet** — the same per-surface surfacing gap called
+out in CLAUDE.md ("a new toolbar control must also be wired into the iOS action
+sheet to be reachable on iPhone"). So iPad/desktop could present, iPhone could
+not. (Once open, the overlay's on-screen ‹ / › nav already works by touch.)
+
+## Fix
+
+- **`markdown-viewer/index.html`** — added a `#ios-present-button`
+  ("Present Diagrams") to `.ios-sheet-actions`, hidden by default (like the
+  desktop Present button).
+- **`markdown-viewer/src/main.js`** —
+  - query the button; on click, `closeIOSActionSheet()` then `startPresentation()`
+    (same handler the desktop button uses);
+  - toggle its visibility alongside the desktop Present button in the render
+    path, so it appears **only when the document has presentable diagrams**
+    (`hasPresentableDiagrams()`).
+
+No change to presentation mode itself — just the iPhone entry point. iPad keeps
+using the toolbar button (the action sheet isn't shown there), so there's no
+duplication.
+
+## Tests / gates
+
+- Added a test: with diagrams present, clicking `#ios-present-button` opens the
+  presentation overlay. `npm test` → **461 pass**.
+- lint 0 errors, typecheck clean, build green.

--- a/docs/project-bugfix-wave/README.md
+++ b/docs/project-bugfix-wave/README.md
@@ -12,6 +12,7 @@ folder tracks the smaller fixes that follow.
 | 2026-06-21 | [tasks-session-01](2026-06-21-tasks-session-01-diagram-controls-overlap.md) | Diagram control toolbar overlapped/covered the diagram on phones (iOS + mobile web) |
 | 2026-06-21 | [tasks-session-02](2026-06-21-tasks-session-02-diagram-double-tap-zoom.md) | Double-tap on a diagram zoom button zoomed the whole page instead of the diagram |
 | 2026-06-21 | [tasks-session-03](2026-06-21-tasks-session-03-jsyaml-dos-advisory.md) | Cleared the js-yaml DoS Dependabot advisory (dev-only transitive) via a scoped override |
+| 2026-06-22 | [tasks-session-04](2026-06-22-tasks-session-04-ios-present-action-sheet.md) | Presentation mode was unreachable on iPhone — added a Present entry to the iOS action sheet |
 
 ## Status
 

--- a/markdown-viewer/index.html
+++ b/markdown-viewer/index.html
@@ -237,6 +237,7 @@
                 </div>
                 <div class="ios-sheet-actions">
                     <button id="ios-split-button" class="ios-sheet-action-button">Split View</button>
+                    <button id="ios-present-button" class="ios-sheet-action-button" style="display: none;">Present Diagrams</button>
                     <button id="ios-comments-button" class="ios-sheet-action-button">Toggle Comments</button>
                     <button id="ios-annotations-button" class="ios-sheet-action-button">Annotations</button>
                     <button id="ios-print-button" class="ios-sheet-action-button">Print</button>

--- a/markdown-viewer/src/main.js
+++ b/markdown-viewer/src/main.js
@@ -210,6 +210,7 @@ const iosMoreButton = /** @type {HTMLButtonElement | null} */ ($('ios-more-butto
 const iosActionSheet = $('ios-action-sheet');
 const iosActionSheetClose = $('ios-action-sheet-close');
 const iosSplitButton = /** @type {HTMLButtonElement | null} */ ($('ios-split-button'));
+const iosPresentButton = /** @type {HTMLButtonElement | null} */ ($('ios-present-button'));
 const iosCommentsButton = /** @type {HTMLButtonElement | null} */ ($('ios-comments-button'));
 const iosAnnotationsButton = /** @type {HTMLButtonElement | null} */ ($('ios-annotations-button'));
 const iosPrintButton = /** @type {HTMLButtonElement | null} */ ($('ios-print-button'));
@@ -621,6 +622,13 @@ function setupEventListeners() {
         });
     }
 
+    if (iosPresentButton) {
+        iosPresentButton.addEventListener('click', () => {
+            closeIOSActionSheet();
+            startPresentation();
+        });
+    }
+
     if (iosCommentsButton) {
         iosCommentsButton.addEventListener('click', () => {
             closeIOSActionSheet();
@@ -881,9 +889,14 @@ async function renderMarkdown(content, filename) {
         // Process mermaid diagrams
         await processMermaidDiagrams();
 
-        // Reveal the Present button only when there are diagrams to present
+        // Reveal the Present entry points (desktop toolbar + iPhone action sheet)
+        // only when there are diagrams to present.
+        const canPresent = hasPresentableDiagrams();
         if (presentButton) {
-            presentButton.style.display = hasPresentableDiagrams() ? '' : 'none';
+            presentButton.style.display = canPresent ? '' : 'none';
+        }
+        if (iosPresentButton) {
+            iosPresentButton.style.display = canPresent ? '' : 'none';
         }
 
         // Reveal the workspace Files toggle when a folder is loaded, and refresh

--- a/tests/unit/presentation.test.js
+++ b/tests/unit/presentation.test.js
@@ -43,6 +43,15 @@ describe('Diagram presentation mode', () => {
     expect(hasPresentableDiagrams()).toBe(true);
   });
 
+  it('launches presentation from the iPhone action-sheet button', () => {
+    addDiagrams(2);
+    const btn = document.getElementById('ios-present-button');
+    expect(btn).not.toBeNull();
+    btn.dispatchEvent(new Event('click', { bubbles: true }));
+    expect(isPresentationOpen()).toBe(true);
+    expect(document.querySelector('.presentation-overlay')).not.toBeNull();
+  });
+
   it('opens a modal stage on the first diagram with a counter', () => {
     addDiagrams(3);
     startPresentation();


### PR DESCRIPTION
## What & why

Answers "is there a presentation mode for mobile?" — there is (full-screen step-through of the doc's Mermaid diagrams, with touch-friendly ‹ / › nav), but it was **unreachable on iPhone**. Its only entry point (`#present-button`) lives in `.content-header-actions`, which is hidden at phone width, and it was never wired into the iPhone bottom **action sheet**. So iPad/desktop could present; iPhone couldn't.

This is the same per-surface surfacing gap CLAUDE.md warns about.

## Fix

- **`index.html`** — added `#ios-present-button` ("Present Diagrams") to `.ios-sheet-actions`, hidden by default.
- **`main.js`** — wired its click to `closeIOSActionSheet()` + `startPresentation()` (the same handler the desktop button uses), and toggle its visibility alongside the desktop Present button so it shows **only when the doc has presentable diagrams**.

No change to presentation mode itself. iPad keeps using the toolbar button (the sheet isn't shown there), so no duplication.

## Tests / gates

- Added a test: with diagrams present, clicking `#ios-present-button` opens the presentation overlay → **461 pass**.
- lint 0 errors, typecheck clean, build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GeGQZEA1iJ8yHWuPuZzayv)_