### PR TITLE
fix diagram fullscreen layout, inline expand button, and Reload from disk

### DIFF
--- a/markdown-viewer/src/features/diagrams.js
+++ b/markdown-viewer/src/features/diagrams.js
@@ -198,11 +198,12 @@ function fitDiagramToContainer(wrapper, svgElement, panzoomInstance) {
     const scaleY = containerHeight / dims.height;
     const fitScale = Math.min(scaleX, scaleY) * 0.9;
 
-    // Center the diagram
-    const scaledWidth = dims.width * fitScale;
-    const scaledHeight = dims.height * fitScale;
-    const x = (containerWidth - scaledWidth) / 2;
-    const y = (containerHeight - scaledHeight) / 2;
+    // Center the diagram. Panzoom's transform is `scale(S) translate(x, y)`, so
+    // the translate is applied in the *pre-scale* coordinate space — a pan of x
+    // moves the element S*x pixels on screen. To land the scaled diagram's
+    // top-left at the centering offset, divide the pixel gap by the scale.
+    const x = (containerWidth / fitScale - dims.width) / 2;
+    const y = (containerHeight / fitScale - dims.height) / 2;
 
     panzoomInstance.zoom(fitScale, { animate: false });
     panzoomInstance.pan(x, y, { animate: false });
@@ -352,13 +353,24 @@ function openFullscreen(diagramId) {
         cursor: 'grab'
     });
 
-    // Use mutable state for deferred fit recalculation
+    // Use mutable state for deferred fit recalculation.
     const fullscreenState = {
         homeState: fitDiagramToContainer(fullscreenWrapper, svgClone, fullscreenPanzoom)
     };
-    requestAnimationFrame(() => {
+    // Panzoom's constructor defers a forced `pan(startX, startY)` (0,0) via a
+    // setTimeout(0) to constrain its initial values — that reset fires *after*
+    // this synchronous fit and would clobber the centering back to the
+    // top-left corner. Re-apply the fit from a setTimeout scheduled here: it was
+    // queued after panzoom's (which ran during construction above), so it fires
+    // after the reset and wins. A trailing rAF refits once more against the
+    // final post-layout container dimensions.
+    const applyFit = () => {
         fullscreenState.homeState = fitDiagramToContainer(fullscreenWrapper, svgClone, fullscreenPanzoom);
-    });
+    };
+    setTimeout(() => {
+        applyFit();
+        requestAnimationFrame(applyFit);
+    }, 0);
 
     // Store for cleanup
     fsOverlay.panzoomInstance = fullscreenPanzoom;

--- a/markdown-viewer/src/platform/desktop.js
+++ b/markdown-viewer/src/platform/desktop.js
@@ -193,22 +193,32 @@ export function setupDesktopIPC() {
     }
   });
 
