### PR TITLE
fix: resolve file paths via the desktop bridge, not the removed File.path

### DIFF
--- a/markdown-viewer/src/features/file-loading.js
+++ b/markdown-viewer/src/features/file-loading.js
@@ -7,17 +7,23 @@ import { normalizeMarkdownUrl } from '../core/utils.js';
 import { handleRepoUrl } from './repo-browser.js';
 import { showToast } from './toast.js';
 import { recordRecentFile, renderRecentFiles } from './recent-files.js';
+import { bridgeGetPathForFile } from '../platform/bridge.js';
 
 const VALID_EXTENSIONS = ['.md', '.markdown'];
 const el = (/** @type {string} */ id) => document.getElementById(id);
 
+// Named uniquely (not a bare `openTab`): the test harness
+// (tests/helpers/loadApp.js) flattens every module to global scope, so a
+// module-top `openTab` here collides with the identically-named binding in
+// share-links.js — whichever configure*() runs last wins the shared global, and
+// this module's createTab (with its filePath/sourceMeta args) silently loses.
 /** @type {(filename: string, content?: string, filePath?: string | null, sourceMeta?: import('../core/state.js').TabSourceMeta | null) => void} */
-let openTab = () => {};
+let openTabFromFile = () => {};
 
 /** @param {{ createTab?: Function }} [deps] */
 export function configureFileLoading(deps) {
   if (deps && typeof deps.createTab === 'function') {
-    openTab = /** @type {typeof openTab} */ (deps.createTab);
+    openTabFromFile = /** @type {typeof openTabFromFile} */ (deps.createTab);
   }
 }
 
@@ -34,7 +40,7 @@ export function handleFileSelect(e) {
   input.value = '';
 }
 
-/** @param {File & { path?: string }} file */
+/** @param {File} file */
 export function handleFile(file) {
   // Validate file type
   const fileExtension = file.name.substring(file.name.lastIndexOf('.')).toLowerCase();
@@ -44,20 +50,28 @@ export function handleFile(file) {
     return;
   }
 
+  // Resolve the on-disk path via the desktop bridge (webUtils.getPathForFile):
+  // Electron v32+ removed the legacy File.path, and browser File objects never
+  // carried one — so reading file.path here silently yielded undefined, losing
+  // the desktop path affordances (recent-file reopen, live reload). The bridge
+  // returns '' off the desktop shell or when a path can't be resolved, so this
+  // is null on the web surface, exactly as before.
+  const filePath = bridgeGetPathForFile(file) || null;
+
   // Read file and open in a new tab
   const reader = new FileReader();
   reader.onload = () => {
     const content = /** @type {string} */ (reader.result);
-    // A browser File exposes size + last-modified (but no path); carry them so
-    // the File info sheet can show them on the web surface.
-    openTab(file.name, content, file.path || null, {
+    // A browser File also exposes size + last-modified; carry them so the File
+    // info sheet can show them on the web surface (where there's no path).
+    openTabFromFile(file.name, content, filePath, {
       size: file.size,
       lastModified: file.lastModified,
     });
-    // On desktop, dropped files carry a real path the main process can re-read,
-    // so record them for one-click re-open. Browser File objects have no path.
-    if (file.path) {
-      recordRecentFile({ type: 'path', ref: file.path, title: file.name });
+    // A real path means the main process can re-read the file, so record it for
+    // one-click re-open. Browser File objects resolve to no path.
+    if (filePath) {
+      recordRecentFile({ type: 'path', ref: filePath, title: file.name });
       renderRecentFiles();
     }
   };
@@ -133,7 +147,7 @@ export async function handleUrl(url) {
     const markdown = await response.text();
     if (urlInput) urlInput.value = '';
     // Record the source URL so the File info sheet can show where it came from.
-    openTab(filename, markdown, null, { url });
+    openTabFromFile(filename, markdown, null, { url });
     // Remember this URL for one-click re-open from the drop zone.
     recordRecentFile({ ref: url, title: filename });
     renderRecentFiles();

--- a/markdown-viewer/src/features/share-links.js
+++ b/markdown-viewer/src/features/share-links.js
@@ -7,13 +7,16 @@
 
 const MAX_DIAGRAM_URL_PARAM_LENGTH = 65536;
 
+// Named uniquely (not a bare `openTab`) to avoid colliding with file-loading.js
+// under the flat-eval test harness, which shares module-top bindings at global
+// scope. See the matching note in file-loading.js.
 /** @type {(filename: string, markdown?: string, filePath?: string | null) => void} */
-let openTab = () => {};
+let openTabFromShare = () => {};
 
 /** @param {{ createTab?: Function }} [deps] */
 export function configureShareLinks(deps) {
   if (deps && typeof deps.createTab === 'function') {
-    openTab = /** @type {typeof openTab} */ (deps.createTab);
+    openTabFromShare = /** @type {typeof openTabFromShare} */ (deps.createTab);
   }
 }
 
@@ -65,7 +68,7 @@ export function checkForDiagramLink() {
 
     // Synthesize a one-diagram markdown document
     const md = '```mermaid\n' + source + '\n```\n';
-    openTab('shared-diagram.md', md);
+    openTabFromShare('shared-diagram.md', md);
   } catch {
     // Silently ignore malformed deep links
   }

--- a/tests/unit/fileHandling.test.js
+++ b/tests/unit/fileHandling.test.js
@@ -343,3 +343,51 @@ describe('Drag and drop (desktop bridge routing)', () => {
   });
 });
 
+// handleFile resolves the on-disk path through the bridge (webUtils.
+// getPathForFile), not the removed File.path. This is the direct fix for the
+// Copilot follow-up: a file that reaches handleFile on desktop (e.g. the web
+// reader fallback, or the <input> picker) must still become a real file-backed
+// tab and get recorded as a recent file.
+describe('handleFile (desktop bridge path resolution)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    window.specdown = {
+      isDesktop: true,
+      getPathForFile: jest.fn((file) => '/abs/' + file.name),
+      watchFile: jest.fn(),
+      unwatchFile: jest.fn(),
+      saveSession: jest.fn(),
+      onFileOpened: jest.fn(),
+      onCloseTab: jest.fn(),
+      onFileChanged: jest.fn(),
+      onTriggerPrint: jest.fn(),
+      onTriggerSearch: jest.fn(),
+      onApplyCustomCss: jest.fn(),
+    };
+    loadHTML(document);
+    loadApp(document);
+  });
+
+  afterEach(() => {
+    delete window.specdown;
+  });
+
+  it('opens a file-backed tab using the bridge-resolved path and records it', (done) => {
+    const file = new File(['# Test'], 'notes.md', { type: 'text/markdown' });
+    handleFile(file);
+
+    expect(window.specdown.getPathForFile).toHaveBeenCalledWith(file);
+
+    setTimeout(() => {
+      const tab = state.tabs.find((t) => t.filename === 'notes.md');
+      expect(tab).toBeTruthy();
+      expect(tab.filePath).toBe('/abs/notes.md');
+      // A resolved path means it should be watched (Live) and recorded.
+      expect(window.specdown.watchFile).toHaveBeenCalledWith('/abs/notes.md');
+      const recents = JSON.parse(localStorage.getItem('specdown-recent-files') || '[]');
+      expect(recents.some((r) => r.ref === '/abs/notes.md' && r.type === 'path')).toBe(true);
+      done();
+    }, 20);
+  });
+});
+

