### PR TITLE
fix: keep fullscreen diagram centered when using the zoom slider

### DIFF
--- a/markdown-viewer/src/features/diagrams.js
+++ b/markdown-viewer/src/features/diagrams.js
@@ -221,6 +221,36 @@ export function resetToFit(panzoomInstance, homeState) {
 }
 
 /**
+ * Change the zoom scale while keeping the container's center point fixed.
+ *
+ * Panzoom's `zoom()`/`zoomIn()`/`zoomOut()` change the scale but leave the pan
+ * (translate) untouched. Because the transform is `scale(S) translate(x, y)`
+ * with a `0 0` origin, the on-screen position of the diagram's top-left is
+ * `S * translate` — so raising S alone pushes the diagram toward the
+ * bottom-right and out of view (the wheel path avoids this by zooming about the
+ * cursor's focal point). Re-derive the pan so the content point under the
+ * container's center stays put across the zoom.
+ *
+ * @param {PanzoomObject} panzoomInstance
+ * @param {HTMLElement} wrapper
+ * @param {() => void} applyZoom  applies the scale change (e.g. zoomIn, zoom)
+ */
+export function zoomKeepingCenter(panzoomInstance, wrapper, applyZoom) {
+    const oldScale = panzoomInstance.getScale();
+    applyZoom();
+    const newScale = panzoomInstance.getScale();
+    // Nothing to re-center if a scale is missing or unchanged.
+    if (!oldScale || !newScale || oldScale === newScale) return;
+    const { x, y } = panzoomInstance.getPan();
+    // Pan is in the pre-scale coordinate space, so the shift needed to hold a
+    // point fixed is the on-screen offset divided out by each scale.
+    const shift = 1 / newScale - 1 / oldScale;
+    const cx = wrapper.clientWidth / 2;
+    const cy = wrapper.clientHeight / 2;
+    panzoomInstance.pan(x + cx * shift, y + cy * shift, { animate: false });
+}
+
+/**
  * @param {PanzoomObject | null} panzoomInstance
  * @param {Element | null} controlsRoot
  */
@@ -440,13 +470,13 @@ function setupFullscreenControls(panzoomInstance, wrapper, fullscreenState) {
     // Add new listeners
     on(newZoomIn, 'click', (e) => {
         e.stopPropagation();
-        panzoomInstance.zoomIn();
+        zoomKeepingCenter(panzoomInstance, wrapper, () => panzoomInstance.zoomIn());
         updateZoomUI(panzoomInstance, controls);
     });
 
     on(newZoomOut, 'click', (e) => {
         e.stopPropagation();
-        panzoomInstance.zoomOut();
+        zoomKeepingCenter(panzoomInstance, wrapper, () => panzoomInstance.zoomOut());
         updateZoomUI(panzoomInstance, controls);
     });
 
@@ -462,7 +492,9 @@ function setupFullscreenControls(panzoomInstance, wrapper, fullscreenState) {
         const target = /** @type {HTMLInputElement} */ (e.target);
         const targetPercent = Number(target.value);
         if (!isNaN(targetPercent)) {
-            panzoomInstance.zoom(targetPercent / 100);
+            zoomKeepingCenter(panzoomInstance, wrapper, () =>
+                panzoomInstance.zoom(targetPercent / 100)
+            );
             updateZoomUI(panzoomInstance, controls);
         }
     });

--- a/tests/integration/mermaid.test.js
+++ b/tests/integration/mermaid.test.js
@@ -495,6 +495,69 @@ describe('Mermaid Diagram Processing', () => {
     });
   });
 
+  describe('zoomKeepingCenter', () => {
+    function makeWrapper(width, height) {
+      const wrapper = document.createElement('div');
+      Object.defineProperty(wrapper, 'clientWidth', { value: width, configurable: true });
+      Object.defineProperty(wrapper, 'clientHeight', { value: height, configurable: true });
+      return wrapper;
+    }
+
+    // The content point currently under the container center, given panzoom's
+    // `scale(S) translate(x, y)` transform (origin 0 0): centerScreen = S*(v + t).
+    function contentUnderCenter(panzoom, wrapper) {
+      const s = panzoom.getScale();
+      const { x, y } = panzoom.getPan();
+      return {
+        x: (wrapper.clientWidth / 2) / s - x,
+        y: (wrapper.clientHeight / 2) / s - y,
+      };
+    }
+
+    it('keeps the container center fixed when zooming to a smaller scale', () => {
+      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      const panzoom = Panzoom(svg, {});
+      const wrapper = makeWrapper(800, 600);
+
+      const before = contentUnderCenter(panzoom, wrapper);
+      zoomKeepingCenter(panzoom, wrapper, () => panzoom.zoom(0.5));
+      const after = contentUnderCenter(panzoom, wrapper);
+
+      expect(panzoom.getScale()).toBe(0.5);
+      expect(after.x).toBeCloseTo(before.x, 6);
+      expect(after.y).toBeCloseTo(before.y, 6);
+      // Pan is re-derived, not left at the origin (the old buggy behavior).
+      expect(panzoom.getPan()).toEqual({ x: 400, y: 300 });
+    });
+
+    it('keeps the container center fixed when zooming to a larger scale', () => {
+      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      const panzoom = Panzoom(svg, {});
+      const wrapper = makeWrapper(800, 600);
+      panzoom.pan(30, -20);
+
+      const before = contentUnderCenter(panzoom, wrapper);
+      zoomKeepingCenter(panzoom, wrapper, () => panzoom.zoom(2));
+      const after = contentUnderCenter(panzoom, wrapper);
+
+      expect(after.x).toBeCloseTo(before.x, 6);
+      expect(after.y).toBeCloseTo(before.y, 6);
+    });
+
+    it('leaves the pan untouched when the scale does not change', () => {
+      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      const panzoom = Panzoom(svg, {});
+      const wrapper = makeWrapper(800, 600);
+      panzoom.pan(45, 15);
+      const panSpy = jest.spyOn(panzoom, 'pan');
+
+      zoomKeepingCenter(panzoom, wrapper, () => panzoom.zoom(1));
+
+      expect(panSpy).not.toHaveBeenCalled();
+      expect(panzoom.getPan()).toEqual({ x: 45, y: 15 });
+    });
+  });
+
   describe('inline diagram affordance', () => {
     async function renderOneDiagram() {
       const markdownContent = document.getElementById('markdown-content');


### PR DESCRIPTION
Fixes the fullscreen diagram drifting off-screen when using the zoom slider.

## Problem

Zooming a fullscreen diagram with the zoom slider (or the +/- buttons) scaled it up but pushed it toward the bottom-right instead of keeping it centered. At 75% the offset was clearly visible.

## Root cause

The slider and +/- buttons called panzoom's zoom()/zoomIn()/zoomOut(), which change the scale but leave the pan (translate) untouched. Panzoom's transform is scale(S) translate(x, y) with a 0 0 origin, so the diagram's on-screen top-left sits at S * translate. Raising S alone pushes the diagram out of view. The mouse-wheel path was unaffected because it zooms about the cursor's focal point.

## Fix

Added zoomKeepingCenter() in markdown-viewer/src/features/diagrams.js, which re-derives the pan after a scale change so the content point under the container's center stays fixed. The zoom slider and the zoom-in/zoom-out buttons now route through it. Wheel zoom is left as-is.

## Testing

- npm test: 538/538 pass, including 3 new zoomKeepingCenter tests
- npm run lint: clean
- npm run typecheck: clean

Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013gtaNuuidHSvHgMehJkdXL)_