### PR TITLE
Add portable SpecDown Xcode skill

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,11 @@
+# Codex skills
+
+This directory contains repository-managed Codex skills. To use one on another
+machine, copy its folder into the local Codex skills directory:
+
+```bash
+mkdir -p ~/.codex/skills
+cp -R skills/specdown-xcode ~/.codex/skills/
+```
+
+Restart or open a new Codex task after copying so the skill is discovered.

--- a/skills/specdown-xcode/SKILL.md
+++ b/skills/specdown-xcode/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: specdown-xcode
+description: Use when updating the local SpecDown repo before iOS/Xcode work, deciding whether dependencies, Vite assets, XcodeGen, xcodebuild, or code signing steps are required, or offering the user safe options for preparing the iOS app.
+---
+
+# SpecDown Xcode
+
+## Overview
+
+Use this for SpecDown repo updates that feed the iOS app. Keep user work safe, pull the latest `main`, inspect what changed, then offer or run only the steps that are actually needed.
+
+## Safety Rules
+
+- Work in `/Users/chrisbremer/code/specdown` unless the user explicitly gives another path.
+- Read `AGENTS.md` and `CLAUDE.md` before actions.
+- Check `git status --short --branch` before pulling. If local changes exist, preserve them with a named stash or ask before proceeding.
+- If the only local change is `package-lock.json`, inspect its diff before stopping. If it is clearly generated-only drift (for example npm metadata, peer/optional flags, platform entries, or lockfile-version alignment) with no dependency-spec changes, report that finding and offer to restore only `package-lock.json` before pulling. Never restore it without the user's approval.
+- Treat source, manifest (`package.json`), iOS, or mixed-file changes as potentially intentional work: preserve them with a named stash or ask before pulling.
+- Pull with `git pull --ff-only` on `main`; avoid merge commits.
+- Use approval for network installs or Xcode commands when sandboxing blocks them.
+- Do not run `xcodegen generate` unless the changed paths require it or the user asks for a full refresh.
+- Never report web preparation as complete solely because commands were invoked. Verify that Vite is installed, the build exits successfully, and the generated bundle contains the current `package.json` version before opening Xcode or reporting success.
+
+## Workflow
+
+1. Capture the starting commit:
+   ```bash
+   before=$(git rev-parse HEAD)
+   ```
+2. Inspect local changes before updating. If `package-lock.json` is the only changed file, inspect it first:
+   ```bash
+   git diff -- package-lock.json
+   ```
+   If it is generated-only drift, offer to restore it; otherwise preserve local work with a named stash or ask before proceeding.
+3. Update latest code:
+   ```bash
+   git checkout main
+   git pull --ff-only
+   after=$(git rev-parse HEAD)
+   ```
+4. Analyze changed paths:
+   ```bash
+   python3 ~/.codex/skills/specdown-xcode/scripts/recommend_steps.py "$before" "$after"
+   ```
+5. Present the recommendation and ask the user which option to run unless they already requested automation.
+6. Run chosen steps and report exact commands and outcomes.
+
+## Decision Rules
+
+- **No changes pulled**: no rebuild is required.
+- **`package.json` or `package-lock.json` changed**: run `npm install` before builds.
+- **`markdown-viewer/`, `vite.config.js`, or bundled static assets changed**: run `npm run build`.
+- **`ios/project.yml` changed**: run `cd ios && xcodegen generate`.
+- **Swift, iOS resources, `ios/project.yml`, or web assets changed and user wants validation**: run the iOS simulator build.
+- **Only docs, README, changelog, desktop config, or non-iOS build assets changed**: no iOS build is required unless the user wants verification.
+
+## User Options
+
+When changes are present, offer concise choices:
+
+- `minimal`: install dependencies and rebuild web assets only when required.
+- `project refresh`: run `xcodegen generate` only when required.
+- `simulator build`: run required prep plus `xcodebuild` for iOS Simulator.
+- `signed/device build`: attempt signing/device-oriented build only when the user asks; explain that credentials/profiles may be machine-dependent.
+- `status only`: report what changed and what would be needed without running more commands.
+
+## Commands
+
+Web prep:
+```bash
+npm install
+test -x node_modules/.bin/vite
+npm run build
+app_version=$(node -p "require('./package.json').version")
+rg -Fq "$app_version" markdown-viewer/dist/assets
+```
+
+If any command fails, stop and report it. Do not install the iOS app from a
+stale `markdown-viewer/dist` bundle. The Xcode project packages that directory
+into the app, so a version mismatch means the installed app will remain old.
+
+XcodeGen:
+```bash
+cd ios && xcodegen generate
+```
+
+Simulator build:
+```bash
+cd ios && xcodebuild -project SpecDown.xcodeproj -scheme SpecDown -destination 'generic/platform=iOS Simulator' build CODE_SIGNING_ALLOWED=NO
+```
+
+Signing check, when requested:
+```bash
+cd ios && xcodebuild -project SpecDown.xcodeproj -scheme SpecDown -showBuildSettings | rg 'CODE_SIGN|DEVELOPMENT_TEAM|PRODUCT_BUNDLE_IDENTIFIER|PROVISIONING'
+```
+
+## Reporting
+
+End with:
+
+- Pulled commit/tag.
+- Whether `npm install`, `npm run build`, `xcodegen generate`, or `xcodebuild` was required and whether each was run.
+- For web preparation, whether `node_modules/.bin/vite` existed and the built bundle contained the expected package version.
+- Any dirty worktree changes created by local tooling, especially `package-lock.json`.
+- The preserved stash name if local work was stashed.

