### PR TITLE
Docs: address Copilot review nits from #181 (real '-' key, precise coverage wording)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,9 @@ When working with this repo, read and follow `CLAUDE.md` for:
 - **Node.js >=22.12 required** (specified in `package.json` engines).
 - **Electron desktop app** cannot run in headless Cloud Agent environments (needs a display). Test the shared viewer code via Jest, or `npm run dev` / `npm run preview` in a browser.
 - **Coverage thresholds**: a hard `coverageThreshold` is enforced for
-  `desktop/main.js` (the only file Jest instruments directly). Renderer modules
+  `desktop/main.js` — the only file the tests both instrument and actually
+  exercise (other globs in `collectCoverageFrom`, like `desktop/preload.js`,
+  are collected but never required by tests). Renderer modules
   under `markdown-viewer/src/` report ~0% because `tests/helpers/loadApp.js`
   evals the module graph outside Jest's instrumentation — don't trust those
   numbers or add renderer thresholds (see CLAUDE.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,8 @@ scripts and the CI workflows do this for you).
 Tests, lint, and typecheck must pass before committing; all three run in CI on
 every PR (`.github/workflows/ci.yml`). Coverage is reported by
 `npm run test:coverage`. A hard `coverageThreshold` is enforced for
-`desktop/main.js` (the only file Jest instruments directly). Renderer modules
+`desktop/main.js` — the only file the tests both instrument and actually
+exercise, so the only one a threshold can honestly gate. Renderer modules
 under `markdown-viewer/src/` show ~0% in coverage reports because the test
 helper (`tests/helpers/loadApp.js`) inlines and evals the module graph outside
 Jest's instrumentation — don't trust those numbers, and don't add renderer

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ does not produce a distributable build.)
 | `Cmd/Ctrl + P` | Print / Save as PDF |
 | `?` | Keyboard shortcut sheet |
 | `← →` | Previous / next diagram (presentation mode) |
-| `+ − 0` | Zoom in / out / fit (presentation & fullscreen) |
+| `+ - 0` | Zoom in / out / fit (presentation & fullscreen) |
 | Mouse wheel over a diagram | Zoom |
 | Drag a diagram | Pan |
 | `Esc` | Exit fullscreen / close overlays |

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ does not produce a distributable build.)
 | `Cmd/Ctrl + P` | Print / Save as PDF |
 | `?` | Keyboard shortcut sheet |
 | `← →` | Previous / next diagram (presentation mode) |
-| `+ - 0` | Zoom in / out / fit (presentation & fullscreen) |
+| `+` (or `=`) / `-` / `0` | Zoom in / out / fit (presentation & fullscreen) |
 | Mouse wheel over a diagram | Zoom |
 | Drag a diagram | Pan |
 | `Esc` | Exit fullscreen / close overlays |


### PR DESCRIPTION
Implements both Copilot suggestions from #181 (single commit):

- **README** shortcuts table now documents the actual ASCII `-` key (`e.key === '-'`) instead of the typographic Unicode minus `−` the app never receives.
- **AGENTS.md / CLAUDE.md** coverage wording made precise: `desktop/main.js` is the only file the tests both instrument *and* exercise — `collectCoverageFrom` also collects files like `desktop/preload.js`, which simply report 0% — rather than "the only file Jest instruments directly".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJevc3MKJ1Hjv8UazJAbhF

---
_Generated by [Claude Code](https://claude.ai/code/session_01YJevc3MKJ1Hjv8UazJAbhF)_