### PR TITLE
diagrams: render inline as static content, move interactivity to fullscreen

### DIFF
--- a/docs/project-bugfix-wave/2026-07-22-brainstorm-diagram-inline-static-ux.md
+++ b/docs/project-bugfix-wave/2026-07-22-brainstorm-diagram-inline-static-ux.md
@@ -1,0 +1,82 @@
+# Brainstorm: Inline Mermaid Diagrams Should Read Like Document Content
+
+**Date:** 2026-07-22
+**Trigger:** User feedback — SpecDown documents with diagrams are harder to read
+than the same markdown in VS Code's preview, where diagrams render "normally"
+with only minimal zoom controls. "Maybe there needs to be a control that's
+invoked, otherwise they look normal."
+
+## Problem
+
+Every mermaid diagram rendered as a heavy interactive widget:
+
+1. **Fixed 500px-tall card** (`.diagram-wrapper { height: 500px }`). A tiny
+   3-node flowchart floated in mostly-empty space; a large sequence diagram was
+   shrunk until its text was illegible. Diagram size had no relationship to
+   diagram content.
+2. **Always-visible 8-control toolbar** (zoom ±, % readout, slider, reset, SVG,
+   PNG, share, fullscreen) floating over every diagram — heavy chrome competing
+   with the document, multiplied by every diagram on the page.
+3. **Always-armed panzoom.** Mouse-wheeling past a diagram hijacked page scroll
+   into a zoom; touch scrolls could become accidental pans (the classic
+   embedded-Google-Maps problem).
+
+Net effect: documents read like control panels, not documents.
+
+## Options considered
+
+- **A. Static-by-default, explore-on-demand** — diagrams render as plain
+  content; one subtle affordance opens the existing fullscreen overlay where
+  all interactivity lives.
+- **B. Click-to-activate in place** (Google Maps embed pattern) — static until
+  clicked, then panzoom arms inline. Keeps document context but retains most of
+  the inline machinery and adds a per-diagram modal state.
+- **C. Conservative cleanup** — keep inline interactivity; content-based
+  height, hover-reveal slimmed toolbar, Ctrl+wheel to zoom. Least change, but
+  diagrams stay widgets.
+- **D. Size-aware hybrid** — small diagrams get zero chrome; only diagrams that
+  had to be scaled down get a discoverable explore affordance.
+- **E. Global "diagram interactivity" setting** — rejected as primary fix
+  (settings are where UX debt hides); could be a later escape hatch.
+
+## Decision: A + D
+
+Inline diagrams are **static document content**: natural size (intrinsic pixel
+size from the SVG viewBox), capped at the column width and 70vh by CSS, no
+toolbar, no panzoom, wheel scrolls the page. All interactive machinery —
+zoom/pan, slider, reset, minimap, SVG/PNG export, share, keyboard shortcuts —
+lives in the **existing fullscreen overlay**, opened by a single expand button.
+
+Size-aware discoverability:
+
+- Diagrams that fit at natural size: expand button revealed on hover /
+  keyboard focus only. Zero chrome while reading.
+- Diagrams scaled down by the caps (`diagram-scaled` class, recomputed on
+  resize): expand button always visible, `zoom-in` cursor, and
+  **click-anywhere opens fullscreen** — a scaled diagram is by definition not
+  fully readable, so the click matches intent.
+- Touch devices (`pointer: coarse`): button always visible and tap-anywhere
+  opens fullscreen (hover doesn't exist; aligns with the mobile
+  fullscreen-first recommendation in
+  [`../2026-05-25-mermaid-navigation-recommendations.md`](../2026-05-25-mermaid-navigation-recommendations.md)).
+
+Click-anywhere is deliberately **not** universal on desktop: small diagrams are
+fully readable inline, and a universal click would steal text selection inside
+`foreignObject` labels and punish casual clicks.
+
+## Consequences
+
+- Inline panzoom, the inline toolbar, per-diagram wheel/dblclick handlers, and
+  `state.currentPanzoomInstances` (plus its cleanup plumbing through main.js,
+  tabs.js, view-mode.js) are deleted.
+- The fullscreen overlay gains the previously inline-only **share** button.
+- The print path is nearly untouched (it already re-renders from
+  `data-mermaid-source` and neutralizes sizing); only the chrome-strip selector
+  changed to `.diagram-expand`.
+- The two earlier bugfix sessions in this folder (controls overlapping the
+  diagram on phones; double-tap zoom on control buttons) are largely obsoleted
+  by removing the inline controls — the `touch-action: manipulation` guard
+  carries over to the expand button.
+
+Implementation checklist:
+[`2026-07-22-tasks-session-05-diagram-inline-static-ux.md`](2026-07-22-tasks-session-05-diagram-inline-static-ux.md)

--- a/docs/project-bugfix-wave/2026-07-22-tasks-session-05-diagram-inline-static-ux.md
+++ b/docs/project-bugfix-wave/2026-07-22-tasks-session-05-diagram-inline-static-ux.md
@@ -1,0 +1,56 @@
+# Tasks — Session 05: Static Inline Diagrams, Explore on Demand
+
+**Date:** 2026-07-22
+**Decision doc:**
+[`2026-07-22-brainstorm-diagram-inline-static-ux.md`](2026-07-22-brainstorm-diagram-inline-static-ux.md)
+
+## Checklist
+
+- [x] `markdown-viewer/src/features/diagrams.js`
+  - [x] Delete `initializePanzoom` (inline Panzoom, wheel/dblclick handlers,
+        8-button toolbar wiring) and `cleanupPanzoomInstances`
+  - [x] `createDiagramContainer`: single `.diagram-expand` button; new
+        `prepareInlineDiagramSvg` sets intrinsic pixel width/height from the
+        viewBox and clears mermaid's inline `max-width` style (viewBox kept —
+        export/minimap/fullscreen/print rely on it)
+  - [x] New `initializeInlineDiagram`: expand-button click → `openFullscreen`;
+        wrapper click → fullscreen only when `diagram-scaled` or coarse
+        pointer; listeners bound once per container (`data-inline-wired`
+        guard survives theme re-renders)
+  - [x] New `markDiagramScaledState` + debounced window-resize recompute;
+        `clientWidth === 0` (pre-layout/jsdom) leaves state untouched
+  - [x] `reRenderMermaidDiagrams` routes through the same prepare/init path
+- [x] Fullscreen overlay gains the share button
+      (`markdown-viewer/index.html` + `setupFullscreenControls`)
+- [x] Caller cleanup: `main.js`, `tabs.js`, `view-mode.js` drop the
+      `cleanupPanzoom` plumbing; `core/state.js` drops
+      `currentPanzoomInstances`
+- [x] `markdown-viewer/styles.css`
+  - [x] `.diagram-container` de-carded (no border/background/shadow/overflow)
+  - [x] `.diagram-wrapper`: fixed 500px height removed; SVG capped at
+        `max-width: 100%` / `max-height: 70vh`, centered
+  - [x] `.diagram-expand`: hover/focus-visible reveal; always visible when
+        `.diagram-scaled` or `(pointer: coarse)`; `prefers-reduced-motion`
+        respected; `touch-action: manipulation` kept
+  - [x] Mobile media query: static toolbar-row rules deleted
+  - [x] Print fallback + `.ios-native` selectors updated to `.diagram-expand`;
+        print overrides the 70vh cap
+- [x] `src/platform/ios-chrome.js`: `buildPrintableDocument` strips
+      `.diagram-expand`
+- [x] Tests
+  - [x] `tests/integration/mermaid.test.js`: inline-panzoom suites replaced
+        with inline-affordance + `markDiagramScaledState` suites; fullscreen
+        share covered; generation-guard tests keep DOM-only assertions
+  - [x] `tests/integration/markdown.test.js`, `tests/unit/printing.test.js`,
+        `tests/unit/presentation.test.js` fixtures updated to the new DOM
+- [x] `npm test` (530 passing), `npm run lint`, `npm run typecheck`,
+      `npm run build` all clean
+
+## Manual verification notes
+
+- Small diagram: natural size, no chrome until hover; wheel scrolls the page.
+- Oversized diagram: capped, `zoom-in` cursor, always-visible expand button,
+  click-anywhere opens fullscreen.
+- Fullscreen: zoom/slider/reset/minimap/export/share/Esc/`+ - 0` unchanged.
+- Theme toggle, `?diagram=` share links, and print (light re-render from dark)
+  verified against the unchanged `data-mermaid-source` path.