-  // Listen for file-changed events (watched file updated on disk)
+  // Listen for file-changed events (watched file updated on disk, or a manual
+  // "Reload from disk"). The same file can be open in more than one tab, so
+  // update EVERY matching tab — and, crucially, decide the visible re-render by
+  // whether the *active* tab is among them, not by the first match. Keying off
+  // the first match (Array.find) silently broke Reload from disk whenever the
+  // same file was open twice and the active copy wasn't the first: the handler
+  // took the background branch and never refreshed the view.
   bridgeOnFileChanged(async function (fileData) {
-    const tab = state.tabs.find((t) => t.filePath === fileData.filePath);
-    if (!tab) return;
+    const matchingTabs = state.tabs.filter((t) => t.filePath === fileData.filePath);
+    if (matchingTabs.length === 0) return;
 
-    tab.rawMarkdown = fileData.content;
-    tab.filename = fileData.filename;
+    for (const tab of matchingTabs) {
+      tab.rawMarkdown = fileData.content;
+      tab.filename = fileData.filename;
+    }
 
-    if (tab.id === state.activeTabId) {
+    const activeTab = matchingTabs.find((t) => t.id === state.activeTabId);
+
+    if (activeTab) {
       // Preserve scroll position across the re-render so an
       // auto-reload doesn't yank the user back to the top.
       const markdownContent = el('markdown-content');
       if (!markdownContent) return;
       const savedScrollTop = markdownContent.scrollTop;
 
-      if (tab.viewMode === 'raw') {
+      if (activeTab.viewMode === 'raw') {
         state.currentRawMarkdown = fileData.content;
         const escaped = fileData.content
           .replace(/&/g, '&amp;')
@@ -224,12 +234,18 @@ export function setupDesktopIPC() {
       // Visual feedback that an auto-reload happened — otherwise
       // the user has no way to tell the content just changed.
       pulseWatchToggle();
-    } else {
-      // Background tab: flag it so the user sees that something
-      // changed when they come back to it.
-      tab.hasUnseenChanges = true;
-      renderTabBar();
     }
+
+    // Flag any non-active copies so the user sees that something changed when
+    // they come back to them. (When the active tab wasn't among the matches,
+    // this covers every match — the previous background-tab behavior.)
+    let flaggedBackground = false;
+    for (const tab of matchingTabs) {
+      if (tab.id === state.activeTabId) continue;
+      tab.hasUnseenChanges = true;
+      flaggedBackground = true;
+    }
+    if (flaggedBackground) renderTabBar();
   });
 
   // Wire up watch toggle button

--- a/markdown-viewer/styles.css
+++ b/markdown-viewer/styles.css
@@ -1023,12 +1023,17 @@ body {
 .diagram-container {
     position: relative;
     margin: 2em 0;
+    /* Reserve a strip above the diagram for the expand button so it never
+       overlaps the diagram itself — a wide flowchart fills the column width,
+       leaving no in-bounds corner the button could sit in without obscuring a
+       node. The button lives in this strip, right-aligned. */
+    padding-top: 40px;
 }
 
 .diagram-expand {
     position: absolute;
-    top: 8px;
-    right: 8px;
+    top: 0;
+    right: 0;
     z-index: 10;
     display: inline-flex;
     align-items: center;
@@ -1039,8 +1044,12 @@ body {
     border-radius: var(--radius-md);
     box-shadow: var(--shadow-md);
     cursor: pointer;
-    min-width: 44px;
-    min-height: 44px;
+    /* Compact control on pointer devices; the touch target grows to 44px on
+       coarse pointers below. Sized to fit the reserved 40px top strip. */
+    width: 32px;
+    height: 32px;
+    min-width: 32px;
+    min-height: 32px;
     opacity: 0;
     transition: opacity 0.15s ease;
     /* A fast double-tap was being read by mobile Safari/WKWebView as the
@@ -1060,8 +1069,16 @@ body {
 }
 
 @media (pointer: coarse) {
+    .diagram-container {
+        /* Widen the reserved strip for the larger touch target. */
+        padding-top: 52px;
+    }
     .diagram-expand {
         opacity: 1;
+        width: 44px;
+        height: 44px;
+        min-width: 44px;
+        min-height: 44px;
     }
 }
 

--- a/tests/integration/mermaid.test.js
+++ b/tests/integration/mermaid.test.js
@@ -431,11 +431,16 @@ describe('Mermaid Diagram Processing', () => {
       const panzoom = Panzoom(svg, {});
       const result = fitDiagramToContainer(wrapper, svg, panzoom);
 
-      // fitScale = 0.72, scaledWidth = 720, scaledHeight = 360
-      // x = (800 - 720) / 2 = 40
-      // y = (600 - 360) / 2 = 120
-      expect(result.x).toBeCloseTo(40, 0);
-      expect(result.y).toBeCloseTo(120, 0);
+      // Panzoom applies the pan inside scale() — transform is
+      // `scale(S) translate(x, y)` — so the pan is in pre-scale coordinates and
+      // the on-screen offset is S*x. To center, the pixel gap is divided by the
+      // scale: x = (800/0.72 - 1000) / 2 ≈ 55.56, y = (600/0.72 - 500) / 2 ≈ 166.67.
+      // These land the scaled diagram at screen offset (40, 120) — truly centered.
+      expect(result.x).toBeCloseTo(55.56, 1);
+      expect(result.y).toBeCloseTo(166.67, 1);
+      // On-screen centering offset = scale * pan.
+      expect(result.scale * result.x).toBeCloseTo(40, 0);
+      expect(result.scale * result.y).toBeCloseTo(120, 0);
     });
 
     it('should call panzoom zoom and pan with correct values', () => {
@@ -454,7 +459,8 @@ describe('Mermaid Diagram Processing', () => {
       fitDiagramToContainer(wrapper, svg, panzoom);
 
       expect(zoomSpy).toHaveBeenCalledWith(expect.closeTo(0.72, 1), { animate: false });
-      expect(panSpy).toHaveBeenCalledWith(expect.closeTo(40, 0), expect.closeTo(120, 0), { animate: false });
+      // Pan is in pre-scale coordinates (see the centering test above).
+      expect(panSpy).toHaveBeenCalledWith(expect.closeTo(55.56, 1), expect.closeTo(166.67, 1), { animate: false });
     });
   });
 

--- a/tests/unit/desktopRenderer.test.js
+++ b/tests/unit/desktopRenderer.test.js
@@ -101,6 +101,36 @@ describe('Desktop renderer integration', () => {
     expect(refreshedEl.classList.contains('tab-has-changes')).toBe(false);
   });
 
+  it('reloads the active tab when the same file is open in an earlier tab too', async () => {
+    const fileChangedCallback = window.specdown.onFileChanged.mock.calls[0][0];
+
+    // Same file opened twice; the second copy is the active tab. Array.find
+    // would return the first (background) copy, so the old handler took the
+    // background branch and never re-rendered the visible view.
+    createTab('dup.md', '# Original', '/tmp/dup.md');
+    createTab('dup.md', '# Original', '/tmp/dup.md');
+
+    const firstTab = state.tabs[0];
+    const activeTab = state.tabs[1];
+    expect(state.activeTabId).toBe(activeTab.id);
+
+    await fileChangedCallback({
+      filename: 'dup.md',
+      filePath: '/tmp/dup.md',
+      content: '# Reloaded from disk',
+    });
+
+    // The visible content must reflect the new file contents.
+    const markdownContent = document.getElementById('markdown-content');
+    expect(markdownContent.innerHTML).toContain('Reloaded from disk');
+    expect(markdownContent.innerHTML).not.toContain('Original');
+
+    // Both copies carry the fresh raw markdown; the background copy is flagged.
+    expect(activeTab.rawMarkdown).toBe('# Reloaded from disk');
+    expect(firstTab.rawMarkdown).toBe('# Reloaded from disk');
+    expect(firstTab.hasUnseenChanges).toBe(true);
+  });
+
   describe('live-reload chip', () => {
     it('shows "Live" with active state for a fresh desktop file tab', () => {
       createTab('one.md', '# One', '/tmp/one.md');


### PR DESCRIPTION
Three bugs reported together from the desktop app:

- Inline expand button obscured the diagram. A wide flowchart fills the
  column width, so the top-right overlay button covered the last node with
  no way to see under it. Reserve a strip above the diagram and place the
  button there (compact 32px on pointer devices, 44px touch target on
  coarse pointers) so it never overlaps diagram content.

- Fullscreen diagram was pinned to the top-left under the controls instead
  of centered. Two causes: (1) Panzoom's constructor defers a forced
  pan(0,0) via setTimeout(0) to constrain its initial values, which fired
  after the synchronous fit and clobbered the centering — re-apply the fit
  from a setTimeout queued after panzoom's so it wins; (2) the centering
  math treated the pan as a screen offset, but panzoom's transform is
  `scale(S) translate(x, y)` so the pan is pre-scale — divide the pixel gap
  by the scale to truly center.

- "Reload from disk" did nothing when the same file was open in more than
  one tab and the active copy wasn't the first. The file-changed handler
  keyed off Array.find (first match), took the background-tab branch, and
  never re-rendered the visible view. Update every matching tab and decide
  the re-render by whether the active tab is among them.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011rFqGWMBibMY7uvdbZhBJS