### PR TITLE
fix: fullscreen diagram minimap rendered an empty box

### DIFF
--- a/docs/project-bugfix-wave/2026-07-24-tasks-session-06-minimap-empty-canvas.md
+++ b/docs/project-bugfix-wave/2026-07-24-tasks-session-06-minimap-empty-canvas.md
@@ -1,0 +1,64 @@
+# Session 06 — Fullscreen minimap renders an empty box
+
+**Date:** 2026-07-24
+**Type:** tasks
+**Surfaces:** web + desktop (the minimap is hidden on iOS native).
+
+## Problem
+
+In the fullscreen diagram overlay, the **minimap** (the small overview in the
+lower-left, with an accent-bordered viewport rectangle) showed an empty box — the
+scaled-down diagram never appeared, only the blue viewport outline.
+
+### Root cause
+
+`updateMinimap()` (`markdown-viewer/src/features/minimap.js`) rasterizes the
+diagram SVG by serializing it, loading the string into an `Image`, and drawing
+that image onto the minimap `<canvas>`.
+
+By the time it runs, panzoom has already stamped an inline
+`transform: scale(...) translate(...)` (plus `transform-origin`) onto the live
+SVG — it is the same element panzoom drives. That transform was serialized into
+the rasterized string, and the **outermost `<svg>`'s CSS transform is honored
+when an SVG is rendered as an image**, so the whole diagram was scaled/translated
+outside the viewBox and the canvas drew nothing. The `.minimap-viewport`
+rectangle still positioned itself, so the result was an empty accent-bordered
+box.
+
+Reproduced in headless Chromium with a real Mermaid SVG:
+
+- clean SVG → ~10,800 non-blank canvas pixels
+- SVG carrying panzoom's inline transform → **0** non-blank pixels
+- clone with the transform stripped + explicit width/height → back to ~10,800
+
+A secondary contributor: Mermaid emits `width="100%"` and a `max-width` style, so
+the `Image` gets a 300px default intrinsic size; pinning explicit natural
+dimensions makes the raster reliable.
+
+## Fix
+
+In `updateMinimap()`, serialize a **clean clone** instead of the live element:
+
+- deep-clone the SVG (never mutate the panzoom target),
+- clear inline `transform`, `transform-origin`, and `max-width`,
+- set explicit `width`/`height` from the natural dimensions already computed
+  from the viewBox.
+
+## Tests
+
+Added `tests/unit/diagramMinimap.test.js` — a regression guard that captures the
+node handed to the serializer and asserts the transform is stripped, explicit
+width/height are set, and the live SVG is left untouched (plus the no-dimensions
+hide path).
+
+## Gates
+
+- `npm test` — 535/535 pass
+- `npm run lint` — clean (`--max-warnings=0`)
+- `npm run typecheck` — clean
+
+## Notes / follow-ups
+
+- Shared-app fix; reaches web + desktop. The minimap is intentionally hidden on
+  iOS native (`.ios-native .fullscreen-minimap { display: none }`), so no iOS
+  surfacing needed.

--- a/docs/project-bugfix-wave/README.md
+++ b/docs/project-bugfix-wave/README.md
@@ -15,6 +15,7 @@ folder tracks the smaller fixes that follow.
 | 2026-06-22 | [tasks-session-04](2026-06-22-tasks-session-04-ios-present-action-sheet.md) | Presentation mode was unreachable on iPhone — added a Present entry to the iOS action sheet |
 | 2026-07-22 | [brainstorm-diagram-inline-static-ux](2026-07-22-brainstorm-diagram-inline-static-ux.md) | Diagrams read like control panels — options + decision to render them as static document content |
 | 2026-07-22 | [tasks-session-05](2026-07-22-tasks-session-05-diagram-inline-static-ux.md) | Static inline diagrams: fixed 500px card + 8-button toolbar + always-armed panzoom replaced by natural-size rendering with an on-demand fullscreen explore mode |
+| 2026-07-24 | [tasks-session-06](2026-07-24-tasks-session-06-minimap-empty-canvas.md) | Fullscreen minimap rendered an empty box — panzoom's inline transform was serialized into the rasterized SVG, pushing content off-canvas |
 
 ## Status
 

