### PR TITLE
Fix PR #178 review findings: CodeQL alert #10 + repo-browser listener stacking

### DIFF
--- a/markdown-viewer/src/features/repo-browser.js
+++ b/markdown-viewer/src/features/repo-browser.js
@@ -58,7 +58,10 @@ export async function fetchGitHubRepoFiles(repoUrl) {
  * @param {{ clearError: Function, showError: Function, onSelectFile: Function }} hooks
  * @returns {Promise<boolean>} true if handled as a repo URL (caller should stop).
  */
-export async function handleRepoUrl(url, { clearError, showError, onSelectFile }) {
+export async function handleRepoUrl(
+  url,
+  { clearError, showError, onSelectFile }
+) {
   clearError();
   const files = await fetchGitHubRepoFiles(url);
   if (files === null) {
@@ -74,6 +77,13 @@ export async function handleRepoUrl(url, { clearError, showError, onSelectFile }
   return true;
 }
 
+// Close handler for the currently-open browser instance. The backdrop click
+// listener is bound ONCE (at modal creation) and delegates through this ref —
+// binding it per open stacked a new listener (plus its captured focus-trap
+// release) on the reused modal element every time the browser opened.
+/** @type {(() => void) | null} */
+let repoBrowserActiveClose = null;
+
 /**
  * @param {RepoFile[]} files
  * @param {string} repoUrl
@@ -88,11 +98,21 @@ function showRepoBrowser(files, repoUrl, onSelectFile) {
     modal.setAttribute('role', 'dialog');
     modal.setAttribute('aria-modal', 'true');
     modal.setAttribute('aria-label', 'Repository file browser');
+    modal.addEventListener('click', (e) => {
+      if (e.target === modal && repoBrowserActiveClose)
+        repoBrowserActiveClose();
+    });
     document.body.appendChild(modal);
   }
   const panel = modal;
 
-  const repoName = repoUrl.replace(/^https?:\/\/github\.com\//, '').replace(/\/$/, '');
+  // Re-opened while already open: release the previous instance's focus trap
+  // before it gets orphaned by the innerHTML rebuild below.
+  if (repoBrowserActiveClose) repoBrowserActiveClose();
+
+  const repoName = repoUrl
+    .replace(/^https?:\/\/github\.com\//, '')
+    .replace(/\/$/, '');
 
   panel.innerHTML = `
         <div class="repo-browser-content">
@@ -122,16 +142,17 @@ function showRepoBrowser(files, repoUrl, onSelectFile) {
   const closeModal = () => {
     releaseTrap();
     panel.style.display = 'none';
+    repoBrowserActiveClose = null;
   };
+  repoBrowserActiveClose = closeModal;
 
+  // Inner elements are rebuilt by the innerHTML assignment above, so these
+  // listeners are fresh per open (no stacking); only the backdrop listener on
+  // the reused modal element itself must not be re-bound here.
   const closeBtn = panel.querySelector('.repo-browser-close');
   if (closeBtn) {
     closeBtn.addEventListener('click', closeModal);
   }
-
-  panel.addEventListener('click', (e) => {
-    if (e.target === panel) closeModal();
-  });
 
   const filterInput = /** @type {HTMLInputElement | null} */ (
     panel.querySelector('.repo-browser-filter')

--- a/tests/unit/desktopRenderer.test.js
+++ b/tests/unit/desktopRenderer.test.js
@@ -73,8 +73,8 @@ describe('Desktop renderer integration', () => {
     createTab('b.md', '# B', '/tmp/b.md');
 
     // Tab b is now active; deliver a file-changed event for tab a.
-    const backgroundTab = state.tabs.find(t => t.filePath === '/tmp/a.md');
-    const activeTab = state.tabs.find(t => t.filePath === '/tmp/b.md');
+    const backgroundTab = state.tabs.find((t) => t.filePath === '/tmp/a.md');
+    const activeTab = state.tabs.find((t) => t.filePath === '/tmp/b.md');
     expect(state.activeTabId).toBe(activeTab.id);
 
     await fileChangedCallback({
@@ -86,19 +86,27 @@ describe('Desktop renderer integration', () => {
     // Background tab should be flagged and its DOM element should carry
     // the change indicator class so the user sees something changed.
     expect(backgroundTab.hasUnseenChanges).toBe(true);
-    const backgroundEl = document.querySelector(`.tab[data-tab-id="${backgroundTab.id}"]`);
+    const backgroundEl = document.querySelector(
+      `.tab[data-tab-id="${backgroundTab.id}"]`
+    );
     expect(backgroundEl.classList.contains('tab-has-changes')).toBe(true);
 
     // Switching to the background tab should clear the flag.
     await switchTab(backgroundTab.id);
     expect(backgroundTab.hasUnseenChanges).toBe(false);
-    const refreshedEl = document.querySelector(`.tab[data-tab-id="${backgroundTab.id}"]`);
+    const refreshedEl = document.querySelector(
+      `.tab[data-tab-id="${backgroundTab.id}"]`
+    );
     expect(refreshedEl.classList.contains('tab-has-changes')).toBe(false);
   });
 
   describe('version check vs. the desktop auto-updater', () => {
     const githubApiCalled = () =>
-      global.fetch.mock.calls.some((call) => String(call[0]).includes('api.github.com'));
+      // startsWith (not includes): asserts the exact API origin, which also
+      // satisfies CodeQL's URL-substring-sanitization rule (alert #10).
+      global.fetch.mock.calls.some((call) =>
+        String(call[0]).startsWith('https://api.github.com/')
+      );
 
     it('skips the GitHub-API poll on macOS, where electron-updater owns updates', () => {
       window.specdown.platform = 'darwin';

--- a/tests/unit/githubRepoBrowser.test.js
+++ b/tests/unit/githubRepoBrowser.test.js
@@ -34,21 +34,27 @@ describe('GitHub Repo Browser', () => {
     });
 
     it('returns null for a GitHub URL that is not a bare repo (e.g. a file path)', async () => {
-      const result = await fetchGitHubRepoFiles('https://github.com/owner/repo/blob/main/README.md');
+      const result = await fetchGitHubRepoFiles(
+        'https://github.com/owner/repo/blob/main/README.md'
+      );
       expect(result).toBeNull();
     });
 
     it('returns null when the fetch response is not ok', async () => {
       global.fetch = jest.fn().mockResolvedValue({ ok: false });
 
-      const result = await fetchGitHubRepoFiles('https://github.com/owner/repo');
+      const result = await fetchGitHubRepoFiles(
+        'https://github.com/owner/repo'
+      );
       expect(result).toBeNull();
     });
 
     it('returns null when fetch throws an error', async () => {
       global.fetch = jest.fn().mockRejectedValue(new Error('Network error'));
 
-      const result = await fetchGitHubRepoFiles('https://github.com/owner/repo');
+      const result = await fetchGitHubRepoFiles(
+        'https://github.com/owner/repo'
+      );
       expect(result).toBeNull();
     });
 
@@ -58,42 +64,65 @@ describe('GitHub Repo Browser', () => {
         json: async () => ({ items: [] }),
       });
 
-      const result = await fetchGitHubRepoFiles('https://github.com/owner/repo');
+      const result = await fetchGitHubRepoFiles(
+        'https://github.com/owner/repo'
+      );
       expect(result).toEqual([]);
     });
 
     it('returns file objects with path, url, and rawUrl', async () => {
       const items = [
-        { path: 'README.md', html_url: 'https://github.com/owner/repo/blob/main/README.md' },
-        { path: 'docs/guide.md', html_url: 'https://github.com/owner/repo/blob/main/docs/guide.md' },
+        {
+          path: 'README.md',
+          html_url: 'https://github.com/owner/repo/blob/main/README.md',
+        },
+        {
+          path: 'docs/guide.md',
+          html_url: 'https://github.com/owner/repo/blob/main/docs/guide.md',
+        },
       ];
       global.fetch = jest.fn().mockResolvedValue({
         ok: true,
         json: async () => ({ items }),
       });
 
-      const result = await fetchGitHubRepoFiles('https://github.com/owner/repo');
+      const result = await fetchGitHubRepoFiles(
+        'https://github.com/owner/repo'
+      );
 
       expect(result).toHaveLength(2);
       expect(result[0].path).toBe('README.md');
-      expect(result[0].rawUrl).toBe('https://raw.githubusercontent.com/owner/repo/HEAD/README.md');
+      expect(result[0].rawUrl).toBe(
+        'https://raw.githubusercontent.com/owner/repo/HEAD/README.md'
+      );
       expect(result[1].path).toBe('docs/guide.md');
-      expect(result[1].rawUrl).toBe('https://raw.githubusercontent.com/owner/repo/HEAD/docs/guide.md');
+      expect(result[1].rawUrl).toBe(
+        'https://raw.githubusercontent.com/owner/repo/HEAD/docs/guide.md'
+      );
     });
 
     it('strips a trailing .git from the repo name', async () => {
       global.fetch = jest.fn().mockResolvedValue({
         ok: true,
         json: async () => ({
-          items: [{ path: 'README.md', html_url: 'https://github.com/owner/repo/blob/main/README.md' }],
+          items: [
+            {
+              path: 'README.md',
+              html_url: 'https://github.com/owner/repo/blob/main/README.md',
+            },
+          ],
         }),
       });
 
-      const result = await fetchGitHubRepoFiles('https://github.com/owner/repo.git');
+      const result = await fetchGitHubRepoFiles(
+        'https://github.com/owner/repo.git'
+      );
 
       // The rawUrl should reference 'repo' without '.git'
       expect(result).not.toBeNull();
-      expect(result[0].rawUrl).toBe('https://raw.githubusercontent.com/owner/repo/HEAD/README.md');
+      expect(result[0].rawUrl).toBe(
+        'https://raw.githubusercontent.com/owner/repo/HEAD/README.md'
+      );
     });
 
     it('accepts a URL with a trailing slash', async () => {
@@ -102,7 +131,9 @@ describe('GitHub Repo Browser', () => {
         json: async () => ({ items: [] }),
       });
 
-      const result = await fetchGitHubRepoFiles('https://github.com/owner/repo/');
+      const result = await fetchGitHubRepoFiles(
+        'https://github.com/owner/repo/'
+      );
       expect(result).toEqual([]);
     });
   });
@@ -112,8 +143,17 @@ describe('GitHub Repo Browser', () => {
   // ===========================
   describe('showRepoBrowser', () => {
     const sampleFiles = [
-      { path: 'README.md', url: 'https://github.com/owner/repo/blob/main/README.md', rawUrl: 'https://raw.githubusercontent.com/owner/repo/HEAD/README.md' },
-      { path: 'docs/guide.md', url: 'https://github.com/owner/repo/blob/main/docs/guide.md', rawUrl: 'https://raw.githubusercontent.com/owner/repo/HEAD/docs/guide.md' },
+      {
+        path: 'README.md',
+        url: 'https://github.com/owner/repo/blob/main/README.md',
+        rawUrl: 'https://raw.githubusercontent.com/owner/repo/HEAD/README.md',
+      },
+      {
+        path: 'docs/guide.md',
+        url: 'https://github.com/owner/repo/blob/main/docs/guide.md',
+        rawUrl:
+          'https://raw.githubusercontent.com/owner/repo/HEAD/docs/guide.md',
+      },
     ];
 
     it('creates and displays the repo browser modal', () => {
@@ -128,7 +168,9 @@ describe('GitHub Repo Browser', () => {
       showRepoBrowser(sampleFiles, 'https://github.com/owner/repo');
 
       const modal = document.getElementById('repo-browser-modal');
-      expect(modal.querySelector('.repo-browser-title').textContent).toBe('owner/repo');
+      expect(modal.querySelector('.repo-browser-title').textContent).toBe(
+        'owner/repo'
+      );
     });
 
     it('renders one list item per file', () => {
@@ -142,8 +184,12 @@ describe('GitHub Repo Browser', () => {
       showRepoBrowser(sampleFiles, 'https://github.com/owner/repo');
 
       const items = document.querySelectorAll('.repo-browser-item');
-      expect(items[0].querySelector('.repo-file-path').textContent).toBe('README.md');
-      expect(items[1].querySelector('.repo-file-path').textContent).toBe('docs/guide.md');
+      expect(items[0].querySelector('.repo-file-path').textContent).toBe(
+        'README.md'
+      );
+      expect(items[1].querySelector('.repo-file-path').textContent).toBe(
+        'docs/guide.md'
+      );
     });
 
     it('each list item has a data-raw-url attribute', () => {
@@ -151,6 +197,34 @@ describe('GitHub Repo Browser', () => {
 
       const items = document.querySelectorAll('.repo-browser-item');
       expect(items[0].getAttribute('data-raw-url')).toBe(sampleFiles[0].rawUrl);
+    });
+
+    it('backdrop click still closes after repeated opens (no listener stacking)', () => {
+      // Regression: the backdrop listener used to be re-bound on every open of
+      // the reused modal element, stacking handlers + captured focus-trap
+      // closures. The listener is now bound once and delegates to the active
+      // instance, so repeated opens keep exactly one close path.
+      showRepoBrowser(sampleFiles, 'https://github.com/owner/repo');
+      showRepoBrowser(sampleFiles, 'https://github.com/owner/repo');
+      showRepoBrowser(sampleFiles, 'https://github.com/owner/repo');
+
+      const modal = document.getElementById('repo-browser-modal');
+      expect(modal.style.display).toBe('flex');
+
+      // Click directly on the backdrop (target === modal) → closes.
+      modal.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      expect(modal.style.display).toBe('none');
+
+      // A stray backdrop click while closed is a harmless no-op…
+      expect(() =>
+        modal.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      ).not.toThrow();
+
+      // …and the browser still opens and closes normally afterwards.
+      showRepoBrowser(sampleFiles, 'https://github.com/owner/repo');
+      expect(modal.style.display).toBe('flex');
+      modal.querySelector('.repo-browser-close').click();
+      expect(modal.style.display).toBe('none');
     });
 
     it('close button hides the modal', () => {
@@ -169,7 +243,10 @@ describe('GitHub Repo Browser', () => {
       const modal = document.getElementById('repo-browser-modal');
       // Simulate a click directly on the modal overlay (target === modal)
       const evt = new MouseEvent('click', { bubbles: true });
-      Object.defineProperty(evt, 'target', { value: modal, configurable: true });
+      Object.defineProperty(evt, 'target', {
+        value: modal,
+        configurable: true,
+      });
       modal.dispatchEvent(evt);
 
       expect(modal.style.display).toBe('none');
@@ -183,9 +260,13 @@ describe('GitHub Repo Browser', () => {
       filterInput.dispatchEvent(new Event('input'));
 
       const items = document.querySelectorAll('.repo-browser-item');
-      const visibleItems = Array.from(items).filter((i) => i.style.display !== 'none');
+      const visibleItems = Array.from(items).filter(
+        (i) => i.style.display !== 'none'
+      );
       expect(visibleItems.length).toBe(1);
-      expect(visibleItems[0].querySelector('.repo-file-path').textContent).toBe('docs/guide.md');
+      expect(visibleItems[0].querySelector('.repo-file-path').textContent).toBe(
+        'docs/guide.md'
+      );
     });
 
     it('filter input is case-insensitive', () => {
@@ -196,9 +277,13 @@ describe('GitHub Repo Browser', () => {
       filterInput.dispatchEvent(new Event('input'));
 
       const items = document.querySelectorAll('.repo-browser-item');
-      const visibleItems = Array.from(items).filter((i) => i.style.display !== 'none');
+      const visibleItems = Array.from(items).filter(
+        (i) => i.style.display !== 'none'
+      );
       expect(visibleItems.length).toBe(1);
-      expect(visibleItems[0].querySelector('.repo-file-path').textContent).toBe('README.md');
+      expect(visibleItems[0].querySelector('.repo-file-path').textContent).toBe(
+        'README.md'
+      );
     });
 
     it('re-uses the existing modal element on subsequent calls', () => {
@@ -222,14 +307,20 @@ describe('GitHub Repo Browser', () => {
 
     it('returns false for a non-GitHub URL', async () => {
       global.fetch = jest.fn(); // should not be called
-      const result = await handleRepoUrl('https://example.com/not-a-repo', hooks());
+      const result = await handleRepoUrl(
+        'https://example.com/not-a-repo',
+        hooks()
+      );
       expect(result).toBe(false);
     });
 
     it('returns false when fetchGitHubRepoFiles returns null (fetch failed)', async () => {
       global.fetch = jest.fn().mockResolvedValue({ ok: false });
 
-      const result = await handleRepoUrl('https://github.com/owner/repo', hooks());
+      const result = await handleRepoUrl(
+        'https://github.com/owner/repo',
+        hooks()
+      );
       expect(result).toBe(false);
     });
 
@@ -239,7 +330,10 @@ describe('GitHub Repo Browser', () => {
         json: async () => ({ items: [] }),
       });
 
-      const result = await handleRepoUrl('https://github.com/owner/repo', hooks());
+      const result = await handleRepoUrl(
+        'https://github.com/owner/repo',
+        hooks()
+      );
       expect(result).toBe(true);
     });
 
@@ -247,11 +341,19 @@ describe('GitHub Repo Browser', () => {
       global.fetch = jest.fn().mockResolvedValue({
         ok: true,
         json: async () => ({
-          items: [{ path: 'README.md', html_url: 'https://github.com/owner/repo/blob/main/README.md' }],
+          items: [
+            {
+              path: 'README.md',
+              html_url: 'https://github.com/owner/repo/blob/main/README.md',
+            },
+          ],
         }),
       });
 
-      const result = await handleRepoUrl('https://github.com/owner/repo', hooks());
+      const result = await handleRepoUrl(
+        'https://github.com/owner/repo',
+        hooks()
+      );
       expect(result).toBe(true);
 
       const modal = document.getElementById('repo-browser-modal');


### PR DESCRIPTION
Follow-up to #178, resolving both unresolved review threads (single commit — squash or rebase both fine):

**1. CodeQL alert #10 — "Incomplete URL substring sanitization"** (`tests/unit/desktopRenderer.test.js`)
The flagged line was a Jest assertion on a mocked `fetch` (no user input, no sanitization decision), but the substring check kept the alert open and failed the CodeQL check on #178. The assertion now uses `startsWith('https://api.github.com/')` — behavior-equivalent for the test, satisfies the rule, and the alert closes on merge.

**2. Copilot finding — repo-browser backdrop listener stacking** (`markdown-viewer/src/features/repo-browser.js`)
`showRepoBrowser()` re-bound a backdrop `click` listener on the reused `#repo-browser-modal` element every open, accumulating handlers and retained focus-trap closures. The backdrop listener is now bound once at modal creation and delegates through a module-level active-close ref; re-opening while already open also releases the previous focus trap before the `innerHTML` rebuild orphans it. New regression test covers repeated opens + backdrop close + reuse.

**Verification:** 483/483 tests, typecheck clean, lint 0 errors/0 warnings (enforced), Vite build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJevc3MKJ1Hjv8UazJAbhF

---
_Generated by [Claude Code](https://claude.ai/code/session_01YJevc3MKJ1Hjv8UazJAbhF)_