--- a/tests/unit/fileHandling.test.js
+++ b/tests/unit/fileHandling.test.js
@@ -374,20 +374,36 @@ describe('handleFile (desktop bridge path resolution)', () => {
 
   it('opens a file-backed tab using the bridge-resolved path and records it', (done) => {
     const file = new File(['# Test'], 'notes.md', { type: 'text/markdown' });
+
+    // Mock FileReader (as the other handleFile tests do) so onload fires
+    // deterministically — no arbitrary wait for the real async read.
+    const originalFileReader = global.FileReader;
+    global.FileReader = class {
+      constructor() {
+        this.readAsText = jest.fn(function () {
+          this.result = '# Test';
+          setTimeout(() => {
+            if (this.onload) this.onload({ target: this });
+
+            const tab = state.tabs.find((t) => t.filename === 'notes.md');
+            expect(tab).toBeTruthy();
+            expect(tab.filePath).toBe('/abs/notes.md');
+            // A resolved path means it should be watched (Live) and recorded.
+            expect(window.specdown.watchFile).toHaveBeenCalledWith('/abs/notes.md');
+            const recents = JSON.parse(localStorage.getItem('specdown-recent-files') || '[]');
+            expect(recents.some((r) => r.ref === '/abs/notes.md' && r.type === 'path')).toBe(true);
+
+            global.FileReader = originalFileReader;
+            done();
+          }, 0);
+        });
+      }
+    };
+
     handleFile(file);
 
+    // Path resolution happens synchronously, before the read.
     expect(window.specdown.getPathForFile).toHaveBeenCalledWith(file);
-
-    setTimeout(() => {
-      const tab = state.tabs.find((t) => t.filename === 'notes.md');
-      expect(tab).toBeTruthy();
-      expect(tab.filePath).toBe('/abs/notes.md');
-      // A resolved path means it should be watched (Live) and recorded.
-      expect(window.specdown.watchFile).toHaveBeenCalledWith('/abs/notes.md');
-      const recents = JSON.parse(localStorage.getItem('specdown-recent-files') || '[]');
-      expect(recents.some((r) => r.ref === '/abs/notes.md' && r.type === 'path')).toBe(true);
-      done();
-    }, 20);
   });
 });
 


### PR DESCRIPTION
Follow-up to the File info panel (#214), addressing the Copilot review's suppressed observation.

## Problem
`handleFile()` recovered a file's on-disk path by reading `file.path`. Electron v32+ **removed** `File.path`, and browser `File` objects never had one, so this always evaluated to `undefined`:

- files reaching `handleFile` on desktop got `filePath === null`, so the new **File info** sheet showed the web fallback ("browser can't reveal its path"), and
- the path-based desktop affordances (recent-file reopen, live reload) were lost.

## Fix
Resolve the path through the existing bridge seam — `bridgeGetPathForFile` → `webUtils.getPathForFile` — the same sanctioned replacement drag-and-drop already uses (session 29). It returns `''` off the desktop shell, so the **web surface is unchanged** (null path, as before).

## Latent collision found while testing
Adding a regression test surfaced a pre-existing identifier collision: `file-loading.js` and `share-links.js` both declared a module-top `let openTab`. In production these are separate ES module scopes, but the flat-eval test harness (`tests/helpers/loadApp.js`) shares module-top bindings at global scope — so whichever `configure*()` ran last won the shared global. Share-links' 2-arg `createTab` wrapper was clobbering file-loading's, silently dropping `filePath`/`sourceMeta` **in tests** (exactly the hazard `CLAUDE.md` calls out). Renamed the two bindings to `openTabFromFile` / `openTabFromShare` so each module keeps its own wiring under the harness. Production behavior is unaffected.

## Tests
New regression test in `fileHandling.test.js` proving `handleFile` opens a file-backed tab using the bridge-resolved path, watches it, and records it as a recent file. Full suite (**574**), lint, typecheck, and build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4r6PXCs2G7A7gvLfCetA5)_