--- a/docs/project-bugfix-wave/README.md
+++ b/docs/project-bugfix-wave/README.md
@@ -13,6 +13,8 @@ folder tracks the smaller fixes that follow.
 | 2026-06-21 | [tasks-session-02](2026-06-21-tasks-session-02-diagram-double-tap-zoom.md) | Double-tap on a diagram zoom button zoomed the whole page instead of the diagram |
 | 2026-06-21 | [tasks-session-03](2026-06-21-tasks-session-03-jsyaml-dos-advisory.md) | Cleared the js-yaml DoS Dependabot advisory (dev-only transitive) via a scoped override |
 | 2026-06-22 | [tasks-session-04](2026-06-22-tasks-session-04-ios-present-action-sheet.md) | Presentation mode was unreachable on iPhone — added a Present entry to the iOS action sheet |
+| 2026-07-22 | [brainstorm-diagram-inline-static-ux](2026-07-22-brainstorm-diagram-inline-static-ux.md) | Diagrams read like control panels — options + decision to render them as static document content |
+| 2026-07-22 | [tasks-session-05](2026-07-22-tasks-session-05-diagram-inline-static-ux.md) | Static inline diagrams: fixed 500px card + 8-button toolbar + always-armed panzoom replaced by natural-size rendering with an on-demand fullscreen explore mode |
 
 ## Status
 

--- a/markdown-viewer/index.html
+++ b/markdown-viewer/index.html
@@ -262,6 +262,7 @@
                     <button class="reset" title="Reset view" aria-label="Reset view"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"/></svg></button>
                     <button class="export-svg" title="Download as SVG">SVG</button>
                     <button class="export-png" title="Download as PNG">PNG</button>
+                    <button class="share-diagram" title="Copy shareable link" aria-label="Copy shareable link"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg></button>
                     <button class="close-fullscreen" title="Exit fullscreen (ESC)" aria-label="Exit fullscreen"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></button>
                 </div>
                 <div class="fullscreen-diagram-wrapper"></div>

--- a/markdown-viewer/samples/diagram-showcase.md
+++ b/markdown-viewer/samples/diagram-showcase.md
@@ -1,9 +1,10 @@
 # Diagram Showcase
 
 A test document packed with **every major Mermaid diagram type** — handy for
-exercising SpecDown's diagram features: per-diagram zoom/pan, fullscreen with
-minimap, SVG/PNG export, share links, theme re-rendering, and **presentation
-mode** (hit *Present* and step through with `←` / `→`).
+exercising SpecDown's diagram features: inline diagrams that expand into a
+fullscreen explorer with zoom/pan, minimap, SVG/PNG export, and share links,
+plus theme re-rendering and **presentation mode** (hit *Present* and step
+through with `←` / `→`).
 
 Between the diagrams there's ordinary markdown — headings for the table of
 contents, a table, and a code block — so this file also works as a general
@@ -13,7 +14,7 @@ smoke-test document.
 
 ## 1. Flowchart — system architecture
 
