### PR TITLE
Docs: sync AGENTS.md and README with current toolchain and features

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,13 +32,18 @@ When working with this repo, read and follow `CLAUDE.md` for:
   build output in `markdown-viewer/dist/`, so `npm run build` must run before
   packaging desktop or iOS. `dist/` is git-ignored and built in CI.
 - **ESLint + Prettier are configured** (`eslint.config.js`, `.prettierrc.json`).
-  `npm run lint` must be clean; it runs in CI alongside the tests
-  (`.github/workflows/ci.yml`). A repo-wide Prettier reformat of the legacy
-  `main.js`/`styles.css` is intentionally deferred to the upcoming internal
-  module split to avoid churn — see `docs/project-modernization/`.
+  `npm run lint` runs with `--max-warnings=0` in CI (`.github/workflows/ci.yml`),
+  so warnings fail the build — keep it at zero. A whole-file Prettier reformat
+  of `markdown-viewer/styles.css` (still not Prettier-conforming) is
+  intentionally avoided: it would bury real changes in ~1,700 lines of
+  formatting noise. Format only the files you touch.
 - **Lockfile committed.** `package-lock.json` is committed; CI uses `npm ci`.
   Use `npm install` locally when adding/upgrading dependencies.
 - **Node.js >=22.12 required** (specified in `package.json` engines).
 - **Electron desktop app** cannot run in headless Cloud Agent environments (needs a display). Test the shared viewer code via Jest, or `npm run dev` / `npm run preview` in a browser.
-- **Coverage thresholds** are not enforced via config, but `npm run test:coverage` will show coverage percentages.
+- **Coverage thresholds**: a hard `coverageThreshold` is enforced for
+  `desktop/main.js` (the only file Jest instruments directly). Renderer modules
+  under `markdown-viewer/src/` report ~0% because `tests/helpers/loadApp.js`
+  evals the module graph outside Jest's instrumentation — don't trust those
+  numbers or add renderer thresholds (see CLAUDE.md).
 - To test markdown rendering interactively, inject markdown via JS in the browser console (simulate drag-and-drop with `DragEvent` + `DataTransfer` on `#drop-zone`).

--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ a **desktop app** (macOS / Windows / Linux), and as an **iOS / iPadOS** app.
 - **Drag & drop** or **browse** for `.md` / `.markdown` files
 - **Open from URL**, including **GitHub repo browsing** (paste a repo URL and pick a file)
 - **Recent files** list for one-click re-open; **session restore** reopens your last doc on the web
-- **Workspace (folder) mode** (desktop) — open a folder, browse its markdown in a
-  sidebar, and follow relative `.md` links between documents
+- **Workspace (folder) mode** — open a folder (desktop picker, or drag a folder
+  onto the web app in Chromium), browse its markdown in a sidebar, and follow
+  relative `.md` links between documents
 - **Live file watching** (desktop) — auto-reload when a watched file changes on disk
 
 ### Navigation & UX
@@ -90,9 +91,11 @@ does not produce a distributable build.)
 | Shortcut | Action |
 |---|---|
 | `Cmd/Ctrl + K` | Command palette |
-| `Cmd/Ctrl + F` | Find in document |
+| `Cmd/Ctrl + F` | Find in document (`Enter` / `Shift+Enter` next / previous match) |
 | `Cmd/Ctrl + P` | Print / Save as PDF |
 | `?` | Keyboard shortcut sheet |
+| `← →` | Previous / next diagram (presentation mode) |
+| `+ − 0` | Zoom in / out / fit (presentation & fullscreen) |
 | Mouse wheel over a diagram | Zoom |
 | Drag a diagram | Pan |
 | `Esc` | Exit fullscreen / close overlays |


### PR DESCRIPTION
Recovers the docs-sync commit that was stranded when #180 was squash-merged while it was being pushed (the exact trap documented in CLAUDE.md's merge discipline — recovered per that procedure: fresh branch off `main`, cherry-picked orphan). Single commit.

- **AGENTS.md** — two stale claims corrected: coverage thresholds ARE now enforced (for `desktop/main.js` only; renderer numbers are untrustworthy under the eval harness, pointer to CLAUDE.md), and the "Prettier reformat deferred to the module split" note is replaced with the current rule (lint gated at `--max-warnings=0`; never whole-file-reformat `styles.css`, format only touched files).
- **README** — workspace mode also works on the web (drag a folder onto the app in Chromium), and the shortcuts table gains search next/previous plus presentation-mode navigation/zoom keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJevc3MKJ1Hjv8UazJAbhF

---
_Generated by [Claude Code](https://claude.ai/code/session_01YJevc3MKJ1Hjv8UazJAbhF)_