--- a/skills/specdown-xcode/agents/openai.yaml
+++ b/skills/specdown-xcode/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SpecDown Xcode"
+  short_description: "Update SpecDown and prepare iOS builds"
+  default_prompt: "Use $specdown-xcode to update SpecDown and tell me what iOS build steps are needed."

--- a/skills/specdown-xcode/scripts/recommend_steps.py
+++ b/skills/specdown-xcode/scripts/recommend_steps.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Recommend SpecDown iOS prep steps from a git diff range."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def changed_paths(before: str, after: str) -> list[str]:
+    result = subprocess.run(
+        ["git", "diff", "--name-only", f"{before}..{after}"],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def matches(path: str, prefixes: tuple[str, ...] = (), names: tuple[str, ...] = ()) -> bool:
+    return path in names or any(path.startswith(prefix) for prefix in prefixes)
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 3:
+        print("usage: recommend_steps.py <before-commit> <after-commit>", file=sys.stderr)
+        return 2
+
+    before, after = argv[1], argv[2]
+    paths = changed_paths(before, after)
+
+    deps = any(matches(p, names=("package.json", "package-lock.json")) for p in paths)
+    web = any(
+        matches(
+            p,
+            prefixes=("markdown-viewer/",),
+            names=("vite.config.js", "package.json", "package-lock.json"),
+        )
+        for p in paths
+    )
+    xcodegen = any(matches(p, names=("ios/project.yml",)) for p in paths)
+    ios_native = any(matches(p, prefixes=("ios/",)) for p in paths)
+    ios_build = web or ios_native
+
+    print(f"Changed files: {len(paths)}")
+    for path in paths:
+        print(f"- {path}")
+
+    print("\nRecommended steps:")
+    print(f"- npm install: {'yes' if deps else 'no'}")
+    print(f"- npm run build: {'yes' if web else 'no'}")
+    print(f"- xcodegen generate: {'yes' if xcodegen else 'no'}")
+    print(f"- iOS simulator build: {'yes' if ios_build else 'optional'}")
+
+    if not paths:
+        print("\nReason: no changes between the provided commits.")
+    elif xcodegen:
+        print("\nReason: ios/project.yml changed, so regenerate SpecDown.xcodeproj.")
+    elif web and not ios_native:
+        print("\nReason: web assets changed; rebuild dist before running the iOS app. XcodeGen is not required.")
+    elif ios_native:
+        print("\nReason: iOS native files changed; XcodeGen is only required if ios/project.yml changed.")
+    else:
+        print("\nReason: changes do not affect the iOS app build inputs.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
## What changed

- Add a repository-managed `specdown-xcode` Codex skill, including its recommendation script and UI metadata.
- Document how to copy the skill into `~/.codex/skills` on another machine.
- Include safe handling for generated-only `package-lock.json` drift.

## Why

The local skill directory is not version-controlled, so this makes the workflow portable and reviewable with SpecDown.

## Validation

- Ran the recommendation script against `HEAD..HEAD`.
- Compiled the Python script successfully.
- Checked the staged diff for whitespace errors.

The pre-existing local `package-lock.json` change is not part of this PR.