-The classic. Drag to pan, scroll to zoom, double-click to reset.
+The classic. Expand it to zoom, pan, and explore.
 
 ```mermaid
 graph TD

--- a/markdown-viewer/src/core/state.js
+++ b/markdown-viewer/src/core/state.js
@@ -30,7 +30,6 @@
 
 /**
  * @typedef {object} AppState
- * @property {any[]} currentPanzoomInstances Active panzoom instances to clean up.
  * @property {'light' | 'dark'} currentTheme The resolved, applied theme.
  * @property {'light' | 'dark' | 'auto'} themePreference User choice; 'auto' follows the OS.
  * @property {string} currentRawMarkdown Raw source of the active document.
@@ -48,7 +47,6 @@
 /** @type {AppState} */
 export const state = {
   // Render / view
-  currentPanzoomInstances: [],
   // `themePreference` is the persisted user choice (light/dark/auto);
   // `currentTheme` is the resolved theme that's actually applied, set by
   // setupTheme() at init (an 'auto' preference resolves via prefers-color-scheme).

--- a/markdown-viewer/src/features/diagrams.js
+++ b/markdown-viewer/src/features/diagrams.js
@@ -1,7 +1,6 @@
 // @ts-check
 import Panzoom from '@panzoom/panzoom';
 import DOMPurify from 'dompurify';
-import { state } from '../core/state.js';
 import { isIOSNative } from '../core/platform.js';
 import { getSvgNaturalDimensions } from '../core/utils.js';
 import { iconSvg } from '../core/icons.js';
@@ -86,8 +85,8 @@ export async function processMermaidDiagrams() {
             // Replace pre/code block with diagram container
             if (preElement) preElement.replaceWith(container);
 
-            // Initialize panzoom for this diagram
-            initializePanzoom(diagramId);
+            // Wire the expand affordance and scaled-state detection
+            initializeInlineDiagram(diagramId);
 
         } catch (error) {
             console.error('Error rendering mermaid diagram:', error);
@@ -113,22 +112,14 @@ function createDiagramContainer(svg, diagramId, mermaidSource) {
     container.className = 'diagram-container';
     container.setAttribute('data-diagram-id', diagramId);
 
-    // Create controls
-    const controls = document.createElement('div');
-    controls.className = 'diagram-controls';
-    controls.innerHTML = `
-        <button class="zoom-in" title="Zoom in">+</button>
-        <button class="zoom-out" title="Zoom out">-</button>
-        <label class="zoom-range-label" title="Zoom level">
-            <span class="zoom-percent">100%</span>
-            <input class="zoom-range" type="range" min="25" max="400" value="100" step="5" aria-label="Diagram zoom level">
-        </label>
-        <button class="reset" title="Reset view" aria-label="Reset view">${iconSvg('rotate-ccw')}</button>
-        <button class="export-svg" title="Download as SVG">SVG</button>
-        <button class="export-png" title="Download as PNG">PNG</button>
-        <button class="share-diagram" title="Copy shareable link" aria-label="Copy shareable link">${iconSvg('link')}</button>
-        <button class="fullscreen" title="Fullscreen" aria-label="Open fullscreen">${iconSvg('maximize')}</button>
-    `;
+    // Single affordance: inline diagrams are static document content, and all
+    // interactive machinery (zoom/pan, export, share, minimap) lives in the
+    // fullscreen overlay this button opens.
+    const expandBtn = document.createElement('button');
+    expandBtn.className = 'diagram-expand';
+    expandBtn.title = 'Expand diagram';
+    expandBtn.setAttribute('aria-label', 'Expand diagram (opens interactive view)');
+    expandBtn.innerHTML = iconSvg('maximize');
 
     // Create wrapper
     const wrapper = document.createElement('div');
@@ -146,11 +137,31 @@ function createDiagramContainer(svg, diagramId, mermaidSource) {
     if (svgEl && mermaidSource) {
         svgEl.setAttribute('data-mermaid-source', mermaidSource);
     }
+    prepareInlineDiagramSvg(svgEl);
 
-    container.appendChild(controls);
+    container.appendChild(expandBtn);
     container.appendChild(wrapper);
 
     return container;
+}
+
+/**
+ * Normalize a freshly rendered mermaid SVG for static inline layout: read the
+ * natural size first (viewBox preferred, attrs as fallback), then strip
+ * mermaid's inline style (its max-width) and set intrinsic pixel width/height
+ * attributes. Small diagrams then render at natural size while the stylesheet
+ * caps large ones at the column width / viewport height. The viewBox is left
+ * untouched — export, minimap, fullscreen fit, and print all rely on it.
+ * @param {SVGElement | null} svgEl
+ */
+function prepareInlineDiagramSvg(svgEl) {
+    if (!svgEl) return;
+    const dims = getSvgNaturalDimensions(svgEl);
+    svgEl.style.cssText = '';
+    if (dims) {
+        svgEl.setAttribute('width', String(dims.width));
+        svgEl.setAttribute('height', String(dims.height));
+    }
 }
 
 // ===========================
@@ -223,119 +234,80 @@ export function updateZoomUI(panzoomInstance, controlsRoot) {
 }
 
 // ===========================
-// Panzoom Initialization
+// Inline Diagram Wiring
 // ===========================
+const hasCoarsePointer = () =>
+    typeof window.matchMedia === 'function' && window.matchMedia('(pointer: coarse)').matches;
+
+/**
+ * Mark containers whose diagram had to be scaled down by the stylesheet caps
+ * (column width / viewport height). Scaled diagrams are not fully readable
+ * inline, so they get an always-visible expand button, a zoom-in cursor, and
+ * click-anywhere-to-expand. A clientWidth of 0 means layout hasn't happened
+ * yet — leave the current state alone rather than guessing.
+ * @param {Element} container
+ */
+function markDiagramScaledState(container) {
+    const svgEl = container.querySelector('.diagram-wrapper svg');
+    if (!svgEl) return;
+    const dims = getSvgNaturalDimensions(/** @type {SVGElement} */ (svgEl));
+    if (!dims) return;
+    const shownWidth = svgEl.clientWidth;
+    const shownHeight = svgEl.clientHeight;
+    if (!shownWidth) return;
+    const scaledDown = shownWidth + 1 < dims.width || shownHeight + 1 < dims.height;
+    container.classList.toggle('diagram-scaled', scaledDown);
+}
+
+let diagramResizeListenerInstalled = false;
+/** @type {ReturnType<typeof setTimeout> | undefined} */
+let diagramResizeRecalcTimer;
+
+// Window resizes move diagrams across the fits/doesn't-fit threshold, so the
+// scaled state (and with it the expand affordance) is recomputed, debounced.
+function installDiagramResizeListener() {
+    if (diagramResizeListenerInstalled) return;
+    diagramResizeListenerInstalled = true;
+    window.addEventListener('resize', () => {
+        clearTimeout(diagramResizeRecalcTimer);
+        diagramResizeRecalcTimer = setTimeout(() => {
+            document
+                .querySelectorAll('#markdown-content .diagram-container')
+                .forEach((container) => markDiagramScaledState(container));
+        }, 150);
+    });
+}
+
 /** @param {string} diagramId */
-function initializePanzoom(diagramId) {
+function initializeInlineDiagram(diagramId) {
     const wrapper = document.getElementById(`wrapper-${diagramId}`);
     if (!wrapper) return;
-
-    const svgElement = wrapper.querySelector('svg');
-    if (!svgElement) return;
-
-    // Initialize panzoom with wide scale range for free navigation
-    const panzoomInstance = Panzoom(svgElement, {
-        maxScale: 10,
-        minScale: 0.1,
-        step: 0.2,
-        cursor: 'grab'
-    });
-
-    // Use a mutable state object so reset always uses the latest fit values.
-    // Initial fit runs immediately; a deferred fit via requestAnimationFrame
-    // recalculates after the browser has laid out the container (in case
-    // clientWidth/Height weren't available synchronously).
-    const instanceState = {
-        homeState: fitDiagramToContainer(wrapper, svgElement, panzoomInstance)
-    };
-    requestAnimationFrame(() => {
-        instanceState.homeState = fitDiagramToContainer(wrapper, svgElement, panzoomInstance);
-    });
-
-    // Store instance for cleanup
-    state.currentPanzoomInstances.push({
-        id: diagramId,
-        instance: panzoomInstance,
-        element: svgElement,
-        state: instanceState
-    });
-
-    // Get controls
-    const container = wrapper.closest('.diagram-container');
+    const container = /** @type {HTMLElement | null} */ (wrapper.closest('.diagram-container'));
     if (!container) return;
-    const controls = container.querySelector('.diagram-controls');
-    if (!controls) return;
-    const zoomInBtn = controls.querySelector('.zoom-in');
-    const zoomOutBtn = controls.querySelector('.zoom-out');
-    const zoomRange = controls.querySelector('.zoom-range');
-    const resetBtn = controls.querySelector('.reset');
-    const exportSvgBtn = controls.querySelector('.export-svg');
-    const exportPngBtn = controls.querySelector('.export-png');
-    const shareBtn = controls.querySelector('.share-diagram');
-    const fullscreenBtn = controls.querySelector('.fullscreen');
 
-    // Bind control events
-    on(zoomInBtn, 'click', (e) => {
-        e.stopPropagation();
-        panzoomInstance.zoomIn();
-        updateZoomUI(panzoomInstance, controls);
-    });
+    // Theme re-renders replace the wrapper's SVG but keep the container,
+    // wrapper, and button elements — bind their listeners only once.
+    if (container.dataset.inlineWired !== 'true') {
+        container.dataset.inlineWired = 'true';
 
-    on(zoomOutBtn, 'click', (e) => {
-        e.stopPropagation();
-        panzoomInstance.zoomOut();
-        updateZoomUI(panzoomInstance, controls);
-    });
+        on(container.querySelector('.diagram-expand'), 'click', (e) => {
+            e.stopPropagation();
+            openFullscreen(diagramId);
+        });
 
-    on(zoomRange, 'input', (e) => {
-        e.stopPropagation();
-        const target = /** @type {HTMLInputElement} */ (e.target);
-        const targetPercent = Number(target.value);
-        if (!isNaN(targetPercent)) {
-            panzoomInstance.zoom(targetPercent / 100);
-            updateZoomUI(panzoomInstance, controls);
-        }
-    });
+        // Click-anywhere opens fullscreen only where it matches intent: a
+        // scaled-down diagram (unreadable inline), or a touch device (no
+        // hover to reveal the button). Small readable diagrams keep normal
+        // click behavior, e.g. selecting label text.
+        on(wrapper, 'click', () => {
+            if (container.classList.contains('diagram-scaled') || hasCoarsePointer()) {
+                openFullscreen(diagramId);
+            }
+        });
+    }
 
-    on(resetBtn, 'click', (e) => {
-        e.stopPropagation();
-        resetToFit(panzoomInstance, instanceState.homeState);
-        updateZoomUI(panzoomInstance, controls);
-    });
-
-    on(exportSvgBtn, 'click', (e) => {
-        e.stopPropagation();
-        downloadDiagramSvg(diagramId);
-    });
-
-    on(exportPngBtn, 'click', (e) => {
-        e.stopPropagation();
-        downloadDiagramPng(diagramId);
-    });
-
-    on(shareBtn, 'click', (e) => {
-        e.stopPropagation();
-        shareDiagramLink(diagramId);
-    });
-
-    on(fullscreenBtn, 'click', (e) => {
-        e.stopPropagation();
-        openFullscreen(diagramId);
-    });
-
-    // Mouse wheel zoom
-    wrapper.addEventListener('wheel', (e) => {
-        e.preventDefault();
-        panzoomInstance.zoomWithWheel(e);
-        updateZoomUI(panzoomInstance, controls);
-    }, { passive: false });
-
-    // Double click to reset to fit
-    wrapper.addEventListener('dblclick', () => {
-        resetToFit(panzoomInstance, instanceState.homeState);
-        updateZoomUI(panzoomInstance, controls);
-    });
-    updateZoomUI(panzoomInstance, controls);
+    requestAnimationFrame(() => markDiagramScaledState(container));
+    installDiagramResizeListener();
 }
 
 // ===========================
@@ -429,6 +401,7 @@ function setupFullscreenControls(panzoomInstance, wrapper, fullscreenState) {
     const resetBtn = controls.querySelector('.reset');
     const exportSvgBtn = controls.querySelector('.export-svg');
     const exportPngBtn = controls.querySelector('.export-png');
+    const shareBtn = controls.querySelector('.share-diagram');
     const closeBtn = controls.querySelector('.close-fullscreen');
     if (!zoomInBtn || !zoomOutBtn || !resetBtn || !closeBtn) return;
 
@@ -440,6 +413,7 @@ function setupFullscreenControls(panzoomInstance, wrapper, fullscreenState) {
     const newZoomRangeLabel = zoomRangeLabel ? zoomRangeLabel.cloneNode(true) : null;
     const newExportSvg = exportSvgBtn ? exportSvgBtn.cloneNode(true) : null;
     const newExportPng = exportPngBtn ? exportPngBtn.cloneNode(true) : null;
+    const newShare = shareBtn ? shareBtn.cloneNode(true) : null;
     const newClose = closeBtn.cloneNode(true);
 
     zoomInBtn.replaceWith(newZoomIn);
@@ -448,6 +422,7 @@ function setupFullscreenControls(panzoomInstance, wrapper, fullscreenState) {
     if (zoomRangeLabel && newZoomRangeLabel) zoomRangeLabel.replaceWith(newZoomRangeLabel);
     if (exportSvgBtn && newExportSvg) exportSvgBtn.replaceWith(newExportSvg);
     if (exportPngBtn && newExportPng) exportPngBtn.replaceWith(newExportPng);
+    if (shareBtn && newShare) shareBtn.replaceWith(newShare);
     closeBtn.replaceWith(newClose);
 
     // Add new listeners
@@ -488,6 +463,11 @@ function setupFullscreenControls(panzoomInstance, wrapper, fullscreenState) {
     on(newExportPng, 'click', (e) => {
         e.stopPropagation();
         downloadDiagramPng(fsOverlay.diagramId || '');
+    });
+
+    on(newShare, 'click', (e) => {
+        e.stopPropagation();
+        shareDiagramLink(fsOverlay.diagramId || '');
     });
 
     on(newClose, 'click', (e) => {
@@ -556,20 +536,6 @@ export function closeFullscreen() {
 }
 
 // ===========================
-// Cleanup
-// ===========================
-export function cleanupPanzoomInstances() {
-    state.currentPanzoomInstances.forEach(({ instance }) => {
-        try {
-            instance.destroy();
-        } catch (error) {
-            console.error('Error destroying panzoom instance:', error);
-        }
-    });
-    state.currentPanzoomInstances = [];
-}
-
-// ===========================
 // Re-render Mermaid (for theme change)
 // ===========================
 export async function reRenderMermaidDiagrams() {
@@ -608,13 +574,6 @@ export async function reRenderMermaidDiagrams() {
             const { svg } = await mermaid.render(`${diagramId}-rerender`, mermaidCode);
             if (generation !== diagramRenderGeneration) return; // superseded mid-render
 
-            // Clean up old panzoom
-            const oldInstance = state.currentPanzoomInstances.find((p) => p.id === diagramId);
-            if (oldInstance) {
-                oldInstance.instance.destroy();
-                state.currentPanzoomInstances = state.currentPanzoomInstances.filter((p) => p.id !== diagramId);
-            }
-
             // Update wrapper content
             // Preserve Mermaid's label markup: allow <foreignObject> (HTML labels for
             // diagram types that use them) so DOMPurify does not strip the text.
@@ -628,9 +587,10 @@ export async function reRenderMermaidDiagrams() {
             if (newSvgElement) {
                 newSvgElement.setAttribute('data-mermaid-source', mermaidCode);
             }
+            prepareInlineDiagramSvg(newSvgElement);
 
-            // Re-initialize panzoom
-            initializePanzoom(diagramId);
+            // Refresh scaled-state detection for the re-themed SVG
+            initializeInlineDiagram(diagramId);
 
         } catch (error) {
             console.error('Error re-rendering mermaid diagram:', error);

--- a/markdown-viewer/src/features/tabs.js
+++ b/markdown-viewer/src/features/tabs.js
@@ -12,7 +12,7 @@
 import { state } from '../core/state.js';
 import { isDesktop } from '../core/platform.js';
 import { escapeHtml } from '../core/utils.js';
-import { cleanupPanzoomInstances, closeFullscreen } from './diagrams.js';
+import { closeFullscreen } from './diagrams.js';
 import { closeSearch } from './search.js';
 import { toggleToc } from './toc.js';
 import { toggleSplitView } from './split-view.js';
@@ -200,7 +200,6 @@ export async function switchTab(id) {
 
   renderTabBar();
   if (isDesktop) refreshWatchUI();
-  cleanupPanzoomInstances();
 
   const markdownContent = el('markdown-content');
   if (!markdownContent) return;
@@ -239,10 +238,6 @@ export async function closeTab(id) {
   // Stop watching before removing the tab
   if (isDesktop && closedTab.watching && closedTab.filePath) {
     endWatch(closedTab.filePath);
-  }
-
-  if (wasActive) {
-    cleanupPanzoomInstances();
   }
 
   state.tabs.splice(idx, 1);
@@ -287,7 +282,6 @@ export async function closeTab(id) {
 
 export function showDropZone() {
   // Cleanup
-  cleanupPanzoomInstances();
   closeFullscreen();
   closeSearch();
   closeIOSActionSheet();

--- a/markdown-viewer/src/features/view-mode.js
+++ b/markdown-viewer/src/features/view-mode.js
@@ -1,6 +1,6 @@
 // @ts-check
-// Preview / raw-markdown view toggle. The preview render and panzoom cleanup
-// live in the render core (main.js) and are supplied via configureViewMode.
+// Preview / raw-markdown view toggle. The preview render lives in the render
+// core (main.js) and is supplied via configureViewMode.
 
 import { state } from '../core/state.js';
 import { iconSvg } from '../core/icons.js';
@@ -11,16 +11,11 @@ const el = (/** @type {string} */ id) => document.getElementById(id);
 
 /** @type {(content: string, title: string) => void} */
 let renderPreview = () => {};
-/** @type {() => void} */
-let cleanupPanzoom = () => {};
 
-/** @param {{ renderMarkdown?: Function, cleanupPanzoom?: Function }} [deps] */
+/** @param {{ renderMarkdown?: Function }} [deps] */
 export function configureViewMode(deps) {
   if (deps && typeof deps.renderMarkdown === 'function') {
     renderPreview = /** @type {typeof renderPreview} */ (deps.renderMarkdown);
-  }
-  if (deps && typeof deps.cleanupPanzoom === 'function') {
-    cleanupPanzoom = /** @type {typeof cleanupPanzoom} */ (deps.cleanupPanzoom);
   }
 }
 
@@ -34,8 +29,6 @@ export function toggleViewMode() {
     if (state.tocVisible) {
       toggleToc(false);
     }
-    // Clean up panzoom before switching
-    cleanupPanzoom();
     // Show raw markdown in a pre/code block
     const escaped = state.currentRawMarkdown
       .replace(/&/g, '&amp;')

--- a/markdown-viewer/src/main.js
+++ b/markdown-viewer/src/main.js
@@ -40,7 +40,6 @@ import {
 } from './features/annotations.js';
 import {
   processMermaidDiagrams,
-  cleanupPanzoomInstances,
   reRenderMermaidDiagrams,
   closeFullscreen,
 } from './features/diagrams.js';
@@ -181,7 +180,6 @@ function init() {
     });
     configureViewMode({
         renderMarkdown: (/** @type {string} */ content, /** @type {string} */ title) => renderMarkdown(content, title),
-        cleanupPanzoom: () => cleanupPanzoomInstances(),
     });
     configureTabs({
         renderMarkdown: (/** @type {string} */ content, /** @type {string} */ title) => renderMarkdown(content, title),
@@ -418,9 +416,6 @@ function setupEventListeners() {
  */
 async function renderMarkdown(content, filename) {
     try {
-        // Clean up existing panzoom instances
-        cleanupPanzoomInstances();
-
         // Store raw markdown for toggle
         state.currentRawMarkdown = content;
         state.currentViewMode = 'preview';

--- a/markdown-viewer/src/platform/ios-chrome.js
+++ b/markdown-viewer/src/platform/ios-chrome.js
@@ -292,7 +292,7 @@ export async function buildPrintableDocument() {
   const printableContent = /** @type {HTMLElement} */ (markdownContent.cloneNode(true));
 
   printableContent
-    .querySelectorAll('.diagram-controls, .annotation-popover, .search-highlight, .search-highlight-current, .code-copy-btn')
+    .querySelectorAll('.diagram-expand, .annotation-popover, .search-highlight, .search-highlight-current, .code-copy-btn')
     .forEach((element) => element.remove());
   printableContent.querySelectorAll('.annotation-badge').forEach((badge) => badge.remove());
   printableContent.querySelectorAll('.has-annotation').forEach((element) => {

--- a/markdown-viewer/styles.css
+++ b/markdown-viewer/styles.css
@@ -1017,68 +1017,81 @@ body {
 /* ===========================
    Diagram Container
    =========================== */
+/* Inline diagrams are static document content: natural size, capped by the
+   column width and viewport height. All interactivity (zoom/pan, export,
+   share) lives in the fullscreen overlay opened by the expand button. */
 .diagram-container {
     position: relative;
     margin: 2em 0;
-    border: 1px solid var(--border-color);
-    border-radius: var(--radius-lg);
-    background-color: var(--bg-secondary);
-    overflow: hidden;
-    box-shadow: var(--shadow-md);
 }
 
-.diagram-controls {
+.diagram-expand {
     position: absolute;
-    top: 10px;
-    right: 10px;
-    display: flex;
-    gap: 5px;
+    top: 8px;
+    right: 8px;
     z-index: 10;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     background-color: var(--bg-primary);
-    padding: 5px;
-    border-radius: var(--radius-md);
-    box-shadow: var(--shadow-md);
-}
-
-.diagram-controls button {
-    background-color: var(--bg-tertiary);
     color: var(--text-primary);
     border: 1px solid var(--border-color);
-    padding: 0.5rem 0.75rem;
-    border-radius: var(--radius-sm);
-    font-size: 1rem;
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-md);
     cursor: pointer;
-    transition: var(--transition);
-    font-weight: 600;
     min-width: 44px;
     min-height: 44px;
-    /* A fast double-tap on a zoom button (e.g. +) was being read by mobile
-       Safari/WKWebView as the page's double-tap-to-zoom gesture, zooming the
-       whole interface. `manipulation` keeps tap/pan/pinch but drops double-tap
-       zoom on the control itself. */
+    opacity: 0;
+    transition: opacity 0.15s ease;
+    /* A fast double-tap was being read by mobile Safari/WKWebView as the
+       page's double-tap-to-zoom gesture, zooming the whole interface.
+       `manipulation` keeps tap/pan/pinch but drops double-tap zoom on the
+       control itself. */
     touch-action: manipulation;
 }
 
-.diagram-controls button:hover {
+/* Reveal on hover/keyboard focus; keep it always visible when the diagram had
+   to be scaled down (it isn't fully readable inline, so expanding is the
+   primary action) and on touch devices, where hover doesn't exist. */
+.diagram-container:hover .diagram-expand,
+.diagram-expand:focus-visible,
+.diagram-container.diagram-scaled .diagram-expand {
+    opacity: 1;
+}
+
+@media (pointer: coarse) {
+    .diagram-expand {
+        opacity: 1;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .diagram-expand {
+        transition: none;
+    }
+}
+
+.diagram-expand:hover {
     background-color: var(--accent-color);
     color: var(--text-on-accent);
     border-color: var(--accent-color);
-    transform: scale(1.1);
 }
 
 .diagram-wrapper {
-    height: 500px;
-    cursor: grab;
-    overflow: hidden;
-    position: relative;
-}
-
-.diagram-wrapper:active {
-    cursor: grabbing;
+    display: flex;
+    justify-content: center;
 }
 
 .diagram-wrapper svg {
-    transform-origin: 0 0;
+    display: block;
+    width: auto;
+    height: auto;
+    max-width: 100%;
+    max-height: 70vh;
+}
+
+.diagram-container.diagram-scaled .diagram-wrapper {
+    cursor: zoom-in;
 }
 
 /* ===========================
@@ -1141,7 +1154,7 @@ body {
     font-weight: 600;
     min-width: 44px;
     min-height: 44px;
-    /* See .diagram-controls button — avoid double-tap-to-zoom on the page. */
+    /* See .diagram-expand — avoid double-tap-to-zoom on the page. */
     touch-action: manipulation;
 }
 
@@ -1264,44 +1277,13 @@ body {
         padding: 1rem;
     }
 
-    /* On phones the control cluster is too wide/tall to float over the diagram
-       without covering it (the zoom slider + touch-sized buttons wrap into a
-       large block). Drop it out of the absolute overlay and into normal flow as
-       a toolbar above the diagram so it never obscures the content. The controls
-       already precede .diagram-wrapper in the DOM, so static positioning stacks
-       them on top. Applies to mobile web and the iOS WKWebView shell alike. */
-    .diagram-controls {
-        position: static;
-        top: auto;
-        right: auto;
-        flex-wrap: wrap;
-        justify-content: flex-start;
-        align-items: center;
-        border-radius: 0;
-        box-shadow: none;
-        background-color: var(--bg-secondary);
-        border-bottom: 1px solid var(--border-color);
-    }
-
     .fullscreen-controls {
         flex-wrap: wrap;
     }
 
-    .diagram-controls button,
     .fullscreen-controls button {
         padding: 0.4rem 0.6rem;
         font-size: 0.9rem;
-    }
-
-    /* Keep the zoom slider from forcing the toolbar absurdly wide on phones. */
-    .diagram-controls .zoom-range-label {
-        flex: 1 1 120px;
-        min-width: 100px;
-    }
-
-    .diagram-controls .zoom-range {
-        width: 100%;
-        min-width: 0;
     }
 }
 
@@ -1415,7 +1397,7 @@ body {
     .workspace-sidebar,
     .annotation-panel,
     .annotation-popover,
-    .diagram-controls,
+    .diagram-expand,
     .fullscreen-overlay,
     .presentation-overlay,
     .overflow-menu,
@@ -1507,6 +1489,7 @@ body {
 
     .diagram-wrapper svg {
         max-width: 100%;
+        max-height: none !important;
         width: auto !important;
         height: auto !important;
         position: static !important;
@@ -2224,7 +2207,7 @@ mark.search-highlight-current {
 .ios-native .browse-button,
 .ios-native .sample-button,
 .ios-native .theme-toggle,
-.ios-native .diagram-controls button,
+.ios-native .diagram-expand,
 .ios-native .fullscreen-controls button {
     transition: none;
 }
@@ -2233,7 +2216,7 @@ mark.search-highlight-current {
 .ios-native .browse-button:hover,
 .ios-native .sample-button:hover,
 .ios-native .theme-toggle:hover,
-.ios-native .diagram-controls button:hover,
+.ios-native .diagram-expand:hover,
 .ios-native .fullscreen-controls button:hover {
     transform: none;
     box-shadow: none;

--- a/tests/integration/markdown.test.js
+++ b/tests/integration/markdown.test.js
@@ -88,15 +88,6 @@ describe('Markdown Rendering', () => {
       expect(markdownContent.innerHTML).toContain('Test Heading');
     });
 
-    it('should cleanup existing panzoom instances', async () => {
-      const cleanupSpy = jest.fn();
-      global.cleanupPanzoomInstances = cleanupSpy;
-
-      await renderMarkdown('# Test', 'test.md');
-
-      expect(cleanupSpy).toHaveBeenCalled();
-    });
-
     it('should call processMermaidDiagrams', async () => {
       const processSpy = jest.fn().mockResolvedValue(undefined);
       global.processMermaidDiagrams = processSpy;

--- a/tests/integration/mermaid.test.js
+++ b/tests/integration/mermaid.test.js
@@ -136,7 +136,7 @@ describe('Mermaid Diagram Processing', () => {
       expect(markdownContent.querySelector('.diagram-container')).toBeTruthy();
     });
 
-    it('should initialize panzoom for each diagram', async () => {
+    it('should not initialize panzoom for inline diagrams', async () => {
       const markdownContent = document.getElementById('markdown-content');
       markdownContent.innerHTML = `
         <pre><code class="language-mermaid">graph TD\nA --> B</code></pre>