--- a/markdown-viewer/src/features/minimap.js
+++ b/markdown-viewer/src/features/minimap.js
@@ -30,9 +30,25 @@ export function updateMinimap(svgElement) {
   canvas.style.width = canvas.width + 'px';
   canvas.style.height = canvas.height + 'px';
 
-  // Render the SVG into the minimap canvas via an image
+  // Render the SVG into the minimap canvas via an image.
+  //
+  // Serialize a *clean clone*, not the element itself: by the time this runs,
+  // panzoom has stamped an inline `transform` (scale + translate) and
+  // `transform-origin` onto the live svg. The outermost <svg>'s CSS transform
+  // is honored when the string is rasterized through an Image, so it shoves the
+  // whole diagram outside the viewBox and the canvas draws nothing (the empty
+  // minimap bug). Strip the transform and pin explicit natural width/height
+  // (Mermaid emits width="100%" + a max-width style, which gives the Image a
+  // 300px default intrinsic size) so it rasterizes at true size.
+  const cleanSvg = /** @type {SVGElement} */ (svgElement.cloneNode(true));
+  cleanSvg.style.transform = '';
+  cleanSvg.style.transformOrigin = '';
+  cleanSvg.style.maxWidth = '';
+  cleanSvg.setAttribute('width', String(dims.width));
+  cleanSvg.setAttribute('height', String(dims.height));
+
   const serializer = new XMLSerializer();
-  const svgStr = serializer.serializeToString(svgElement);
+  const svgStr = serializer.serializeToString(cleanSvg);
   const blob = new Blob([svgStr], { type: 'image/svg+xml;charset=utf-8' });
   const url = URL.createObjectURL(blob);
   const img = new Image();

--- a/tests/unit/diagramMinimap.test.js
+++ b/tests/unit/diagramMinimap.test.js
@@ -1,0 +1,95 @@
+/**
+ * Unit tests for the fullscreen diagram minimap.
+ *
+ * Regression guard: the minimap rasterizes the diagram SVG through an Image.
+ * By the time it runs, panzoom has stamped an inline `transform` on the live
+ * SVG. If that transform is serialized into the rasterized string, the
+ * outermost <svg>'s CSS transform shoves the content outside the viewBox and
+ * the minimap canvas renders empty (the "missing content" bug). updateMinimap
+ * must serialize a clean clone with the transform stripped and explicit
+ * natural dimensions set.
+ */
+
+const { loadHTML, loadApp } = require('../helpers/loadApp');
+require('../mocks/marked');
+require('../mocks/mermaid');
+require('../mocks/panzoom');
+require('../mocks/highlightjs');
+
+describe('Diagram Minimap', () => {
+  let serializeSpy;
+  let capturedNodes;
+
+  beforeEach(() => {
+    localStorage.clear();
+    loadHTML(document);
+    loadApp(document);
+
+    global.URL.createObjectURL = jest.fn(() => 'blob:mock-url');
+    global.URL.revokeObjectURL = jest.fn();
+
+    // Capture whatever gets handed to the serializer so we can inspect the
+    // exact node the minimap rasterizes.
+    capturedNodes = [];
+    serializeSpy = jest
+      .spyOn(XMLSerializer.prototype, 'serializeToString')
+      .mockImplementation(function (node) {
+        capturedNodes.push(node);
+        return '<svg></svg>';
+      });
+  });
+
+  afterEach(() => {
+    serializeSpy.mockRestore();
+    delete global.URL.createObjectURL;
+    delete global.URL.revokeObjectURL;
+  });
+
+  /** Build an SVG carrying a panzoom-style inline transform. */
+  function makeTransformedSvg() {
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('viewBox', '0 0 731 80');
+    svg.setAttribute('width', '100%');
+    svg.style.maxWidth = '731px';
+    svg.style.transform = 'scale(0.35) translate(120px, 80px)';
+    svg.style.transformOrigin = '0px 0px';
+    return svg;
+  }
+
+  it('strips the panzoom transform before serializing for the canvas', () => {
+    updateMinimap(makeTransformedSvg());
+
+    expect(capturedNodes.length).toBe(1);
+    const serialized = capturedNodes[0];
+    expect(serialized.style.transform).toBe('');
+    expect(serialized.style.transformOrigin).toBe('');
+  });
+
+  it('pins explicit natural width/height from the viewBox', () => {
+    updateMinimap(makeTransformedSvg());
+
+    const serialized = capturedNodes[0];
+    expect(serialized.getAttribute('width')).toBe('731');
+    expect(serialized.getAttribute('height')).toBe('80');
+    // The percentage width + max-width (which give an Image a 300px default
+    // intrinsic size) must be gone.
+    expect(serialized.style.maxWidth).toBe('');
+  });
+
+  it('does not mutate the live SVG element passed in', () => {
+    const svg = makeTransformedSvg();
+    updateMinimap(svg);
+
+    // The original keeps its transform — only the clone is cleaned.
+    expect(svg.style.transform).toBe('scale(0.35) translate(120px, 80px)');
+    expect(capturedNodes[0]).not.toBe(svg);
+  });
+
+  it('hides the minimap when the SVG has no usable dimensions', () => {
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    updateMinimap(svg);
+
+    expect(document.getElementById('fullscreen-minimap').style.display).toBe('none');
+    expect(capturedNodes.length).toBe(0);
+  });
+});


### PR DESCRIPTION
The minimap rasterizes the diagram SVG by serializing it, loading the
string into an Image, and drawing that onto the minimap canvas. But by
the time updateMinimap() runs, panzoom has stamped an inline
`transform: scale(...) translate(...)` onto the live SVG (its pan/zoom
target). That transform was serialized into the rasterized string, and
the outermost <svg>'s CSS transform is honored when rendered as an image
— so the diagram was pushed outside the viewBox and the canvas drew
nothing, leaving just the accent-bordered viewport rectangle.

Serialize a clean clone instead: strip transform/transform-origin/
max-width and pin explicit natural width/height from the viewBox
(Mermaid's width="100%" otherwise gives the Image a 300px default
intrinsic size). Never mutate the live panzoom element.

Verified in headless Chromium with a real Mermaid SVG: transformed
render → 0 non-blank pixels; cleaned clone → ~10,800. Adds
tests/unit/diagramMinimap.test.js as a regression guard.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015N2WHHA1mseuDgjxe4Zx6M