@@ -144,8 +144,8 @@ describe('Mermaid Diagram Processing', () => {
 
       await processMermaidDiagrams();
 
-      // Panzoom should be initialized
-      expect(Panzoom).toHaveBeenCalled();
+      // Inline diagrams are static; panzoom only exists in fullscreen
+      expect(Panzoom).not.toHaveBeenCalled();
     });
 
     it('should generate unique IDs for each diagram', async () => {
@@ -212,17 +212,19 @@ describe('Mermaid Diagram Processing', () => {
       expect(container.getAttribute('data-diagram-id')).toBe(diagramId);
     });
 
-    it('should create control buttons', () => {
+    it('should create a single expand button instead of a toolbar', () => {
       const svg = '<svg><text>test</text></svg>';
       const diagramId = 'test-diagram-123';
 
       const container = createDiagramContainer(svg, diagramId);
 
-      const controls = container.querySelector('.diagram-controls');
-      expect(controls.querySelector('.zoom-in')).toBeTruthy();
-      expect(controls.querySelector('.zoom-out')).toBeTruthy();
-      expect(controls.querySelector('.reset')).toBeTruthy();
-      expect(controls.querySelector('.fullscreen')).toBeTruthy();
+      const expandBtn = container.querySelector('.diagram-expand');
+      expect(expandBtn).toBeTruthy();
+      expect(expandBtn.getAttribute('aria-label')).toContain('Expand diagram');
+      // The old inline control cluster must be gone
+      expect(container.querySelector('.diagram-controls')).toBeNull();
+      expect(container.querySelector('.zoom-in')).toBeNull();
+      expect(container.querySelector('.zoom-range')).toBeNull();
     });
 
     it('should create wrapper with correct ID', () => {
@@ -241,8 +243,25 @@ describe('Mermaid Diagram Processing', () => {
 
       const container = createDiagramContainer(svg, diagramId);
 
-      const wrapper = container.querySelector('.diagram-wrapper');
-      expect(wrapper.innerHTML).toBe(svg);
+      const svgEl = container.querySelector('.diagram-wrapper svg');
+      expect(svgEl).toBeTruthy();
+      expect(svgEl.textContent).toBe('test diagram');
+    });
+
+    it('should give the SVG an intrinsic pixel size from its viewBox', () => {
+      // Mermaid emits width/height of "100%" and an inline max-width style;
+      // static inline layout replaces those with the natural pixel size and
+      // lets the stylesheet cap oversized diagrams.
+      const svg =
+        '<svg viewBox="0 0 800 600" width="100%" height="100%" style="max-width: 800px;"><text>big</text></svg>';
+
+      const container = createDiagramContainer(svg, 'test-diagram-123');
+
+      const svgEl = container.querySelector('.diagram-wrapper svg');
+      expect(svgEl.getAttribute('width')).toBe('800');
+      expect(svgEl.getAttribute('height')).toBe('600');
+      expect(svgEl.style.maxWidth).toBe('');
+      expect(svgEl.getAttribute('viewBox')).toBe('0 0 800 600');
     });
   });
 
@@ -470,51 +489,120 @@ describe('Mermaid Diagram Processing', () => {
     });
   });
 
-  describe('panzoom initialization with fit', () => {
-    it('should initialize panzoom with wider scale range', async () => {
+  describe('inline diagram affordance', () => {
+    async function renderOneDiagram() {
       const markdownContent = document.getElementById('markdown-content');
       markdownContent.innerHTML = `
         <pre><code class="language-mermaid">graph TD\nA --> B</code></pre>
       `;
-
       await processMermaidDiagrams();
+      return markdownContent.querySelector('.diagram-container');
+    }
 
-      expect(Panzoom).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.objectContaining({
-          maxScale: 10,
-          minScale: 0.1
-        })
-      );
+    it('expand button opens the fullscreen overlay', async () => {
+      const container = await renderOneDiagram();
+
+      container.querySelector('.diagram-expand').click();
+
+      const overlay = document.getElementById('fullscreen-overlay');
+      expect(overlay.style.display).toBe('flex');
+      expect(overlay.panzoomInstance).toBeTruthy();
     });
 
-    it('should not use contain option for free panning', async () => {
-      const markdownContent = document.getElementById('markdown-content');
-      markdownContent.innerHTML = `
-        <pre><code class="language-mermaid">graph TD\nA --> B</code></pre>
-      `;
+    it('clicking a scaled-down diagram opens fullscreen', async () => {
+      const container = await renderOneDiagram();
+      container.classList.add('diagram-scaled');
 
-      await processMermaidDiagrams();
+      container.querySelector('.diagram-wrapper').click();
 
-      const panzoomOptions = Panzoom.mock.calls[0][1];
-      expect(panzoomOptions.contain).toBeUndefined();
+      const overlay = document.getElementById('fullscreen-overlay');
+      expect(overlay.style.display).toBe('flex');
     });
 
-    it('should store mutable state with homeState in panzoom instance data', async () => {
+    it('clicking a diagram that fits inline does not open fullscreen', async () => {
+      const container = await renderOneDiagram();
+
+      container.querySelector('.diagram-wrapper').click();
+
+      const overlay = document.getElementById('fullscreen-overlay');
+      expect(overlay.style.display).toBe('none');
+    });
+
+    it('tap-anywhere opens fullscreen on coarse-pointer (touch) devices', async () => {
+      const container = await renderOneDiagram();
+      const originalMatchMedia = window.matchMedia;
+      window.matchMedia = jest.fn(() => ({ matches: true }));
+
+      try {
+        container.querySelector('.diagram-wrapper').click();
+
+        const overlay = document.getElementById('fullscreen-overlay');
+        expect(overlay.style.display).toBe('flex');
+      } finally {
+        window.matchMedia = originalMatchMedia;
+      }
+    });
+
+    it('fullscreen share button copies a diagram deep link', async () => {
+      const container = await renderOneDiagram();
+      const writeSpy = jest.fn(() => Promise.resolve());
+      Object.defineProperty(navigator, 'clipboard', {
+        value: { writeText: writeSpy },
+        configurable: true,
+      });
+
+      const diagramId = container.getAttribute('data-diagram-id');
+      openFullscreen(diagramId);
+      document.querySelector('#fullscreen-overlay .share-diagram').click();
+
+      expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining('?diagram='));
+    });
+  });
+
+  describe('markDiagramScaledState', () => {
+    async function renderOneDiagram() {
       const markdownContent = document.getElementById('markdown-content');
       markdownContent.innerHTML = `
         <pre><code class="language-mermaid">graph TD\nA --> B</code></pre>
       `;
-
       await processMermaidDiagrams();
+      return markdownContent.querySelector('.diagram-container');
+    }
 
-      // currentPanzoomInstances should have state.homeState
-      expect(state.currentPanzoomInstances.length).toBeGreaterThan(0);
-      expect(state.currentPanzoomInstances[0].state).toBeDefined();
-      expect(state.currentPanzoomInstances[0].state.homeState).toBeDefined();
-      expect(state.currentPanzoomInstances[0].state.homeState).toHaveProperty('scale');
-      expect(state.currentPanzoomInstances[0].state.homeState).toHaveProperty('x');
-      expect(state.currentPanzoomInstances[0].state.homeState).toHaveProperty('y');
+    /** Natural size from the mock SVG's viewBox is 800x600. */
+    function setRenderedSize(container, width, height) {
+      const svg = container.querySelector('.diagram-wrapper svg');
+      Object.defineProperty(svg, 'clientWidth', { value: width, configurable: true });
+      Object.defineProperty(svg, 'clientHeight', { value: height, configurable: true });
+    }
+
+    it('flags containers whose SVG was scaled down by the CSS caps', async () => {
+      const container = await renderOneDiagram();
+      setRenderedSize(container, 400, 300);
+
+      markDiagramScaledState(container);
+
+      expect(container.classList.contains('diagram-scaled')).toBe(true);
+    });
+
+    it('clears the flag when the SVG renders at natural size', async () => {
+      const container = await renderOneDiagram();
+      container.classList.add('diagram-scaled');
+      setRenderedSize(container, 800, 600);
+
+      markDiagramScaledState(container);
+
+      expect(container.classList.contains('diagram-scaled')).toBe(false);
+    });
+
+    it('leaves the state alone before layout (clientWidth 0)', async () => {
+      const container = await renderOneDiagram();
+      container.classList.add('diagram-scaled');
+      // jsdom default clientWidth/clientHeight is 0 — no layout information
+
+      markDiagramScaledState(container);
+
+      expect(container.classList.contains('diagram-scaled')).toBe(true);
     });
   });
 
@@ -653,24 +741,19 @@ describe('Mermaid Diagram Processing', () => {
       await expect(reRenderMermaidDiagrams()).resolves.not.toThrow();
     });
 
-    it('should cleanup old panzoom instance before re-render', async () => {
+    it('should keep the static inline sizing on the re-rendered SVG', async () => {
       const markdownContent = document.getElementById('markdown-content');
       markdownContent.innerHTML = `
         <pre><code class="language-mermaid">graph TD\nA --> B</code></pre>
       `;
       await processMermaidDiagrams();
 
-      // Get the panzoom instance that was created
-      const panzoomCalls = Panzoom.mock.results;
-      expect(panzoomCalls.length).toBeGreaterThan(0);
-      
-      const firstInstance = panzoomCalls[0].value;
-      const destroySpy = jest.spyOn(firstInstance, 'destroy');
-
       await reRenderMermaidDiagrams();
 
-      // Verify that the old panzoom instance was destroyed
-      expect(destroySpy).toHaveBeenCalled();
+      const svgEl = markdownContent.querySelector('.diagram-wrapper svg');
+      expect(svgEl.getAttribute('width')).toBe('800');
+      expect(svgEl.getAttribute('height')).toBe('600');
+      expect(svgEl.getAttribute('data-mermaid-source')).toBeTruthy();
     });
   });
 
@@ -682,7 +765,7 @@ describe('Mermaid Diagram Processing', () => {
       URL.revokeObjectURL = jest.fn();
     });
 
-    it('a superseded diagram pass stops mutating DOM and panzoom state', async () => {
+    it('a superseded diagram pass stops mutating the DOM', async () => {
       const markdownContent = document.getElementById('markdown-content');
 
       // Doc A: its mermaid.render is deferred so the pass stalls mid-render.
@@ -703,7 +786,6 @@ describe('Mermaid Diagram Processing', () => {
       markdownContent.innerHTML =
         '<pre><code class="language-mermaid">graph B</code></pre>';
       await processMermaidDiagrams();
-      const instancesAfterCurrent = state.currentPanzoomInstances.length;
       const domAfterCurrent = markdownContent.innerHTML;
 
       // The stale pass now finishes its render — and must change nothing.
@@ -713,7 +795,6 @@ describe('Mermaid Diagram Processing', () => {
       });
       await stalePass;
 
-      expect(state.currentPanzoomInstances.length).toBe(instancesAfterCurrent);
       expect(markdownContent.innerHTML).toBe(domAfterCurrent);
     });
 
@@ -740,7 +821,6 @@ describe('Mermaid Diagram Processing', () => {
         '<pre><code class="language-mermaid">graph B</code></pre>';
       await processMermaidDiagrams();
       const domAfterCurrent = markdownContent.innerHTML;
-      const instancesAfterCurrent = state.currentPanzoomInstances.length;
 
       resolveStale({
         svg: '<svg viewBox="0 0 800 600" width="800" height="600"><text>stale</text></svg>',
@@ -749,9 +829,8 @@ describe('Mermaid Diagram Processing', () => {
       await staleRerender;
 
       // The stale re-render must not have replaced doc B's diagram markup
-      // nor added/destroyed panzoom instances after it was superseded.
+      // after it was superseded.
       expect(markdownContent.innerHTML).toBe(domAfterCurrent);
-      expect(state.currentPanzoomInstances.length).toBe(instancesAfterCurrent);
     });
   });
 });

--- a/tests/unit/presentation.test.js
+++ b/tests/unit/presentation.test.js
@@ -16,22 +16,19 @@ function addDiagrams(n) {
     container.className = 'diagram-container';
     container.setAttribute('data-diagram-id', 'd' + i);
 
-    // Faithful to production DOM: the controls come FIRST and contain SVG
-    // icon buttons. This is the regression fixture for the bug where
-    // presentation mode cloned the reset-button icon (a bare 'svg' query
-    // matched the controls) instead of the diagram in the wrapper.
-    const controls = document.createElement('div');
-    controls.className = 'diagram-controls';
+    // Faithful to production DOM: the expand button comes FIRST and contains
+    // an SVG icon. This is the regression fixture for the bug where
+    // presentation mode cloned a button icon (a bare 'svg' query matched the
+    // chrome) instead of the diagram in the wrapper.
     const iconSvgEl = document.createElementNS(
       'http://www.w3.org/2000/svg',
       'svg'
     );
     iconSvgEl.setAttribute('data-icon-not-a-diagram', 'true');
-    const resetBtn = document.createElement('button');
-    resetBtn.className = 'reset';
-    resetBtn.appendChild(iconSvgEl);
-    controls.appendChild(resetBtn);
-    container.appendChild(controls);
+    const expandBtn = document.createElement('button');
+    expandBtn.className = 'diagram-expand';
+    expandBtn.appendChild(iconSvgEl);
+    container.appendChild(expandBtn);
 
     const wrapper = document.createElement('div');
     wrapper.className = 'diagram-wrapper';

--- a/tests/unit/printing.test.js
+++ b/tests/unit/printing.test.js
@@ -30,7 +30,7 @@ function loadPrintFixture() {
     <h1>First section</h1>
     <p>Intro paragraph well above the fold.</p>
     <div class="diagram-container" data-diagram-id="d0">
-      <div class="diagram-controls"><button class="reset"><svg data-icon="true"></svg></button></div>
+      <button class="diagram-expand"><svg data-icon="true"></svg></button>
       <div class="diagram-wrapper">
         <svg data-mermaid-source="graph TD; A--&gt;B" viewBox="0 0 800 600"
              style="position: absolute; width: 800px; transform: scale(2);"></svg>
@@ -64,9 +64,9 @@ describe('Printable document builder', () => {
     expect(html).toContain('spec.md');
   });
 
-  it('strips UI chrome: diagram controls, copy buttons, annotation badges', async () => {
+  it('strips UI chrome: diagram expand button, copy buttons, annotation badges', async () => {
     const html = await buildPrintableDocument();
-    expect(html).not.toContain('diagram-controls');
+    expect(html).not.toContain('diagram-expand');
     expect(html).not.toContain('code-copy-btn');
     expect(html).not.toContain('annotation-badge');
     expect(html).not.toContain('has-annotation');


### PR DESCRIPTION
Mermaid diagrams read like control panels: a fixed 500px card, an
always-visible 8-button toolbar, and always-armed panzoom that hijacked
page scroll into zoom. Documents were harder to read than the same
markdown in other viewers.

Inline diagrams are now plain document content — natural size from the
SVG viewBox, capped at the column width and 70vh, no toolbar, wheel
scrolls the page. A single expand button (hover/focus-reveal) opens the
existing fullscreen overlay, which keeps all interactive machinery and
gains the previously inline-only share button. Diagrams the caps scaled
down get an always-visible button, a zoom-in cursor, and
click-anywhere-to-expand; touch devices get tap-anywhere.

Deletes inline panzoom wiring and state.currentPanzoomInstances plus its
cleanup plumbing (main.js, tabs.js, view-mode.js). Print path unchanged
except the chrome-strip selector. Decision doc and session checklist in
docs/project-bugfix-wave/.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0177bCAkRj3D1TJ8M3o6GvPN