### PR TITLE
Plan: HTML documents as a forked viewer runtime

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ Each project gets its own subdirectory:
 | [project-modernization/](project-modernization/) | Cross-platform modernization — product/UX/engineering evaluation, vision, phased roadmap |
 | [project-bugfix-wave/](project-bugfix-wave/) | Post-modernization bug fixes & UX polish across web, desktop, and iOS |
 | [project-sharing/](project-sharing/) | Product sharing kit — LinkedIn copy, article outlines, web showcase homepage |
+| [project-html/](project-html/) | HTML documents — forked viewing runtime next to markdown (planning) |
 
 ## Naming Conventions
 
@@ -31,3 +32,4 @@ YYYY-MM-DD-<type>-<detail>.md
 - **Desktop (`project-desktop`)**: No remaining features in the current Session 1–4 scope.
 - **URL opening (`project-url`)**: Inline reviewer comments (Google Docs-style) are still unimplemented and intentionally deferred from Session 01.
 - **iOS/iPad (`project-ios`)**: Shell is implemented; latest work adds an adaptive iPadOS split layout while keeping the shared viewer architecture intact.
+- **HTML documents (`project-html`)**: Planning complete. Implementation starts at Session 01 (kind + open + sandboxed preview). Do not convert HTML to markdown and do not inject it into the app origin — fork the document runtime. See [project-html/README.md](project-html/README.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ Each project gets its own subdirectory:
 | [project-url/](project-url/) | URL-based file opening — load markdown from GitHub or any web URL |
 | [project-modernization/](project-modernization/) | Cross-platform modernization — product/UX/engineering evaluation, vision, phased roadmap |
 | [project-bugfix-wave/](project-bugfix-wave/) | Post-modernization bug fixes & UX polish across web, desktop, and iOS |
-| [project-sharing/](project-sharing/) | Product sharing kit — LinkedIn copy, article outlines, web showcase homepage |
+| [project-sharing/](project-sharing/) | Product sharing kit — LinkedIn copy, article outlines, web showcase homepage; names/press for the HTML era live in [project-html](project-html/2026-08-23-brainstorm-names-and-press.md) |
 | [project-html/](project-html/) | HTML documents — forked viewing runtime next to markdown (planning, council-amended) |
 
 ## Naming Conventions

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ Each project gets its own subdirectory:
 | [project-modernization/](project-modernization/) | Cross-platform modernization — product/UX/engineering evaluation, vision, phased roadmap |
 | [project-bugfix-wave/](project-bugfix-wave/) | Post-modernization bug fixes & UX polish across web, desktop, and iOS |
 | [project-sharing/](project-sharing/) | Product sharing kit — LinkedIn copy, article outlines, web showcase homepage |
-| [project-html/](project-html/) | HTML documents — forked viewing runtime next to markdown (planning) |
+| [project-html/](project-html/) | HTML documents — forked viewing runtime next to markdown (planning, council-amended) |
 
 ## Naming Conventions
 
@@ -32,4 +32,4 @@ YYYY-MM-DD-<type>-<detail>.md
 - **Desktop (`project-desktop`)**: No remaining features in the current Session 1–4 scope.
 - **URL opening (`project-url`)**: Inline reviewer comments (Google Docs-style) are still unimplemented and intentionally deferred from Session 01.
 - **iOS/iPad (`project-ios`)**: Shell is implemented; latest work adds an adaptive iPadOS split layout while keeping the shared viewer architecture intact.
-- **HTML documents (`project-html`)**: Planning complete. Implementation starts at Session 01 (kind + open + sandboxed preview). Do not convert HTML to markdown and do not inject it into the app origin — fork the document runtime. See [project-html/README.md](project-html/README.md).
+- **HTML documents (`project-html`)**: Planning complete and [council-amended](project-html/2026-08-23-council-html-plan-review.md). Implementation starts at Session 01 (kind + open + sandboxed preview). Do not convert HTML to markdown and do not inject it into the app origin — fork the document runtime. See [project-html/README.md](project-html/README.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ Each project gets its own subdirectory:
 | [project-modernization/](project-modernization/) | Cross-platform modernization — product/UX/engineering evaluation, vision, phased roadmap |
 | [project-bugfix-wave/](project-bugfix-wave/) | Post-modernization bug fixes & UX polish across web, desktop, and iOS |
 | [project-sharing/](project-sharing/) | Product sharing kit — LinkedIn copy, article outlines, web showcase homepage; names/press for the HTML era live in [project-html](project-html/2026-08-23-brainstorm-names-and-press.md) |
-| [project-html/](project-html/) | HTML documents — forked viewing runtime next to markdown (planning, council-amended) |
+| [project-html/](project-html/) | HTML documents — forked viewing runtime; staging rail before any merge to `main` |
 
 ## Naming Conventions
 
@@ -32,4 +32,11 @@ YYYY-MM-DD-<type>-<detail>.md
 - **Desktop (`project-desktop`)**: No remaining features in the current Session 1–4 scope.
 - **URL opening (`project-url`)**: Inline reviewer comments (Google Docs-style) are still unimplemented and intentionally deferred from Session 01.
 - **iOS/iPad (`project-ios`)**: Shell is implemented; latest work adds an adaptive iPadOS split layout while keeping the shared viewer architecture intact.
-- **HTML documents (`project-html`)**: Planning complete and [council-amended](project-html/2026-08-23-council-html-plan-review.md). Implementation starts at Session 01 (kind + open + sandboxed preview). Do not convert HTML to markdown and do not inject it into the app origin — fork the document runtime. See [project-html/README.md](project-html/README.md).
+- **HTML documents (`project-html`)**: Planning complete
+  ([council-amended](project-html/2026-08-23-council-html-plan-review.md)
+  + [staging rail](project-html/2026-08-25-spec-html-staging.md)).
+  First code is [Session 00](project-html/2026-08-25-tasks-session-00-staging-rail.md)
+  onto `main` (flag off, no gates). HTML runtime is Session 01+
+  onto branch `html`, not `main`. Do not convert HTML to markdown
+  and do not inject it into the app origin — fork the document
+  runtime. See [project-html/README.md](project-html/README.md).

--- a/docs/project-html/2026-08-23-brainstorm-html-documents.md
+++ b/docs/project-html/2026-08-23-brainstorm-html-documents.md
@@ -784,11 +784,12 @@ No Find-in-page, no host-internal print, no asset protocol.
 Raw, switch to a markdown tab and back, confirm the document cannot
 `alert` in the parent (manual).
 
-### Session 02 — Reader chrome honesty
+### Session 02 — Reader chrome honesty (Print is the wedge)
 
-TOC + Find-via-bridge + Print/PDF snapshot + kind-aware toolbar /
-palette / iOS sheet + file info + live reload verification +
-creator-detect. Hide anything still dishonest.
+Host-internal Print/PDF + kind-aware hiding that survived
+Session 01 + live-reload verification. **Hide Find** unless the
+bridge highlight is real in the same PR (likely hide). Parser
+TOC or hide Contents. No creator-detect. No landing launch.
 
 ### Session 03 — Mixed workspace + links
 

--- a/docs/project-html/2026-08-23-brainstorm-html-documents.md
+++ b/docs/project-html/2026-08-23-brainstorm-html-documents.md
@@ -766,8 +766,21 @@ From `CLAUDE.md` and the retrospective, applied to this project:
 ## 6. Phased roadmap
 
 Sessions are implementation-sized, one PR each, rebase-and-merge.
+**Session 00 → `main`. Sessions 01–04 → integration branch `html`.**
+Do not merge the runtime to `main` until the Session 02 staging
+demo passes. Merge-to-`main` is a Release. Contract:
+[spec-html-staging](2026-08-25-spec-html-staging.md).
 
-### Session 01 — Kind + open + sandbox (this project's first code)
+### Session 00 — Staging rail (first code, onto `main`)
+
+See
+[`2026-08-25-tasks-session-00-staging-rail.md`](2026-08-25-tasks-session-00-staging-rail.md).
+Compile-time flag default **off**, `dev:html` / `preview:html` /
+`desktop:html`, CI artifact, create branch `html`. No open gates,
+no iframe, no CSP change. This is how we avoid shipping a
+half-fork to Pages and auto-update.
+
+### Session 01 — Kind + open + sandbox (first HTML runtime, onto `html`)
 
 See
 [`2026-08-23-tasks-session-01-kind-and-open.md`](2026-08-23-tasks-session-01-kind-and-open.md)
@@ -777,16 +790,18 @@ sample, **parent `frame-src`**, **workspace listing**, **honest
 chrome** (Print hidden), **iframe teardown**, **navigation lock**.
 No Find-in-page, no host-internal print, no asset protocol.
 
-**Demo:** drop `html-showcase.html`, see the designed page, toggle
-Raw, switch to a markdown tab and back, confirm the document cannot
-`alert` in the parent (manual).
+**Demo (HTML-on staging only):** drop `html-showcase.html`, see the
+designed page, toggle Raw, switch to a markdown tab and back,
+confirm the document cannot `alert` in the parent (manual). Also
+run the markdown golden path (Present + Print) on the same build.
 
 ### Session 02 — Reader chrome honesty (Print is the wedge)
 
-Host-internal Print/PDF + kind-aware hiding that survived
-Session 01 + live-reload verification. **Hide Find** unless the
-bridge highlight is real in the same PR (likely hide). Parser
-TOC or hide Contents. No creator-detect. No landing launch.
+Still a PR into **`html`**. Host-internal Print/PDF + kind-aware
+hiding that survived Session 01 + live-reload verification.
+**Hide Find** unless the bridge highlight is real in the same
+PR (likely hide). Parser TOC or hide Contents. No creator-detect.
+No landing launch.
 
 ### Session 03 — Mixed workspace + links
 
@@ -813,14 +828,15 @@ Skip if we have no evidence anyone wants it.
 
 ### Sequencing rationale
 
-Open+sandbox first because every later feature is unsafe or
-lying without it. Reader chrome second because a frame without
-Find/Print is Chrome. Workspace third because that is the job
-in §2.2. Assets fourth because they are the hard desktop
-problem and must not block the single-file 80% case. Safe mode
-fifth because we need Faithful in the world before we know the
-toggle's label. Enhance last — it is a differentiator, not the
-reason to exist.
+Staging rail (Session 00) before any render-path change because
+`main` is a Release. Open+sandbox next because every later
+feature is unsafe or lying without it. Reader chrome second
+because a frame without Find/Print is Chrome. Workspace third
+because that is the job in §2.2. Assets fourth because they are
+the hard desktop problem and must not block the single-file 80%
+case. Safe mode fifth because we need Faithful in the world
+before we know the toggle's label. Enhance last — it is a
+differentiator, not the reason to exist.
 
 Do **not** start with Mermaid-in-HTML. That is comforting (it
 looks like our existing product) and wrong (most agent HTML is
@@ -832,7 +848,8 @@ looks like our existing product) and wrong (most agent HTML is
 
 | Risk | Likelihood | Mitigation |
 |---|---|---|
-| We ship XSS via `srcdoc` + same-origin | High if anyone "just wants TOC to be easy" | Invariants 2–3; code review checklist in the spec; a test that fails if `allow-same-origin` appears next to `allow-scripts` on the host iframe |
+| Merge to `main` auto-ships Pages + DMG auto-update | High if Session 01 is a normal PR | Staging rail: Session 00 on `main`, runtime on `html`, flag off in production builds, go/no-go after Session 02 demo |
+| `#document-stage` clips markdown print even with HTML gates off | High | Flag does not isolate layout; golden-path Print on the HTML branch before `html` → `main` |
 | We become a bad browser (navigation, CDNs, popups) | Medium (feature requests will ask) | Product "no" list; relative document links open tabs |
 | Print regresses to viewport clip | Medium (new full-height ancestor) | Reuse `buildPrintableDocument`; add HTML to the print regression notes |
 | Jest is green, production sandbox is not | High (harness + mocks) | Manual smoke; real-attribute test; no Safe-mode claims from passthrough purify |

--- a/docs/project-html/2026-08-23-brainstorm-html-documents.md
+++ b/docs/project-html/2026-08-23-brainstorm-html-documents.md
@@ -7,6 +7,11 @@ iOS/iPadOS (WKWebView shell)
 **Decision already taken:** **fork the document runtime.** Do not convert
 HTML to markdown. Do not feed HTML through `marked` + `#markdown-content`.
 
+**Council (same day):** thesis held; Session 01 was not implementation-ready.
+Amendments live in
+[council-html-plan-review](2026-08-23-council-html-plan-review.md)
+and are folded into the spec + Session 01 checklist.
+
 This is a three-lens plan for making SpecDown honest about the files AI
 systems actually emit in 2026. It is written to the same standard as the
 modernization evaluation
@@ -448,14 +453,20 @@ Not on web, not in Electron, not in WKWebView.
 **Invariant 2.** The preview frame is isolated:
 
 ```
-sandbox="allow-scripts allow-forms"
+sandbox="allow-scripts"
+allow=""
 ```
 
 No `allow-same-origin`. No `allow-top-navigation`. No
+`allow-forms` in v1 (injected CSP is `form-action 'none'`). No
 `allow-popups` in v1 (external links are rewritten to
 `target="_blank" rel="noopener"` and intercepted by the host
 bridge → parent → existing desktop `openExternal` / web
-`window.open` policy).
+`window.open` policy). Empty `allow` denies device permissions.
+
+**Invariant 2b (council F3).** The iframe must not become a
+browser. Preview `src` stays the blob we minted; desktop
+`will-frame-navigate` denies in-frame http(s).
 
 **Invariant 3.** We never combine `srcdoc` (or a blob URL that
 inherits the app origin) with `allow-same-origin` +
@@ -478,10 +489,13 @@ the HTML faithful path (it would strip the document). It *is* the
 HTML **Safe mode** path (Phase 2) and a defense for any HTML we
 *do* inject into the parent (we should inject none).
 
-**Invariant 6.** CSP: the app's meta CSP stays as it is (scripts
-`'self' 'unsafe-eval'` for Mermaid; `object-src 'none'`;
-`form-action 'none'`). The iframe document gets its **own** CSP
-meta we inject:
+**Invariant 6.** CSP: the app's script policy stays as it is
+(`'self' 'unsafe-eval'` for Mermaid; `object-src 'none'`;
+`form-action 'none'`). **The app CSP must gain**
+`frame-src 'self' blob: file: specdown:` — today's `default-src`
+has no `blob:`, so a blob iframe is blocked (council F1). Do not
+add `blob:` to `script-src`. The iframe document gets its **own**
+CSP meta we inject:
 
 ```
 default-src 'none';
@@ -759,9 +773,12 @@ Sessions are implementation-sized, one PR each, rebase-and-merge.
 ### Session 01 — Kind + open + sandbox (this project's first code)
 
 See
-[`2026-08-23-tasks-session-01-kind-and-open.md`](2026-08-23-tasks-session-01-kind-and-open.md).
+[`2026-08-23-tasks-session-01-kind-and-open.md`](2026-08-23-tasks-session-01-kind-and-open.md)
+and the [council amendments](2026-08-23-council-html-plan-review.md).
 Ship the fork's skeleton: detect, accept, isolate, raw, tests,
-sample. No workspace, no Find-in-page, no protocol.
+sample, **parent `frame-src`**, **workspace listing**, **honest
+chrome** (Print hidden), **iframe teardown**, **navigation lock**.
+No Find-in-page, no host-internal print, no asset protocol.
 
 **Demo:** drop `html-showcase.html`, see the designed page, toggle
 Raw, switch to a markdown tab and back, confirm the document cannot
@@ -775,8 +792,9 @@ creator-detect. Hide anything still dishonest.
 
 ### Session 03 — Mixed workspace + links
 
-Scan union, sidebar icons or quiet kind mark, relative links both
-ways, repo browser HTML, lone-file asset toast.
+Listing already shipped in Session 01. This session is relative
+links both ways, repo browser HTML, lone-file asset toast, quiet
+kind mark in the sidebar.
 
 ### Session 04 — Desktop asset protocol + web folder assets
 
@@ -787,7 +805,8 @@ real for multi-file agent output.
 ### Session 05 — Safe mode + trust UX
 
 Per-tab Faithful/Safe, toast + ⋮ copy, Safe = no scripts +
-DOMPurify (real library tests). Default stays Faithful.
+DOMPurify (real library tests). Default: **Faithful for local
+files, Safe for URL-opened HTML** (council H10).
 
 ### Session 06 — Enhance (only if Session 01–04 got used)
 

--- a/docs/project-html/2026-08-23-brainstorm-html-documents.md
+++ b/docs/project-html/2026-08-23-brainstorm-html-documents.md
@@ -465,17 +465,14 @@ bridge → parent → existing desktop `openExternal` / web
 `window.open` policy). Empty `allow` denies device permissions.
 
 **Invariant 2b (council F3).** The iframe must not become a
-browser. Preview `src` stays the blob we minted; desktop
+browser. Preview `src` stays the preview-host URL; desktop
 `will-frame-navigate` denies in-frame http(s).
 
-**Invariant 3.** We never combine `srcdoc` (or a blob URL that
-inherits the app origin) with `allow-same-origin` +
-`allow-scripts`. That combination is XSS. The v1 host uses a
-**blob: URL** created from a rewritten document, or a **custom
-protocol** on desktop (`specdown-doc://`), both of which are
-non-app origins. `srcdoc` is allowed only if the iframe stays
-*without* `allow-same-origin` (opaque). Prefer blob/protocol so
-relative URL resolution has a fighting chance in Phase 2.
+**Invariant 3.** Preview is a **bundled host page** (real URL,
+own CSP), not `blob:` / `srcdoc`. Those inherit the parent CSP
+and (for blob) the app origin. `allow-same-origin` + scripts
+on either is XSS. Desktop `specdown-doc://` remains Session 04
+for sibling assets.
 
 **Invariant 4.** The parent talks to the frame only via
 `postMessage` with a strict origin check and a typed message
@@ -492,10 +489,10 @@ HTML **Safe mode** path (Phase 2) and a defense for any HTML we
 **Invariant 6.** CSP: the app's script policy stays as it is
 (`'self' 'unsafe-eval'` for Mermaid; `object-src 'none'`;
 `form-action 'none'`). **The app CSP must gain**
-`frame-src 'self' blob: file: specdown:` — today's `default-src`
-has no `blob:`, so a blob iframe is blocked (council F1). Do not
-add `blob:` to `script-src`. The iframe document gets its **own**
-CSP meta we inject:
+`frame-src 'self' file: specdown:` so the bundled preview host
+can be framed. Do not add `blob:` or `'unsafe-inline'` to parent
+`script-src`. The **preview host page** (not a blob document)
+carries its own CSP:
 
 ```
 default-src 'none';
@@ -851,10 +848,8 @@ looks like our existing product) and wrong (most agent HTML is
 ## 8. Open questions (decide in Session 01 or 02, not in the abstract)
 
 1. **Blob URL vs `srcdoc` vs desktop protocol for v1 preview?**
-   Recommendation: **blob URL on all surfaces in Session 01**
-   (simplest opaque origin). Desktop protocol is Session 04.
-   Avoid `srcdoc` unless blob+base is insufficient for a URL-opened
-   file (then `<base>` on the blob document is enough).
+   **Neither blob nor srcdoc.** Bundled `html-preview-host.html`.
+   Desktop protocol is Session 04.
 2. **Do we sniff `Content-Type` on URL open when the path has no
    extension?** **No in Session 01.** Extension-only. Sniffing
    turns the URL box into a scripted browser. Session 05 if ever.

--- a/docs/project-html/2026-08-23-brainstorm-html-documents.md
+++ b/docs/project-html/2026-08-23-brainstorm-html-documents.md
@@ -855,18 +855,15 @@ looks like our existing product) and wrong (most agent HTML is
    Avoid `srcdoc` unless blob+base is insufficient for a URL-opened
    file (then `<base>` on the blob document is enough).
 2. **Do we sniff `Content-Type` on URL open when the path has no
-   extension?** Recommendation: yes, `text/html` → html, otherwise
-   markdown (today's behavior). Don't sniff bytes for `<!DOCTYPE
-   html>` on `.md` files — extension wins.
+   extension?** **No in Session 01.** Extension-only. Sniffing
+   turns the URL box into a scripted browser. Session 05 if ever.
 3. **`.htm`?** Yes. Cost is one string in a list. Agents and
    Windows tools still emit it.
-4. **Default Faithful or Safe?** Faithful. Safe-as-default makes
-   the feature look broken on the exact files we are targeting.
-   Unknown-URL downloads could later default Safe; local files
-   the user dropped are a different trust level.
-5. **Is iOS in Session 01?** Shared renderer yes; `public.html`
-   registration yes (it's a plist/picker change, not TestFlight).
-   Device smoke is best-effort.
+4. **Default Faithful or Safe?** Local Faithful. Session 01 does
+   not fetch remote HTML by Content-Type. When URL HTML ships,
+   default Safe (council product seat).
+5. **Is iOS in Session 01?** Shared renderer + picker types.
+   No sample button. Device smoke is best-effort.
 
 ---
 

--- a/docs/project-html/2026-08-23-brainstorm-html-documents.md
+++ b/docs/project-html/2026-08-23-brainstorm-html-documents.md
@@ -1,0 +1,866 @@
+# Brainstorm — HTML Documents as a First-Class SpecDown Kind
+
+**Date:** 2026-08-23
+**Type:** brainstorm (product + UX + engineering plan)
+**Scope:** All surfaces — web (GitHub Pages / PWA), desktop (Electron),
+iOS/iPadOS (WKWebView shell)
+**Decision already taken:** **fork the document runtime.** Do not convert
+HTML to markdown. Do not feed HTML through `marked` + `#markdown-content`.
+
+This is a three-lens plan for making SpecDown honest about the files AI
+systems actually emit in 2026. It is written to the same standard as the
+modernization evaluation
+([`docs/project-modernization/2026-06-13-brainstorm-modernization-evaluation.md`](../project-modernization/2026-06-13-brainstorm-modernization-evaluation.md)):
+product first, then interaction design, then the engineering that makes
+the product safe to ship.
+
+---
+
+## 0. The decision in one page
+
+### What changed in the world
+
+SpecDown's original job is still true: *the reader for specs with serious
+diagrams.* What changed is the **artifact**. Agentic coding tools
+(Cursor, Claude Code, ChatGPT, Gemini, Copilot) still write long
+markdown — and they *also* write complete HTML files, constantly:
+
+| Artifact | Why agents emit HTML instead of markdown |
+|---|---|
+| Status reports / weekly reviews | Need a designed page, not a GitHub README |
+| Architecture explainers | Custom layout, tabs, callouts, in-page nav |
+| Dashboards / evals / scorecards | Charts, filters, client-side JS |
+| Slide decks | Full-viewport slides; markdown slides are a downgrade |
+| Interactive prototypes | Buttons, state, local demo data |
+| "Open this in a browser" handoffs | The agent already compiled the doc |
+
+Opening those in Chrome works, and is a bad reading workflow: no live
+reload while the agent iterates, no workspace of mixed `.md` + `.html`,
+no SpecDown print/PDF path, no tabs/recents/session, and `file://`
+sibling assets are a mess. Opening them in SpecDown *today* is
+impossible — every gate hard-rejects anything that is not
+`.md`/`.markdown`.
+
+### Two rejected designs
+
+**Convert (HTML → markdown via Turndown, then render).** This is the
+trap. It throws away the one thing the file was chosen for: the
+author's layout, CSS, and interaction. The result looks like a
+half-parsed email. Users will correctly call it broken. Agents will
+keep emitting HTML. We would be fighting the format.
+
+**Absorb (set `innerHTML` on `#markdown-content`).** This is the
+security trap. SpecDown's renderer security is *clean* because every
+dynamic HTML path goes through DOMPurify and the app origin never
+executes document scripts. Dumping an agent's HTML into the app origin
+is an XSS primitive with a file picker as the delivery mechanism. The
+v2 audit called renderer security "clean — no injection sink found."
+That finding is not optional.
+
+### The fork
+
+```
+                    open()
+                      │
+                      ▼
+              detectKind(name)
+                 │         │
+        markdown │         │ html
+                 ▼         ▼
+         renderMarkdown   renderHtmlDocument
+         (compiler)       (already compiled)
+                 │         │
+                 ▼         ▼
+         #markdown-content  sandboxed <iframe>
+         marked → purify    opaque origin + host bridge
+         mermaid / TOC /    faithful preview
+         annotate / present
+                 │         │
+                 └────┬────┘
+                      ▼
+              shared chrome
+         tabs · recents · workspace
+         live reload · print · palette
+         file info · theme chrome
+```
+
+Markdown stays the **compiler pipeline** (parse → sanitize → enhance).
+HTML is a **document kind** with its own render host. Shared chrome
+(tabs, recents, workspace, live reload, print, command palette) is
+kind-agnostic. Features that assume a SpecDown-owned DOM (annotations,
+presentation, comment-reveal) are **capability-gated** per kind, not
+half-wired.
+
+That is the whole project. Everything below is how to do it without
+becoming a browser, without diluting markdown, and without giving up
+the security posture the modernization wave earned.
+
+---
+
+## 1. Product snapshot (what exists today)
+
+SpecDown is a markdown *viewer* — deliberately not an editor — whose
+differentiator is interactive Mermaid: per-diagram pan/zoom, fullscreen
+with minimap, presentation mode, SVG/PNG export. One shared
+`markdown-viewer/` runs on web, desktop, and iOS.
+
+Every ingress is markdown-only:
+
+| Gate | Where | What it accepts |
+|---|---|---|
+| Browse / `<input accept>` | `index.html` | `.md,.markdown` |
+| Drag-and-drop | `features/file-loading.js` | `VALID_EXTENSIONS` |
+| Desktop `Open…` / Finder / `open-file` | `desktop/main.js` | same list |
+| Desktop workspace scan | `desktop/main.js` `scanWorkspace` | same list |
+| Web workspace scan | `features/workspace.js` | `.md`/`.markdown` links |
+| URL fetch | `handleUrl` + `normalizeMarkdownUrl` | any URL, then treated as markdown |
+| GitHub repo browser | `features/repo-browser.js` | GitHub search for `.md` |
+| PWA "Open with" | `manifest.webmanifest` `file_handlers` | `text/markdown` |
+| iOS document types | `ios/project.yml` | `net.daringfireball.markdown`, `public.plain-text` |
+| iOS picker UTTypes | `WebBridge.swift` | plainText / sourceCode / json / xml — **not** `public.html` |
+| Bundled samples / landing | `landing.js`, iOS sidebar | `.md` only |
+| Tab / render | `state.Tab.rawMarkdown` → `renderMarkdown` | always `marked.parse` |
+
+There is no `kind` on a tab. The render function's name is the product
+assumption: everything is markdown.
+
+That assumption is now the adoption blocker for the fastest-growing
+document source we have — agents.
+
+---
+
+## 2. Product management evaluation
+
+### 2.1 Positioning — expand the job, keep the soul
+
+The honest one-liner today:
+
+> The reader for specs with serious diagrams.
+
+The honest one-liner after this project:
+
+> The reader for AI-generated specs — markdown and HTML — with serious
+> diagrams.
+
+We are **not** becoming:
+
+- A browser (address bar, history, multiple origins, extensions)
+- An HTML editor or "live server" (Vite/BrowserSync already exist)
+- A generic "open any file" kitchen sink (PDF, DOCX, PPTX stay out)
+- A markdown converter that "fixes" HTML
+
+We **are** becoming the place you drop whatever the agent just wrote,
+and *read* it — with SpecDown's existing reading workflow around it.
+
+That is a tighter product move than it looks. The competition for
+markdown-with-Mermaid is still weak (GitHub static diagrams, VS Code
+preview, Obsidian-as-editor). The competition for "open this HTML the
+agent made" is **Chrome**, which is free, ubiquitous, and terrible at
+the *iteration* loop (agent writes file → you reload → you lost your
+scroll, your folder, your other tabs, your print settings).
+
+**The wedge is live-reload + workspace + print, not "we render HTML."**
+Anyone can iframe a file. SpecDown's unique offer is: the HTML sits in
+the same reading surface as the markdown spec it came from, reloads
+when the agent saves, prints as a document, and does not execute in
+the app origin.
+
+### 2.2 Jobs to be done (ranked)
+
+1. **Agent iteration.** I asked the agent for a report / deck /
+   dashboard. It wrote `out/report.html`. I want to see it, say
+   "change the chart," and watch it update. (Desktop live reload is
+   the killer feature. Web folder + reload-from-disk is the fallback.)
+2. **Mixed spec repositories.** A `docs/` folder has `architecture.md`
+   *and* `review.html` *and* `slides.html`. I want one workspace, one
+   sidebar, relative links that work in both directions.
+3. **Faithful reading.** I want the page the agent designed, not a
+   SpecDown-styled approximation. Typography, color, layout, and
+   in-page JS (tabs, charts) are the document.
+4. **Share / archive.** Print or PDF the HTML the same way I print a
+   markdown spec — full document, not the visible viewport (the
+   hard-won print path must survive).
+5. **Review.** Find in document, TOC if the HTML has headings, file
+   info, annotations later. Not in v1 if they fight the sandbox.
+
+### 2.3 What we will not ship (the product "no")
+
+Saying no is the whole product. HTML support is how products accidentally
+become browsers.
+
+| Temptation | Why we refuse |
+|---|---|
+| Navigate the iframe to arbitrary http(s) pages | That's a browser. External links leave SpecDown (desktop already has `openExternal`). |
+| `allow-same-origin` + `allow-scripts` on `srcdoc` | XSS in the app origin. Absolute veto. |
+| Restyle the document with SpecDown tokens | Destroys the artifact. Theme chrome stays *around* the document. |
+| Convert HTML → markdown as a default path | See rejected designs. A later "Copy as markdown" is a command, not a viewer. |
+| PDF / DOCX / images-as-documents | Different runtimes, different security, different jobs. One new kind per project. |
+| Edit the HTML | Viewer, not editor. Raw view is read-only source, same as markdown. |
+| Auto-run a local HTTP server | Fixes sibling assets at the cost of ports, firewalls, and "is this a dev tool?" Identity clash. A contained custom protocol on desktop is enough. |
+| Execute document scripts in the parent | Never. The host bridge is *our* script, injected, talking via `postMessage`. |
+
+### 2.4 Adoption story (who cares, in order)
+
+1. **The person already using SpecDown desktop for agent-written
+   markdown.** They already have live reload. The next file the agent
+   writes is `.html`. This is a one-release unlock, not a new audience.
+2. **The person who currently `open report.html` in Chrome, then
+   alt-tabs back to the agent.** We steal that loop.
+3. **Teams reviewing a folder of generated artifacts** (eval HTML +
+   design-doc markdown). Workspace mode becomes the review surface.
+4. **Web / PWA users** dropping a single file. Weaker (no live reload,
+   no sibling assets unless they Open Folder) but it still beats
+   "rejected: please select a valid Markdown file."
+
+iOS is last for *distribution* reasons (still no TestFlight), but the
+shared renderer must work there from Session 01 or we grow a
+platform-skew the iPhone action-sheet lesson already taught us.
+
+### 2.5 Success looks like
+
+- A user can drop `report.html` on any surface and see the page the
+  agent designed, inside SpecDown chrome, without a toast that says
+  "please select a valid Markdown file."
+- The same user can keep a markdown spec and an HTML report open in
+  two tabs and not wonder why one of them "looks like GitHub."
+- An untrusted HTML file cannot read SpecDown state, cannot hit
+  `window.specdown`, cannot run in the app origin. A security review
+  of the HTML path should be able to say the same sentence the v2
+  audit said about markdown: no injection sink.
+- Desktop live reload updates the HTML preview the way it updates
+  markdown. This is the demo.
+- We have not added a second empty-state product. The landing still
+  says SpecDown. The drop card just accepts more files.
+
+### 2.6 Pricing the identity risk
+
+SpecDown's name and README still say *markdown viewer*. That is fine
+for a long time. We do **not** rename the app. We do **not** lead the
+showcase with "now opens HTML!" like a file-manager changelog.
+
+We change the *job* in the lede ("AI-generated specs") and keep
+Mermaid as the differentiator. HTML is how we stay the reader for
+those specs as the artifact mix shifts. If, two releases later, HTML
+opens outnumber markdown opens, *then* we talk about naming. Not now.
+
+---
+
+## 3. UX design evaluation
+
+### 3.1 The feeling we want
+
+Opening markdown in SpecDown feels like: *the document is the product;
+the chrome is a slim reader.* Opening HTML must feel like: *the
+document is still the product — and this one brought its own
+typesetting.*
+
+The failure modes are both obvious:
+
+- **Over-chrome.** We wrap a designed page in SpecDown's prose column,
+  max-width, and tokens. It looks imprisoned. Users will open it in
+  Chrome instead.
+- **Under-chrome.** We go fullscreen-iframe and lose tabs, filename,
+  Live chip, print, find. Then we are Chrome with extra steps.
+
+The design answer is a **document stage**: the iframe is a first-class
+surface that owns the content pane (`#markdown-content` becomes a
+kind-aware stage, or we add `#document-stage` and keep the markdown
+root inside it). SpecDown chrome stays *outside* the stage. The
+document's CSS never leaks out; SpecDown's CSS never leaks in
+(iframe boundary).
+
+### 3.2 Empty state and first-run
+
+Today the web landing is a showcase: "Drop Markdown File Here," Try
+diagram showcase, pillars about diagrams. Desktop/iOS keep the compact
+drop-zone.
+
+Copy change, not a redesign:
+
+- Drop card: **"Drop a Markdown or HTML file"**
+- Browse accept list includes `.html,.htm`
+- Helper line: "HTML opens as the page it is — not converted to
+  markdown."
+- One bundled sample: `samples/html-showcase.html` — a *designed*
+  one-pager (not an unstyled kitchen sink) that shows why the fork
+  exists: custom layout, a small chart or tabs, a heading TOC can
+  see. The existing Mermaid markdown sample stays the hero; the HTML
+  sample is a second button, not a replacement.
+
+Do **not** add a third pillar or a second hero. Coherence debt is how
+the v2 audit said the last feature wave felt. HTML is an accepted
+*input*, not a new product on the landing.
+
+### 3.3 Kind-aware chrome (the toolbar problem)
+
+The desktop toolbar is already at its limit (Contents / Split /
+Annotate / Present / Search / ⋮). HTML must not add a button. It must
+*subtract* ones that lie.
+
+| Control | Markdown | HTML v1 | HTML later |
+|---|---|---|---|
+| Filename + Live chip | yes | yes | |
+| File info | yes | yes | |
+| Raw / Preview | yes | yes (source / page) | |
+| Split | yes | yes (source \| page) | |
+| Find | yes | yes (via host bridge) | |
+| Contents (TOC) | yes | yes if headings exist | |
+| Print / PDF | yes | yes (bridge `print`) | |
+| Present | if Mermaid | hidden unless we detect presentable diagrams | Phase 3 enhance |
+| Annotate / Notes | yes | hidden | Phase 4, host-bridge anchors |
+| Comments (authored `<!-- -->`) | yes | hidden | probably never — HTML comments are source, not a reading feature |
+| Workspace Files | if folder open | same | mixed kinds |
+| Command palette | all commands | commands that apply; others filtered or disabled with reason | |
+
+iPhone: every new *reachable* action must be added to the iOS action
+sheet. For v1 that means Open already works (picker types), Print
+already exists, Raw/Find/Contents need sheet entries **if** they are
+not already there for markdown. Do not add an "HTML options" row.
+
+Tab chrome: a quiet kind mark, not a badge farm. The tab title is the
+filename. A `title` tooltip can say `HTML document`. An optional 12px
+`HTML`/`MD` text in the tab is acceptable if it stays visually quieter
+than the close button. No file-type icons in two colors — that is a
+finder, not a reader.
+
+### 3.4 Theme: the document wins
+
+SpecDown light/dark/auto applies to **chrome**. It does not recolor
+the HTML document.
+
+AI HTML almost always ships its own palette. Forcing
+`prefers-color-scheme` or injecting SpecDown tokens will fight the
+author and create the "imprisoned page" failure.
+
+Optional, later, not v1: a host-bridge message
+`{ type: 'specdown-theme', theme: 'dark' }` for documents that
+*opt in* (e.g. they already listen to `prefers-color-scheme`). Never
+rewrite their CSS.
+
+The empty iframe letterbox (if the document is narrower than the
+stage) uses the chrome background, not a second white page.
+
+### 3.5 Trust and the sandbox banner
+
+Users will not understand "opaque origin." They will understand:
+
+> This page runs in a sandbox. It cannot touch SpecDown or your other
+> documents.
+
+Show that **once per session** the first time an HTML tab opens, as a
+toast (not a modal, not a permanent bar that steals 40px from the
+document). A ⋮ menu item "About HTML sandbox…" can repeat it.
+
+If we later add Safe (no-script) vs Faithful (scripts on), that is a
+per-tab toggle in the ⋮ menu + palette, default **Faithful**. Safe is
+the "I don't know who made this file" escape hatch. Do not put it on
+the toolbar.
+
+### 3.6 Error and empty-document states
+
+| Situation | UX |
+|---|---|
+| `.html` with empty body | Stage shows a quiet empty state: "This HTML file has no content." Raw still works. |
+| File too large (cap) | Toast, refuse to open. Same energy as the 10-tab limit. |
+| Parse failure (not UTF-8, binary named `.html`) | Toast: "Couldn't read this as text." |
+| Document throws in the iframe | Host bridge reports `{ type: 'specdown-error' }`; toast once; Raw still works. Do not white-screen the chrome. |
+| Sibling asset 404 (`./chart.js`) | The page looks broken *inside* the iframe, like a browser. v1 toast only if we *know* there is no base (lone dropped file referencing relative URLs). Phase 2 protocol fixes the desktop case. |
+| User drops `index.html` + folder | v1: the file opens, assets miss. Desktop tip in the toast: "Open the folder to load images and scripts next to this file." Phase 2 makes Open Folder the real fix. |
+
+### 3.7 Find, TOC, and print — designed for a wall
+
+The iframe is a security wall. The parent cannot read
+`contentDocument`. So Find/TOC/Print cannot be "query the rendered
+DOM" the way markdown does.
+
+UX implication: we must not ship a Find that only searches the source
+and highlights nothing in the page — that feels like a bug. v1 Find
+goes through the **host bridge** (our injected script highlights in
+the iframe and reports match counts). TOC is built from a
+`DOMParser` parse of the source *and* confirmed/refreshed by a
+`headings` message from the host after the page's own JS has run
+(so JS-injected headings appear). Print is a bridge command, not
+`window.print()` on the SpecDown window (the print-clips-to-viewport
+bug must not return).
+
+If a slice cannot do Find-in-page honestly, **hide Find** for HTML
+rather than ship a lying control. Same rule as Present.
+
+### 3.8 Motion, a11y, focus
+
+- The iframe is a single tab stop. Do not leave the user trapped
+  inside the document with no way back — the host cannot fix the
+  document's own focus traps, but SpecDown chrome (palette, `?`,
+  Find, Esc) must keep working. Esc closes SpecDown overlays first;
+  a second Esc is *not* "exit the HTML" (there is nowhere to exit to).
+- `prefers-reduced-motion` applies to chrome transitions only.
+- Stage iframe needs `title` = filename (accessible name).
+- Kind changes must be announced: when a tab switch goes markdown →
+  HTML, an `aria-live` polite update ("HTML document") is enough.
+- Contrast of chrome stays our problem; contrast inside the document
+  is the author's.
+
+### 3.9 Per-surface notes
+
+- **Web.** Drop / browse / URL / Open Folder (Chromium). Lone File
+  drop has no directory, so relative assets break — the toast in
+  §3.6 is the honesty. PWA file handlers should advertise HTML so
+  "Open with SpecDown" works for both kinds.
+- **Desktop.** This is the home surface for the job. Finder
+  "Open with," dock drop, live reload, workspace scan, File menu
+  filters, and (Phase 2) a contained asset protocol. Dialog title
+  becomes "Open File" with a Markdown + HTML + All filter list.
+- **iOS.** Picker must include `public.html` or users with Files
+  full of agent HTML will not see them. iPhone sheet must expose
+  Raw / Find / Contents if those are in v1. Do not wait for
+  TestFlight to wire the shared renderer — the last project taught
+  us "works in the bundle" ≠ "reachable on iPhone."
+
+---
+
+## 4. Engineering evaluation (distinguished-engineer lens)
+
+### 4.1 Why a fork is cheaper than it looks — and more expensive than a flag
+
+Cheaper: the open path is already a funnel (`handleFile` /
+`openFileByPath` / `handleUrl` / workspace / iOS `loadFileContent`).
+Kind detection is an extension check plus an optional sniff. Tabs
+already carry `rawMarkdown`, `viewMode`, `filePath`, `sourceMeta`.
+Live reload already re-reads and re-renders. Print already refuses
+to print the live viewport.
+
+More expensive: **every feature that walks `#markdown-content` is a
+markdown assumption.** A grep today hits render, TOC, search, split,
+annotations, comments, diagrams, presentation, print clone,
+workspace link clicks, code-copy, creator-detect. A boolean
+`isHtml` sprinkled through those modules is how we get a third
+"notes" button. The fork has to be a **capability table** + a
+single `renderDocument(tab)` entry, not 20 `if (html)` branches.
+
+### 4.2 Security model (non-negotiable)
+
+This is the load-bearing section. If we get it wrong, HTML support
+is a vulnerability we shipped on purpose.
+
+**Invariant 1.** Document scripts never run in the SpecDown origin.
+Not on web, not in Electron, not in WKWebView.
+
+**Invariant 2.** The preview frame is isolated:
+
+```
+sandbox="allow-scripts allow-forms"
+```
+
+No `allow-same-origin`. No `allow-top-navigation`. No
+`allow-popups` in v1 (external links are rewritten to
+`target="_blank" rel="noopener"` and intercepted by the host
+bridge → parent → existing desktop `openExternal` / web
+`window.open` policy).
+
+**Invariant 3.** We never combine `srcdoc` (or a blob URL that
+inherits the app origin) with `allow-same-origin` +
+`allow-scripts`. That combination is XSS. The v1 host uses a
+**blob: URL** created from a rewritten document, or a **custom
+protocol** on desktop (`specdown-doc://`), both of which are
+non-app origins. `srcdoc` is allowed only if the iframe stays
+*without* `allow-same-origin` (opaque). Prefer blob/protocol so
+relative URL resolution has a fighting chance in Phase 2.
+
+**Invariant 4.** The parent talks to the frame only via
+`postMessage` with a strict origin check and a typed message
+enum (`specdown-ready`, `specdown-headings`, `specdown-find-result`,
+`specdown-print-done`, `specdown-open-external`, `specdown-error`).
+Unknown messages are dropped. The frame cannot call
+`window.specdown` because it cannot see it.
+
+**Invariant 5.** DOMPurify remains the markdown path. It is **not**
+the HTML faithful path (it would strip the document). It *is* the
+HTML **Safe mode** path (Phase 2) and a defense for any HTML we
+*do* inject into the parent (we should inject none).
+
+**Invariant 6.** CSP: the app's meta CSP stays as it is (scripts
+`'self' 'unsafe-eval'` for Mermaid; `object-src 'none'`;
+`form-action 'none'`). The iframe document gets its **own** CSP
+meta we inject:
+
+```
+default-src 'none';
+script-src 'unsafe-inline' 'unsafe-eval' https: blob:;
+style-src 'unsafe-inline' https:;
+img-src data: blob: https: http:;
+font-src data: https:;
+connect-src https:;
+object-src 'none';
+base-uri 'self';
+form-action 'none';
+frame-ancestors 'self';
+```
+
+`'unsafe-inline'` / `'unsafe-eval'` inside the *frame* is
+deliberate: that is how agent HTML is written. It is acceptable
+only because of Invariant 1. `connect-src https:` lets charts
+fetch; Phase 2 Safe mode sets `connect-src 'none'` and
+`script-src` empty.
+
+**Invariant 7.** Desktop path containment for any asset protocol
+reuses the workspace rule: resolved paths must stay under the
+document's directory (or the workspace root). No
+`/etc/passwd`. The relative-link work already taught us this
+(`requestOpenRelative` + root containment). Copy that, don't
+re-invent it.
+
+**Invariant 8.** Tests that claim to prove sanitizer / sandbox
+behavior must exercise the **real** library and a real iframe
+policy, not the passthrough DOMPurify mock. The comment-node bug
+was the lesson; we will not relearn it with `allow-same-origin`.
+
+### 4.3 Host rewrite (what we do to the file before it hits the frame)
+
+We do not display the raw bytes. We parse with `DOMParser`
+(`text/html`), then:
+
+1. Ensure a `<html>`/`<head>`/`<body>` skeleton if the file is a
+   fragment (`<div>…</div>` is common from agents).
+2. Inject our CSP meta as the first head child.
+3. Inject `<script src="…/html-host.js">` (bundled, hashed) as the
+   last head child — **our** bridge, small, no deps.
+4. Set `<base href="…">` when we have a resolvable base (URL open,
+   desktop protocol, workspace). Omit for lone web File drops.
+5. Rewrite `target="_top"` / `_parent` on links to `_blank`.
+6. Optional: strip `<iframe>`, `<object>`, `<embed>`,
+   `<meta http-equiv="refresh">` — nested browsing is how a
+   document escapes a sandbox in spirit even when the origin is
+   opaque. v1 strips nested frames. Revisit if a real corpus needs
+   them.
+
+The rewritten HTML is what the blob/protocol serves. The tab still
+stores the **author's** raw source for Raw / Split / save-to-recents
+hashing / creator-detect.
+
+### 4.4 Module map (where the fork lives)
+
+Keep the seam boring and local:
+
+| Module | Role |
+|---|---|
+| `core/document-kind.js` **new** | `detectKind(filename)`, extension lists, capability table. Pure. Unique names (`htmlKind…`) for the eval harness. |
+| `features/html-document.js` **new** | Rewrite, blob lifecycle (revoke on tab close / re-render), iframe mount, host-bridge listener, Find/TOC/Print messages. |
+| `features/file-loading.js` | `VALID_EXTENSIONS` becomes the union; toast copy changes; URL filename fallback `untitled.html` when the path says so. |
+| `core/state.js` | `Tab.kind: 'markdown' \| 'html'`. Keep `rawMarkdown` as the source string in v1 (least churn); rename to `rawSource` only if a session is *only* that rename. |
+| `main.js` `renderMarkdown` | Becomes `renderDocument` that dispatches on `kind`. Markdown body stays here or moves to `features/markdown-document.js` if the file grows. |
+| `features/tabs.js` | Persist `kind`; reset the stage; don't assume `#markdown-content` innerHTML for HTML tabs. |
+| `features/workspace.js` + `desktop/main.js` `scanWorkspace` | Union of extensions; relative link regex includes `html?`. |
+| `features/repo-browser.js` | Search `md OR html` or two queries. Don't silently hide HTML in a repo the user pasted. |
+| `platform/ios-chrome.js` | Print payload for HTML uses the bridge snapshot or rewritten printable, never the live app layout. |
+| `desktop/main.js` | Filters, `isValidOpenableFile`, Finder associations, Phase 2 protocol. |
+| `ios/project.yml` + `WebBridge.swift` | `public.html`, picker UTTypes. |
+| `public/manifest.webmanifest` | `file_handlers` accept `text/html`. |
+| `index.html` | `accept=".md,.markdown,.html,.htm"`; stage markup. |
+
+Do not put HTML policy in `desktop/preload.js` beyond exposing a
+future `resolveDocumentAsset` if Phase 2 needs it. The
+`window.specdown` bridge stays the only shell coupling.
+
+### 4.5 Feature capability table (engineering view)
+
+```
+kind          md   html
+tabs          ●    ●
+recents       ●    ●
+session       ●    ●
+live reload   ●    ●
+file info     ●    ●
+raw / split   ●    ●
+print / pdf   ●    ●  (bridge, not app window)
+toc           ●    ●  (parser + host refresh)
+find          ●    ●  (host highlight) or hidden
+workspace     ●    ●  (Phase 1 scan; Phase 2 assets)
+relative link ●    ●  (Phase 1 .html in regex)
+mermaid       ●    ○  (Phase 3 enhance)
+present       ●    ○
+annotate      ●    ○  (Phase 4)
+comments UI   ●    ○
+code-copy     ●    ○  (document owns its <pre>)
+custom CSS    ●    ○  (would restyle the artifact)
+creator-detect●    ●  (same signatures + generator meta)
+```
+
+A feature that is ○ is **not called** for that kind. No empty
+panels, no "0 diagrams" Present button.
+
+### 4.6 Surface-specific engineering
+
+**Desktop.** `VALID_EXTENSIONS` and `isValidMarkdownFile` should
+become `isOpenableDocument` used by open, drop, session restore,
+recents, and workspace. Keep a `isMarkdownDocument` helper for
+anything that still *is* markdown-specific (there should be
+almost nothing in main.js). Phase 2: `protocol.registerFileProtocol`
+or `protocol.handle('specdown-doc')` rooted at the file's
+directory; the iframe `src` is `specdown-doc://doc/<id>/` +
+relative asset paths. Containment tests go next to the existing
+workspace-root tests.
+
+**Web.** Blob URL + optional `<base>` for URL-opened files
+(relative assets resolve against the remote URL — CORS still
+applies; broken assets fail like a browser). Workspace Open Folder
+can, in Phase 2, satisfy relative assets via blob URLs per file
+handle. v1 does not need that to be useful.
+
+**iOS.** `loadFileContent(content, filename)` already exists.
+Kind comes from `filename`. WKWebView hosting an iframe with a
+blob URL works. Security-scoped reads for `public.html` need the
+document type registered or Files "Open in SpecDown" won't offer
+us. Print stays on `buildPrintableDocument` / the existing
+`printDocument` bridge — for HTML, pass a printable snapshot from
+the host (`document.documentElement.outerHTML` after load) so
+charts exist, then run that through the same print window, not
+the live shell.
+
+### 4.7 Test strategy (written to the harness, not around it)
+
+The eval harness (`tests/helpers/loadApp.js`) inlines the module
+graph and evals at global scope. **Name every new top-level
+binding uniquely** (`htmlDetectKind`, `htmlMountFrame`, …). Do not
+export `render` or `openTab`.
+
+What to test in Session 01 (Jest/jsdom):
+
+- `detectKind` for `.md`, `.markdown`, `.html`, `.htm`, case, and
+  unknown → reject.
+- `handleFile` accepts HTML and creates a tab with `kind: 'html'`
+  and does **not** call `marked.parse`.
+- `handleFile` still rejects `.txt`, `.pdf`, `.exe`.
+- Rewrite injects CSP + host script; does not execute in jsdom
+  parent.
+- Capability table hides Present/Annotate for HTML.
+- Desktop `isOpenableDocument` unit tests (existing
+  `desktop-main.test.js` pattern).
+
+What Jest **cannot** honestly prove: Chromium sandbox flags,
+`postMessage` isolation, Electron protocol containment, WKWebView
+iframe behavior. Those get a short **manual smoke checklist** in
+the session tasks (web preview, desktop if a display exists,
+iOS simulator when an Apple runner is available). Do not invent
+a Playwright suite in Session 01.
+
+What we will not trust: a green suite that never created an
+`<iframe sandbox>`. At least one test must assert the iframe
+attribute string.
+
+### 4.8 Performance and limits
+
+- **Size cap:** 8 MB UTF-8. Agent HTML is usually tens to hundreds
+  of KB. Multi-megabyte inlined-base64 pages exist; they can wait
+  behind an explicit raise.
+- **Blob revoke** on tab close and before re-render (live reload)
+  or we leak.
+- **One iframe per HTML tab**, created on activate, destroyed or
+  frozen on background. Do not keep 10 live chart pages ticking.
+  v1 can keep src and hide; if memory shows up, tear down and
+  restore scroll via the host.
+- Mermaid stays lazy and **off** the HTML path in v1.
+
+### 4.9 Gotchas we already paid for (do not repurchase)
+
+From `CLAUDE.md` and the retrospective, applied to this project:
+
+- **Print in the visible window.** HTML print goes through the
+  existing printable-document path or `iframe` + host
+  `window.print()` *inside* a frame that is allowed to print. Do
+  not `webContents.print()` on a hidden BrowserWindow. Do not
+  `window.print()` the SpecDown shell.
+- **iPhone action sheet.** New reading actions must be wired
+  there.
+- **Passthrough mocks.** Sandbox tests need the real attribute
+  and, for purify-on-Safe-mode, the real DOMPurify.
+- **`window.prompt`/`alert`.** Any "this HTML looks dangerous,
+  continue?" UI is an in-app modal.
+- **Electron `File.path`.** Drops still go through
+  `getPathForFile` / `openDroppedPath`. HTML does not get a
+  second drop path.
+- **One logical change per PR.** Session 01 is "kind + open +
+  sandboxed preview." Session 02 is workspace/assets or Find/TOC
+  honesty. Do not land the protocol and the landing rewrite and
+  annotations in one PR.
+
+---
+
+## 5. Feature set (the catalog, with phase tags)
+
+### P0 — Must be true before we claim "we support HTML"
+
+- Open `.html` / `.htm` from browse, drop, desktop dialog, desktop
+  OS-open, iOS picker, URL (extension or `Content-Type: text/html`),
+  PWA file handler.
+- Tab `kind: 'html'`.
+- Faithful sandboxed preview (scripts in the frame, not the app).
+- Raw source view + split.
+- Rejected-file toast updated.
+- App origin cannot be reached from document JS (invariants).
+
+### P1 — Reader, not just a frame
+
+- TOC from headings (parser + host refresh).
+- Find in page via host bridge (or hidden).
+- Print / PDF via host snapshot + existing printable path.
+- File info, recents, session restore, live reload.
+- Kind-aware toolbar / palette / iOS sheet.
+- Landing copy + `html-showcase.html` sample.
+- Creator-detect on HTML (`<meta name="generator">` + existing
+  signatures in source).
+
+### P2 — Mixed workspace (the real product)
+
+- Workspace scan includes HTML.
+- Relative links `.md` ↔ `.html` ↔ `#anchors`.
+- Desktop `specdown-doc://` (or equivalent) for sibling assets,
+  contained.
+- Web folder: resolve relative assets through file handles.
+- Lone-file toast pointing at Open Folder.
+- GitHub repo browser includes HTML.
+- Safe / Faithful per-tab mode.
+
+### P3 — SpecDown-enhance (opt-in, not default)
+
+- Detect `<pre class="mermaid">` / `div.mermaid` in the HTML;
+  offer "Render diagrams with SpecDown" which uses our Mermaid
+  + pan/zoom + Present. Default remains faithful (their CDN
+  script, if any).
+- Presentation mode over those enhanced diagrams only.
+
+### P4 — Review workflows
+
+- Annotations via host-bridge anchoring (fingerprint of block
+  text, same store schema v2). Hard; do not start from the
+  parent DOM.
+- Export/import already exists; keys must include kind + a
+  stronger identity than filename (content hash) — that is an
+  annotations project that HTML can ride.
+
+### Explicitly later / never in this project
+
+- Editing, preview-as-you-type, format-on-save.
+- PDF/DOCX.
+- Running the document's service worker.
+- Full request interception / offline cache of document CDNs
+  (privacy + disk).
+- Multi-page sites (`about.html` navigating the iframe to
+  `pricing.html` as a site). Relative *document* links open a
+  **new tab** (or replace the current tab) via the parent, like
+  workspace markdown links — they do not navigate the frame.
+  That one sentence is how we stay a reader.
+
+---
+
+## 6. Phased roadmap
+
+Sessions are implementation-sized, one PR each, rebase-and-merge.
+
+### Session 01 — Kind + open + sandbox (this project's first code)
+
+See
+[`2026-08-23-tasks-session-01-kind-and-open.md`](2026-08-23-tasks-session-01-kind-and-open.md).
+Ship the fork's skeleton: detect, accept, isolate, raw, tests,
+sample. No workspace, no Find-in-page, no protocol.
+
+**Demo:** drop `html-showcase.html`, see the designed page, toggle
+Raw, switch to a markdown tab and back, confirm the document cannot
+`alert` in the parent (manual).
+
+### Session 02 — Reader chrome honesty
+
+TOC + Find-via-bridge + Print/PDF snapshot + kind-aware toolbar /
+palette / iOS sheet + file info + live reload verification +
+creator-detect. Hide anything still dishonest.
+
+### Session 03 — Mixed workspace + links
+
+Scan union, sidebar icons or quiet kind mark, relative links both
+ways, repo browser HTML, lone-file asset toast.
+
+### Session 04 — Desktop asset protocol + web folder assets
+
+The "Open Folder and the dashboard's `./chart.js` works" release.
+Containment tests. This is the session that makes Faithful mode
+real for multi-file agent output.
+
+### Session 05 — Safe mode + trust UX
+
+Per-tab Faithful/Safe, toast + ⋮ copy, Safe = no scripts +
+DOMPurify (real library tests). Default stays Faithful.
+
+### Session 06 — Enhance (only if Session 01–04 got used)
+
+Mermaid-in-HTML detection + opt-in SpecDown render + Present.
+Skip if we have no evidence anyone wants it.
+
+### Sequencing rationale
+
+Open+sandbox first because every later feature is unsafe or
+lying without it. Reader chrome second because a frame without
+Find/Print is Chrome. Workspace third because that is the job
+in §2.2. Assets fourth because they are the hard desktop
+problem and must not block the single-file 80% case. Safe mode
+fifth because we need Faithful in the world before we know the
+toggle's label. Enhance last — it is a differentiator, not the
+reason to exist.
+
+Do **not** start with Mermaid-in-HTML. That is comforting (it
+looks like our existing product) and wrong (most agent HTML is
+*not* a Mermaid document).
+
+---
+
+## 7. Risks
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| We ship XSS via `srcdoc` + same-origin | High if anyone "just wants TOC to be easy" | Invariants 2–3; code review checklist in the spec; a test that fails if `allow-same-origin` appears next to `allow-scripts` on the host iframe |
+| We become a bad browser (navigation, CDNs, popups) | Medium (feature requests will ask) | Product "no" list; relative document links open tabs |
+| Print regresses to viewport clip | Medium (new full-height ancestor) | Reuse `buildPrintableDocument`; add HTML to the print regression notes |
+| Jest is green, production sandbox is not | High (harness + mocks) | Manual smoke; real-attribute test; no Safe-mode claims from passthrough purify |
+| iPhone can't reach Raw/Find | High (historical) | Sheet wiring in Session 02, not "desktop works" |
+| Sibling assets make v1 feel broken | Medium | Honest toast; Session 04 on the roadmap in the README so it is not forgotten |
+| Identity dilution | Low if we keep the landing | Copy discipline in §3.2 |
+| Eval-harness name collision | Medium | Unique prefixes (`html*`) from the first file |
+| Agent HTML uses ES modules + import maps + shadow DOM | Medium | Faithful iframe handles most; we don't polyfill; Safe mode will look worse and that's OK |
+| Nested iframe / open-redirect in document | Medium | Strip nested frames in rewrite; no `allow-top-navigation` |
+
+---
+
+## 8. Open questions (decide in Session 01 or 02, not in the abstract)
+
+1. **Blob URL vs `srcdoc` vs desktop protocol for v1 preview?**
+   Recommendation: **blob URL on all surfaces in Session 01**
+   (simplest opaque origin). Desktop protocol is Session 04.
+   Avoid `srcdoc` unless blob+base is insufficient for a URL-opened
+   file (then `<base>` on the blob document is enough).
+2. **Do we sniff `Content-Type` on URL open when the path has no
+   extension?** Recommendation: yes, `text/html` → html, otherwise
+   markdown (today's behavior). Don't sniff bytes for `<!DOCTYPE
+   html>` on `.md` files — extension wins.
+3. **`.htm`?** Yes. Cost is one string in a list. Agents and
+   Windows tools still emit it.
+4. **Default Faithful or Safe?** Faithful. Safe-as-default makes
+   the feature look broken on the exact files we are targeting.
+   Unknown-URL downloads could later default Safe; local files
+   the user dropped are a different trust level.
+5. **Is iOS in Session 01?** Shared renderer yes; `public.html`
+   registration yes (it's a plist/picker change, not TestFlight).
+   Device smoke is best-effort.
+
+---
+
+## 9. North-star (how we'll know the phase was the right one)
+
+Six months after Session 01, the desktop app is where someone
+leaves an agent-written `docs/` folder open all afternoon:
+markdown architecture on the left, HTML review dashboard on the
+right, Live chip blinking when the agent saves, Print producing
+a real PDF of either kind. Nobody opened Chrome "just to see
+the HTML." Nobody converted the HTML to markdown to "use
+SpecDown." Nobody filed a security issue that starts with
+`innerHTML = fileText`.
+
+That is a better SpecDown. It is still a viewer. It is still
+not a browser. It is finally caught up to what the agents write.

--- a/docs/project-html/2026-08-23-brainstorm-names-and-press.md
+++ b/docs/project-html/2026-08-23-brainstorm-names-and-press.md
@@ -41,6 +41,27 @@ embargoed until the HTML wedge is real — shipping B after
 Session 01 (a sandboxed iframe) would be the landing launch
 the council already killed.
 
+**Under research (not a rename):** **Specular** and **Lantern**
+stay on the shortlist as interesting options. Shipping name
+remains SpecDown until that research lands.
+
+**Interesting lines (not swapping the live hero, not replacing
+the HTML-era lede):**
+
+- **Present the diagram, not a screenshot.** Already the
+  landing title. Still the differentiator. HTML is an input;
+  the aha is still the diagram you can fly through.
+- **Specs you can stand in front of.** Present as a room, not
+  a file. Does not say markdown or HTML, so it survives the
+  format fork. Pairs with Lectern. Short enough for a wordmark
+  subtitle or OG.
+- **SpecDown — Diagrams you can present.** Wordmark subtitle.
+  Same job as the landing title, quieter. Fine on a DMG,
+  About panel, or OG without the “screenshot” contrast.
+- **SpecDown — The spec reader.** Wordmark subtitle. Names
+  the job. Survives HTML. Soft enough to live under the
+  wordmark forever.
+
 ---
 
 ## 1. Product seat — what the name is for
@@ -104,7 +125,7 @@ is a guess — no trademark or domain search was run.
 |---|---|---|
 | SpecRead | 3 | Honest. Sounds like a feature, not a product. |
 | SpecView | 2.5 | “View” is chrome-adjacent; easy to confuse with file preview. |
-| Specular | 3 | “To look.” Pretty. People will say *speck-you-ler* or think lighting. |
+| **Specular** | 4 | **Under research.** Spec + *speculum* / specular — to look, a mirror highlight. Keeps “spec” in the word. Risks: *SPECK-yə-lər* vs *speck-YOU-lər*; 3D “specular highlight”; lighting/graphics products. |
 | Inspect | 1 | Taken, sounds like DevTools. |
 | Speclight | 2 | Spotlight clone energy. |
 
@@ -112,7 +133,8 @@ is a guess — no trademark or domain search was run.
 
 | Name | Score | Note |
 |---|---|---|
-| **Lectern** | 4 | You stand at it and present the diagram. Not a browser. Hard to spell; explain once. |
+| **Lantern** | 4 | **Under research.** Light for the page you are reading. Easy to say and spell. Warm, not a browser. Distinct from Lectern. Risks: crowded word (lamps, restaurants, other apps); no “spec” in the name. |
+| **Lectern** | 4 | You stand at it and present the diagram. Not a browser. Hard to spell; explain once. Do not confuse with Lantern. |
 | **Folio** | 3.5 | A set of leaves — md + html in one workspace. Crowded word (Vercel, legal, browsers). |
 | Codex | 3 | Book of many quires. Also every AI company in 2024. |
 | Dossier | 3 | Review vibe. A bit spy / HR. |
@@ -146,15 +168,25 @@ SpecDown AI, BriefAI, Rendered, Sideview, House Lights.
 
 ### Shortlist if we ever rename
 
-1. **SpecDown** (stay)
-2. **Afterwrite** — best *new* word for the job
-3. **Lectern** — best *old* word for the room
-4. **Faircopy** — if we want print/PDF in the name’s bones
-5. **Folio** — if workspace (mixed md+html) becomes the story
+1. **SpecDown** (stay / ship today)
+2. **Specular** — under research (spec family; “to look”)
+3. **Lantern** — under research (reading light; easy to say)
+4. **Afterwrite** — best *new* invented word for the job
+5. **Lectern** — the stand you present from (not Lantern)
+6. **Faircopy** / **Folio** — print bones / mixed workspace
 
-**Chair recommendation:** stay SpecDown. If a rename PR ever
-opens, the debate is Afterwrite vs Lectern, not a committee of
-twenty.
+**Chair recommendation:** ship as SpecDown. Specular and
+Lantern stay interesting; they are research, not a decision.
+If a rename PR ever opens, those two are in the room with
+Afterwrite — not a committee of twenty.
+
+### Research notes (Specular, Lantern)
+
+Not done here: trademark, domain, GitHub org/repo, App Store
+collision, how it sounds in a room, how it looks in a DMG
+title (`Specular Desktop` vs `Lantern Desktop` vs today’s
+`Specdown Desktop`). A later `project-rename` session should
+check those before anyone touches `package.json` `name`.
 
 ---
 
@@ -167,15 +199,28 @@ or “seamless.”
 ### Now (existing product — ship these)
 
 1. **Present the diagram, not a screenshot.**  
-   *(Already the landing title. Keep.)*
+   *(Already the landing title. **Keeper.** Still true after
+   HTML: the wedge is the other file, not a new aha.)*
 2. **A markdown viewer where Mermaid diagrams are first-class.**  
-   *(Already the lede. Keep.)*
+   *(Already the lede. Keep until HTML Session 02.)*
 3. **Not an editor. The reading and presenting layer.**  
    *(From the copy kit contrast. Good on a slide.)*
 4. **Zoom, pan, present, export — your architecture is a place
    you can fly through.**  
    *(Landing lede, slightly tightened.)*
-5. **Specs you can stand in front of.**
+5. **Specs you can stand in front of.**  
+   *(**Keeper / under research.** Present mode as a room you
+   stand in — the meeting, not the PNG. Format-agnostic, so it
+   still works when the file is HTML. Pairs with Lectern.
+   Risks: conference-slogan energy; does not name the diagram
+   unless you already know Present exists. Fine as a subtitle
+   or a second breath under the landing title.)*
+
+**Do not retire #1 to make room for #5, or the reverse.** They
+do different jobs: #1 is the product claim (diagrams, not
+screenshots). #5 is the feeling (you are in the room with the
+spec). The HTML-era lede (#6) is a third job (both files).
+Keep all three in the kit.
 
 ### After HTML is real (wedge shipped)
 
@@ -201,8 +246,14 @@ Use **one** of these as the new lede. Do not stack them.
 
 ### Subtitles (under the wordmark)
 
-- SpecDown — Diagrams you can present
-- SpecDown — The spec reader
+Keepers first — these are ok. The rest stay in the kit.
+
+- **SpecDown — Diagrams you can present** *(keeper: quiet
+  version of the landing claim)*
+- **SpecDown — The spec reader** *(keeper: the job, format-
+  agnostic)*
+- SpecDown — Present the diagram, not a screenshot
+- SpecDown — Specs you can stand in front of
 - SpecDown — Read the spec. Fly the diagram.
 - SpecDown — Markdown & HTML, still a viewer
 - SpecDown — After the agent writes
@@ -407,11 +458,18 @@ Free, no account: https://cbremer.github.io/specdown
 
 ## 8. What we are not deciding
 
-- No repo rename.
-- No landing hero change in HTML Session 01.
+- No repo rename. Specular and Lantern stay interesting;
+  they are research, not a ship name.
+- No landing hero change in HTML Session 01. The live title
+  stays **Present the diagram, not a screenshot.** Keeper
+  subtitles **Diagrams you can present** and **The spec
+  reader** stay in the kit, not on the homepage, until
+  someone deliberately A/Bs them. **Specs you can stand in
+  front of** likewise.
 - No trademark/domain work in this PR.
 - No “SpecDown AI” experiment, even as an A/B.
 
-If someone wants Afterwrite or Lectern, that is a **new**
-project folder (`project-rename`) with a real availability
-check — not a drive-by in the HTML implementation PRs.
+If someone wants Afterwrite, Lectern, Specular, or Lantern,
+that is a **new** project folder (`project-rename`) with a
+real availability check — not a drive-by in the HTML
+implementation PRs.

--- a/docs/project-html/2026-08-23-brainstorm-names-and-press.md
+++ b/docs/project-html/2026-08-23-brainstorm-names-and-press.md
@@ -1,0 +1,417 @@
+# Council — Names, taglines, and press
+
+**Date:** 2026-08-23
+**Type:** brainstorm (brand / comms, not a rename ticket)
+**Seats:** product, naming, voice, press
+**Subject:** What SpecDown is called, and how we talk about it, if HTML
+documents ship as a forked kind.
+**Companion:** [HTML plan](2026-08-23-brainstorm-html-documents.md) ·
+[council review](2026-08-23-council-html-plan-review.md) ·
+[feature copy](../project-sharing/2026-08-20-spec-feature-copy.md)
+
+This is **copy**, not a product rename. The HTML council already
+voted: do not change the one-liner until the wedge works (local
+HTML + Live chip + print). Session 01 does not touch the landing
+hero. These drafts are for after that, or for talking about the
+*existing* product today.
+
+---
+
+## Verdict (chair)
+
+**Keep the name SpecDown.** Spend the invention on taglines and
+on *when* we say HTML.
+
+A rename to chase “AI HTML” would trade a sharp, already-shipped
+word (spec + markdown + diagrams) for a generic 2026 slogan.
+The product seat from the architecture council was right: HTML
+is an **input**, not a company sentence.
+
+What *does* change, in layers:
+
+| When | Name | Tagline |
+|---|---|---|
+| **Now** (exists today) | SpecDown | A markdown viewer where Mermaid diagrams are first-class. |
+| **After HTML Session 02** (print + Live on a local `.html`) | SpecDown | The reader for specs — markdown, diagrams, and the HTML your agent just wrote. |
+| **Only if HTML opens dominate** | still SpecDown; *maybe* a subtitle | SpecDown — the reading surface. |
+| **Never for this project** | AgentRead, NotChrome, SpecDown AI | Anything that says browser, editor, or “for AI” as the noun. |
+
+Press: two releases below. **A** can go out today. **B** is
+embargoed until the HTML wedge is real — shipping B after
+Session 01 (a sandboxed iframe) would be the landing launch
+the council already killed.
+
+---
+
+## 1. Product seat — what the name is for
+
+The job is still *read*. The differentiator is still *diagrams
+you can fly through*. HTML is how we stay honest about the
+second file the agent writes.
+
+A name that wins on “opens HTML” loses the only reason this
+is not Chrome. A name that wins on “AI” expires in a year.
+A name that drops “spec” forgets the user (architects,
+reviewers, PMs reading a design).
+
+**Must protect**
+
+- Viewer, not editor (existing copy kit).
+- Not a browser (HTML council no-list).
+- Mermaid as the aha (landing hero, OG card, GIF).
+- No App Store / TestFlight claim.
+- No invented user counts.
+
+**The “Down” problem**
+
+SpecDown parses as *spec* + *markdown*. That is an asset for
+the current product and a tax once HTML is real. Options:
+
+1. **Keep and outgrow it** (recommended). Plenty of products
+   outlive their etymology (JavaScript, Firefox, GitHub).
+   “Down” becomes a proper noun, not a file extension.
+2. **Subtitle** — SpecDown Reader. Soft. A bit enterprise.
+3. **Rename** — only with a measurable reason (the architecture
+   council’s unenforceable “HTML opens outnumber markdown”
+   line). Until we can count, we do not rename.
+
+**Kill list (product)**
+
+- Names that mean “browser” or “preview server”
+- Names that mean “notes app” or “Obsidian competitor”
+- Names with “AI,” “Agent,” “GPT,” “Copilot”
+- Names that require a pronunciation guide in the first sentence
+
+---
+
+## 2. Naming seat — candidates
+
+Scored 1–5 on: say-it-once, repo/app continuity, not-a-browser,
+still-a-spec-reader, not-generic-AI. **5 is good.** Availability
+is a guess — no trademark or domain search was run.
+
+### Keep
+
+| Name | Score | Note |
+|---|---|---|
+| **SpecDown** | 4.5 | Already shipped, GitHub, DMG, PWA. “Down” is markdown residue; survive it. |
+| SpecDown Reader | 3.5 | Clearer job; longer; sounds like a SKU. |
+| Specdown | 4 | Same word, worse logo (we already title-case SpecDown). |
+
+### Spec family (small move)
+
+| Name | Score | Note |
+|---|---|---|
+| SpecRead | 3 | Honest. Sounds like a feature, not a product. |
+| SpecView | 2.5 | “View” is chrome-adjacent; easy to confuse with file preview. |
+| Specular | 3 | “To look.” Pretty. People will say *speck-you-ler* or think lighting. |
+| Inspect | 1 | Taken, sounds like DevTools. |
+| Speclight | 2 | Spotlight clone energy. |
+
+### Reading / room (the job)
+
+| Name | Score | Note |
+|---|---|---|
+| **Lectern** | 4 | You stand at it and present the diagram. Not a browser. Hard to spell; explain once. |
+| **Folio** | 3.5 | A set of leaves — md + html in one workspace. Crowded word (Vercel, legal, browsers). |
+| Codex | 3 | Book of many quires. Also every AI company in 2024. |
+| Dossier | 3 | Review vibe. A bit spy / HR. |
+| Galley | 3 | Publishing proof. Niche. |
+| Quire | 2.5 | Beautiful, unsearchable. |
+| Vellum | 3 | Skin of the page. Soft, maybe too pretty. |
+| Leaf | 2 | Taken everywhere. |
+
+### After the agent writes
+
+| Name | Score | Note |
+|---|---|---|
+| **Afterwrite** | 4 | The app you open *after* the agent writes the file. Does not say AI. Slightly invented. |
+| Faircopy | 3.5 | Printers’ term for the clean manuscript. Lovely; unknown. |
+| Opened | 2 | Verb as name. Slack-adjacent. |
+| Shown | 2 | Same. |
+| Stage | 3 | We already use it for the iframe. Theatre = Present. Also “staging server.” |
+
+### Diagram-forward
+
+| Name | Score | Note |
+|---|---|---|
+| Meridian | 3 | Mermaid echo without saying it. Also a map / airline word. |
+| Podium | 3 | Present mode. Sports / conference. |
+| Minimap | 1 | A feature, not a product. |
+
+### Do not
+
+AgentRead, AgentDeck, Artifact, Emit, Sandbox Reader, NotChrome,
+SpecDown AI, BriefAI, Rendered, Sideview, House Lights.
+
+### Shortlist if we ever rename
+
+1. **SpecDown** (stay)
+2. **Afterwrite** — best *new* word for the job
+3. **Lectern** — best *old* word for the room
+4. **Faircopy** — if we want print/PDF in the name’s bones
+5. **Folio** — if workspace (mixed md+html) becomes the story
+
+**Chair recommendation:** stay SpecDown. If a rename PR ever
+opens, the debate is Afterwrite vs Lectern, not a committee of
+twenty.
+
+---
+
+## 3. Voice seat — taglines
+
+Rules: one breath, no file-extension laundry list in the first
+clause, Mermaid or “read” in the first sentence, never “powerful”
+or “seamless.”
+
+### Now (existing product — ship these)
+
+1. **Present the diagram, not a screenshot.**  
+   *(Already the landing title. Keep.)*
+2. **A markdown viewer where Mermaid diagrams are first-class.**  
+   *(Already the lede. Keep.)*
+3. **Not an editor. The reading and presenting layer.**  
+   *(From the copy kit contrast. Good on a slide.)*
+4. **Zoom, pan, present, export — your architecture is a place
+   you can fly through.**  
+   *(Landing lede, slightly tightened.)*
+5. **Specs you can stand in front of.**
+
+### After HTML is real (wedge shipped)
+
+Use **one** of these as the new lede. Do not stack them.
+
+6. **The reader for specs — markdown, diagrams, and the HTML
+   your agent just wrote.**  
+   *(Chair pick for the HTML era. Job first, formats second,
+   agent as a clause not the noun.)*
+7. **Read what the agent wrote. Don’t open Chrome to do it.**  
+   *(Punchy. Risks the browser comparison. Support-reply
+   required: we are not a browser.)*
+8. **Drop the markdown. Drop the HTML. Stay in the review.**
+9. **Live-reload the report. Present the diagram. Print the spec.**  
+   *(The wedge as a tagline. Only true after Session 02–04.)*
+10. **One reader for both files the agent leaves in `docs/`.**
+11. **Markdown when it’s a spec. HTML when it’s a page. Same
+    chrome. Same Live chip.**
+12. **Not a browser. A sandboxed stage for the page, and a
+    real reader for the spec.**  
+    *(True, too long, too security. File-info / first-toast,
+    not a billboard.)*
+
+### Subtitles (under the wordmark)
+
+- SpecDown — Diagrams you can present
+- SpecDown — The spec reader
+- SpecDown — Read the spec. Fly the diagram.
+- SpecDown — Markdown & HTML, still a viewer
+- SpecDown — After the agent writes
+
+### Lines the voice seat vetoes
+
+- “The AI-native document viewer”
+- “Chrome for specs”
+- “A better live server”
+- “Now with HTML support!” as the hero
+- “All your artifacts in one place” (kitchen sink)
+- “Secure sandboxed iframe technology” on the homepage
+
+### Tone check vs current landing
+
+Keep the eyebrow energy (“Diagram drive online”) if it still
+makes someone smile. Do not replace it with “Now opens .html.”
+The HTML drop-card helper, when it finally ships, is one quiet
+line: *HTML opens as the page it is — not converted to
+markdown.*
+
+---
+
+## 4. Press seat — when and how
+
+**Release A (below) is legal today.** It describes the shipped
+product: markdown, Mermaid, three surfaces, MIT, no account.
+
+**Release B is embargoed** until all of:
+
+- Local `.html` opens on web + desktop and is *visible*
+  (preview host, not a blank frame)
+- Live reload on a path-backed HTML file
+- Print/PDF of HTML from inside the isolated frame (or an
+  honest hidden Print control until then — **do not ship B
+  with Print hidden**)
+- Workspace lists HTML
+- No OS-default HTML handler claim
+- No TestFlight claim
+
+Do not send B after Session 01. That is a sandboxed iframe
+with a press list. The architecture council would reopen.
+
+**Channels** (from the sharing playbook): LinkedIn + the web
+URL first; Show HN only when the GIF includes an HTML drop
+*and* a Mermaid present, or you will be filed under “HTML
+previewer.”
+
+**Boilerplate** (reuse at the end of both releases):
+
+> SpecDown is an open-source viewer for technical specs. It
+> runs in the browser (installable as a PWA), as a desktop app
+> for macOS, Windows, and Linux, and as a build-from-source
+> iOS app. There is no account. It is MIT licensed.
+> https://cbremer.github.io/specdown
+
+---
+
+## 5. Press release A — SpecDown as it exists
+
+**FOR IMMEDIATE RELEASE**
+
+**SpecDown makes architecture diagrams something you can
+present — not a screenshot in a markdown file**
+
+A free, open-source viewer for specs with first-class Mermaid:
+zoom, pan, fullscreen, and a presentation mode that steps
+through every diagram in the document.
+
+Technical specs have a diagram problem. The document lives in
+markdown. The important picture is a Mermaid block. GitHub
+renders it static. Editors treat it as a preview. Meetings get
+a PNG someone cropped at 11pm.
+
+SpecDown is a *reader*. You drop a `.md` file — or paste a
+GitHub repo and pick one — and the diagrams are the product:
+wheel to zoom, drag to pan, fullscreen with a minimap, export
+SVG or PNG, present with the arrow keys. Light and dark follow
+the OS. Print and PDF re-render diagrams for paper so you do
+not get a black box.
+
+It is the same app in the browser (installable, works offline),
+on the desktop (signed and notarized on macOS; Windows and
+Linux builds on GitHub Releases), and as a build-from-source
+iOS shell. There is no account, no vault, and no editor chrome.
+TOC, find, split view, annotations, a command palette, and
+folder workspaces are there because reviewers asked for a
+reading surface, not another IDE.
+
+SpecDown is MIT licensed. Try it at
+https://cbremer.github.io/specdown — no sign-in. Desktop
+builds are on the project’s GitHub Releases page.
+
+**About SpecDown**
+
+SpecDown is an open-source markdown viewer whose differentiator
+is interactive Mermaid diagrams. It is built for people who
+*read and present* specs — architects, engineers, PMs — not
+people looking for another editor.
+
+### Notes to editors (A)
+
+- Do not call it an editor.
+- iOS is not on the App Store or TestFlight.
+- Do not lead with the v0.0.x label.
+- Do not invent usage numbers. Public signals are the GitHub
+  repo and Releases.
+- Demo: drop `diagram-showcase.md` → Present → pan → export PNG.
+
+---
+
+## 6. Press release B — SpecDown after HTML (embargoed)
+
+**EMBARGOED until the HTML wedge is real**
+(local open + Live chip + print — see §4)
+
+**SpecDown now reads the other file your agent writes**
+
+The spec reader that already treats Mermaid as first-class
+opens standalone HTML the same way it opens markdown — as a
+document, in the same workspace, with live reload and print.
+It is still not a browser.
+
+Agents write two kinds of specs. Long markdown, full of
+diagrams. And a finished page: a report, a scorecard, an
+explainer the model already laid out in HTML. Until now,
+SpecDown took the first file and refused the second. Chrome
+took the second and lost the review: no live reload when the
+agent saved, no folder of mixed docs, no print path that
+knows what a spec is.
+
+SpecDown’s HTML path is a *fork*, not a conversion. The page
+stays the page — your layout, your type, your charts. It runs
+on a sandboxed stage that cannot touch SpecDown or your other
+tabs. Markdown still goes through the compiler you already
+trust. Same chrome: tabs, recents, a Live chip when the file
+is on disk, print and PDF that do not clip to the window.
+
+Drop a file, open a folder, or paste a URL that ends in
+`.html`. The markdown spec and the HTML report can sit in two
+tabs. Relative links between them are a workspace problem we
+took on purpose. We did not add an address bar. We did not
+become the system’s HTML app. We did not restyle your page
+to look like ours.
+
+The differentiator has not moved. Open the markdown when the
+diagrams matter; present them fullscreen. Open the HTML when
+the agent already designed the page. Either way you are still
+in a viewer.
+
+SpecDown remains free, MIT licensed, and usable without an
+account. Web: https://cbremer.github.io/specdown — desktop
+builds on GitHub Releases.
+
+**About SpecDown**
+
+SpecDown is an open-source reader for technical specs —
+markdown with first-class Mermaid, and HTML as a first-class
+document kind. It is a viewer, not an editor and not a
+browser.
+
+### Notes to editors (B)
+
+- Lead with the *job* (read what the agent wrote), not “we
+  added HTML.”
+- Do not say “like Chrome” or “a live server.”
+- Do not say we are the default app for `.html`.
+- Do not demo a URL-opened dashboard that needs cookies.
+- Demo sequence: open `architecture.md` → Present a diagram →
+  drop `report.html` → Live chip on save → Print the HTML.
+- If Print is still hidden, **this release does not go out.**
+- Tagline on the wire: *The reader for specs — markdown,
+  diagrams, and the HTML your agent just wrote.*
+
+### Short wire (B, 80 words)
+
+SpecDown, the open-source viewer for specs with interactive
+Mermaid diagrams, now opens standalone HTML alongside
+markdown. Agent-written reports stay the page they are, in a
+sandbox, with live reload and print — not converted, not
+dumped into the app. It is still a viewer, not a browser.
+Free, no account: https://cbremer.github.io/specdown
+
+---
+
+## 7. Social stubs (optional, not a Session 01 launch)
+
+**Existing product (any day)**
+
+> GitHub leaves your architecture as a static image. SpecDown
+> is the reader: zoom, pan, present every Mermaid in the spec.
+> No account. https://cbremer.github.io/specdown
+
+**HTML era (after embargo lifts)**
+
+> The agent wrote `design.md` and `review.html`. I used to
+> open one in SpecDown and the other in Chrome. SpecDown
+> takes both now. The HTML stays the page. The diagrams still
+> fly. Not a browser.
+
+---
+
+## 8. What we are not deciding
+
+- No repo rename.
+- No landing hero change in HTML Session 01.
+- No trademark/domain work in this PR.
+- No “SpecDown AI” experiment, even as an A/B.
+
+If someone wants Afterwrite or Lectern, that is a **new**
+project folder (`project-rename`) with a real availability
+check — not a drive-by in the HTML implementation PRs.

--- a/docs/project-html/2026-08-23-council-html-plan-review.md
+++ b/docs/project-html/2026-08-23-council-html-plan-review.md
@@ -498,3 +498,25 @@ Also adopted:
   silent add.
 
 F1 (blank blob frame) is superseded: we do not use blob.
+
+---
+
+## 9. Addendum — Staging rail (2026-08-25)
+
+The council told Session 01 not to *launch*. It did not say
+how to keep that code off the Release pipeline. Merge-to-`main`
+is Pages + version bump + `latest*.yml`. That is production.
+
+**Adopted** in [spec-html-staging](2026-08-25-spec-html-staging.md):
+
+- Session 00 (flag default off, `*:html` scripts, CI artifact)
+  is the first code PR, into **`main`**.
+- Sessions 01–04 are PRs into integration branch **`html`**.
+- Kill/pause still happens after the Session 02 demo — on
+  **staging** (`desktop:html`), not on github.io.
+- Do not host a staging app at `/specdown/html-staging/` (PWA
+  service worker scope).
+- The compile-time flag keeps `.html` rejected on production
+  builds; it does **not** isolate `#document-stage` CSS. Git
+  isolation is what protects the live app until go/no-go.
+

--- a/docs/project-html/2026-08-23-council-html-plan-review.md
+++ b/docs/project-html/2026-08-23-council-html-plan-review.md
@@ -420,3 +420,41 @@ focus.” Relabel Raw → Source when the control is shared.
 **Reversed from the first pass:** H1 (OS HTML association)
 and H4 (Content-Type sniff) are **not** Session 01. They
 were the launch. Workspace listing (H2) stays.
+
+---
+
+## 8. Addendum — Platform seat (same day)
+
+The fork is right. These gates were still missing after the
+product/UX tighten:
+
+- **Live reload DI.** `configureDesktop`, `configureTabs`, and
+  `configureViewMode` all take `renderMarkdown`. If any stay on
+  the markdown function, a Live save or Raw→Preview runs
+  `marked.parse` on HTML. `refresh-file` still uses
+  `isValidMarkdownFile`. Wire all three + the IPC to
+  `renderDocument(tab)` (kind on the tab, not re-detected).
+- **Stage apply on raw.** `tabs.js` / `view-mode.js` raw paths
+  write `#markdown-content` and return **without** hiding the
+  iframe. Raw-on-HTML leaves the page sitting on the source.
+- **8 MB at read**, not at rewrite (`handleFile` /
+  `openFileByPath` / iOS `openDocument`). Rewrite is too late.
+- **`#document-stage` `@media print` reset in Session 01**
+  even though HTML print is Session 02. New full-height
+  ancestor otherwise reclips markdown Cmd+P (`CLAUDE.md`).
+- **iOS UTI.** Add `public.html` to `LSItemContentTypes` only.
+  Do not redeclare it under `UTImportedTypeDeclarations`. Rank
+  stays Alternate. iPad `ContentView.swift` label can say
+  “Open File”; no new sample button.
+- **Drops stay on `getPathForFile`.** No `file.path` (Electron
+  32+).
+- **Inverted tests** go red for the right reason
+  (`desktop-main.test.js` `.html` false, file-loading toast
+  copy). Update them in the same PR. CSP proof is a **static
+  grep** of `index.html` — `loadApp` copies `<body>` only.
+- **Session 04, if `fileAssociations` land:** macOS
+  `open-file` is not enough; Win/Linux need `process.argv` /
+  `second-instance` or the association is paper.
+
+Workspace listing stays one helper on desktop **and** the web
+walk (H2). Do not leave Open Folder kind-skewed.

--- a/docs/project-html/2026-08-23-council-html-plan-review.md
+++ b/docs/project-html/2026-08-23-council-html-plan-review.md
@@ -1,0 +1,379 @@
+# Council Review — HTML Documents Plan
+
+**Date:** 2026-08-23
+**Type:** council (adversarial review of a plan, before code)
+**Subject:** [brainstorm](2026-08-23-brainstorm-html-documents.md) ·
+[spec v1](2026-08-23-spec-html-v1.md) ·
+[Session 01](2026-08-23-tasks-session-01-kind-and-open.md)
+**Method:** four seats (security, product, UX, platform) challenged
+the plan against *current* code, not against the plan's own claims.
+This file is the chair's synthesis: what survived, what was wrong,
+what Session 01 must change.
+
+---
+
+## Verdict
+
+**The thesis is solid. The Session 01 contract was not.**
+
+Ship the fork. Do not convert. Do not `innerHTML` the file into the
+app origin. Faithful-as-default for local files. Capability table,
+not `if (html)` soup. That stack survived every seat.
+
+**Do not implement Session 01 as originally written.** As specified,
+the first PR would:
+
+1. **Fail to show the page** — the app CSP blocks `blob:` iframes.
+2. **Lie about Print** — `#ios-print-button` and `performPrint()`
+   still clone `#markdown-content` (empty for HTML) or fall through
+   to `window.print()` on the shell (the viewport-clip bug).
+3. **Lie about folders** — workspace scan stays markdown-only, so
+   "we open HTML" is false the moment someone drops a `docs/` folder.
+4. **Invite a Session 02 XSS** — printing a Faithful snapshot via
+   `frameDoc.write()` in a same-origin iframe is the Absorb attack
+   with a Print button on it.
+
+Direction: **ship-with-fixes**. The amendments below are now in the
+spec and Session 01 checklist. Implementation starts from those, not
+from the first draft.
+
+---
+
+## Seats
+
+| Seat | Charge | Verdict |
+|---|---|---|
+| **Security** | Attack the sandbox, CSP, print, host bridge | Fork is the right isolation. Three fatals if implemented as drafted. |
+| **Product** | Is this the right phase? Will the "no" list hold? | Right phase *if* Session 01 stays tiny. v2 said "consolidate, don't add" — this is the one addition that is a job, not a feature. |
+| **UX** | Lying controls, landing, chrome vs document | Coherent *after* hiding Print/Find/TOC/Comments/Annotate/Present on HTML until they are honest. Folder-drop is the first-run trap. |
+| **Platform** | Missed gates, harness, Electron/iOS | `fileAssociations`, session restore, tab/iframe lifecycle, `handleUrl` Content-Type, and the eval harness were under-specified. |
+
+---
+
+## 1. Challenges that landed (adopted)
+
+### F1 — Parent CSP will block the preview iframe
+
+**Seat:** Security, verified in `markdown-viewer/index.html`.
+
+The app CSP is:
+
+```
+default-src 'self' file: specdown:;
+script-src 'self' 'unsafe-eval' file: specdown:;
+…
+```
+
+There is **no** `frame-src` or `child-src`. CSP3 falls `frame-src`
+back to `default-src`. `blob:` is not in `default-src`. Session 01's
+`iframe.src = URL.createObjectURL(...)` is therefore **blocked in
+production** on web, and likely on desktop (`file:`) and iOS
+(`specdown:`) too.
+
+The plan's Invariant 6 said "the app's meta CSP stays as it is."
+That sentence is false if we use blob URLs.
+
+**Amendment:** Session 01 adds an explicit
+
+```
+frame-src 'self' blob: file: specdown:
+```
+
+Do **not** add `blob:` to `script-src`. A test must assert the
+production `index.html` CSP allows `frame-src` blob and does not
+allow `blob:` on `script-src`.
+
+### F2 — Session 02 print-as-specified is XSS
+
+**Seat:** Security, verified in `platform/ios-chrome.js`
+(`printViaHiddenFrame` → `frameDoc.write(printableHtml)` into a
+**same-origin, unsandboxed** iframe) and `desktop/main.js`
+(`loadPrintableWindow` writes a temp `.html` and `loadFile`s it).
+
+Spec §5 said: host returns `document.documentElement.outerHTML`
+(post-JS, scripts and all) and the parent "wraps the snapshot in
+the print window/iframe already used for markdown."
+
+That write is the Absorb design we vetoed. Faithful HTML in a
+same-origin print iframe runs document scripts in the SpecDown
+origin. Desktop PDF is the same class of bug (temp file +
+`loadFile`, `sandbox: true` on the *BrowserWindow* but still an
+app-controlled document executing attacker HTML).
+
+**Amendment (design now, code in Session 02):**
+
+- **Preferred:** print *from inside* the opaque preview iframe
+  (`specdown-print` → host calls `window.print()`). Charts exist.
+  Scripts stay in the opaque origin. The dialog attaches to the
+  visible window (macOS sheet rule still holds because the iframe
+  is in the visible window).
+- **Fallback:** print a **script-stripped** rewrite (no event
+  handlers, no `<script>`). Never `document.write` Faithful HTML
+  into a same-origin frame.
+- Session 01: **Print is a hidden capability for HTML.** Cmd+P /
+  File > Print / `#ios-print-button` / `#print-button` must not
+  call `performPrint()` on an HTML tab (toast if invoked: "Print
+  for HTML lands next"). Markdown print is unchanged.
+
+### F3 — Iframe self-navigation turns SpecDown into a browser
+
+**Seat:** Security + Product.
+
+`sandbox` without `allow-top-navigation` stops the iframe from
+navigating *the parent*. It does **not** stop
+`location.href = 'https://…'` *inside* the iframe. Agent HTML
+(or a `data:text/html` / `javascript:` link) can replace the
+preview with an arbitrary site. That is the #1 way the "no
+browser" list fails in practice.
+
+Desktop `will-navigate` allows `file:` and opens http(s)
+externally — it is a **main-frame** guard. Subframe navigation
+is a separate hole (`will-frame-navigate` is not wired).
+
+**Amendment:**
+
+- Invariant 9: the preview `src` must remain the blob (or
+  protocol URL) we minted. On `load`, if it is not, reset to
+  the blob and toast.
+- Desktop Session 01: `will-frame-navigate` — deny anything
+  that is not our blob / `about:blank` / `file:` (app). http(s)
+  from a subframe → `openExternal`, do not display in-frame.
+- Rewrite: strip `<base target>`, neutralize `javascript:` and
+  `data:text/html` `href`s.
+
+### H1 — `fileAssociations` missing from the gate table
+
+**Seat:** Platform, verified in `package.json` →
+`build.fileAssociations` (only `md` / `markdown`).
+
+Without this, a released desktop build will not offer SpecDown
+in Finder / Explorer "Open with" for `.html`. The in-app dialog
+can still open them. The OS-open job in the brainstorm ("this
+is the home surface") would be false for a full release cycle.
+
+**Amendment:** Session 01 adds an HTML `fileAssociations` entry
+(`html`, `htm`, `text/html`, role Viewer). Do not put a space
+in any `artifactName` (existing regression).
+
+### H2 — Workspace listing must move into Session 01
+
+**Seat:** UX + Platform.
+
+`scanWorkspace` and the web folder walk still use markdown-only
+predicates. Session 01 advertising "drop HTML" plus an existing
+**Open Folder** button produces "No markdown files found" on a
+folder of agent reports. That is a first-run defect, not a
+Phase-2 nice-to-have.
+
+Relative *link following* and sibling assets stay later.
+**Listing** is one helper and must ship with the kind.
+
+**Amendment:** `isOpenableDocument` is used by `scanWorkspace`
+and the web walk in Session 01. Empty-folder copy becomes
+"No Markdown or HTML files found." Link clicks on `.html` can
+wait for Session 03 if the regex is not ready — but the sidebar
+must *show* the files.
+
+### H3 — Tab / empty-state iframe lifecycle was hand-waved
+
+**Seat:** Platform, verified in `features/tabs.js`.
+
+`createTab` / `switchTab` / `closeTab` all call `renderDoc(content,
+filename)` — fine once that dispatches. `showDropZone` only
+`setHtml('markdown-content', '')`. It does not clear
+`#html-frame.src` or revoke the blob. Closing the last HTML tab
+leaves a live sandboxed document ticking under the landing.
+
+`tab.scrollTop` is applied to `#markdown-content`, which is hidden
+on HTML preview. Accept scroll-loss for Session 01; do not pretend
+it works.
+
+**Amendment:** Session 01 tasks include `htmlTeardownFrame()` on
+empty state, tab close of the last HTML tab, and before swapping
+blobs. One iframe, many tabs: every activate remounts the blob
+from `tab.rawMarkdown`.
+
+### H4 — `handleUrl` does not read `Content-Type`
+
+**Seat:** Platform, verified in `features/file-loading.js`.
+
+The spec already required extensionless URL + `text/html` → html.
+The Session 01 checklist never mentioned `handleUrl`. Today's
+code always `createTab(filename, markdown)` and filename from the
+path (`untitled.md` for `/`). A gist or `raw` URL without `.html`
+would render as markdown garbage.
+
+**Amendment:** Session 01 — `handleUrl` passes
+`response.headers.get('content-type')` into `detectKind(filename,
+contentType)`. Extension still wins.
+
+### H5 — 8 MB cap must be HTML-only
+
+**Seat:** Security / Platform.
+
+The spec put the cap on `handleFile` / `openFileByPath` /
+`handleUrl` without saying "HTML." A large markdown spec would
+start getting refused. Cap the HTML path only.
+
+### H6 — iOS sheet and desktop Print are lying on day one
+
+**Seat:** UX, verified in `index.html` (`#ios-print-button`,
+`#ios-comments-button`, `#ios-annotations-button`,
+`#ios-split-button`, `#ios-present-button`).
+
+Session 01 hid Present / Annotate / Comments in the task list
+and left Print as "may no-op." An iPhone user has no toolbar;
+the sheet *is* the product. Print-on-empty-`#markdown-content`
+is worse than a missing button.
+
+**Amendment:** `documentCapabilities('html')` in Session 01 is
+`preview`, `raw`, `split` (only if split actually hosts the
+iframe), `liveReload`, `fileInfo`. Everything else **hidden**,
+including Print / Find / TOC / Comments / Annotate / Present.
+`syncIOSChrome` must consult the table. Palette commands that
+are hidden are omitted, not disabled-without-reason.
+
+### H7 — Permissions-Policy and rewrite gaps
+
+**Seat:** Security.
+
+The iframe needs `allow=""` (or an explicit deny list:
+camera, microphone, geolocation, payment, usb, display-capture)
+so Faithful pages cannot prompt for device APIs.
+
+Rewrite must also: strip `<base target>`, remove
+`meta[http-equiv=set-cookie]` if present, and not assume
+DOMParser preserves a doctype (re-emit `<!DOCTYPE html>`).
+
+### H8 — Host module vs eval harness
+
+**Seat:** Platform, verified in `tests/helpers/loadApp.js`.
+
+If `html-host.js` is a relative import, the harness inlines it
+into the **parent** global scope. A host file with `function
+onMessage` or `let ready` will collide. The host must export
+only a string constant (`htmlHostInlineSource`) and use
+`htmlHost*` prefixes if it has any bindings. No top-level
+side effects — the parent must not run the host.
+
+### H9 — Product "no" list needs a mechanical guard
+
+**Seat:** Product.
+
+The no-browser rule fails the first time a document navigates
+(F3) or Print writes into the app origin (F2). Those are now
+invariants, not prose. Remaining social pressure (PDF, edit,
+"just allow-same-origin so TOC is easier") is a review
+checklist item on every HTML PR, already started in spec §6.
+
+### H10 — Faithful-for-URLs is a different trust level
+
+**Seat:** Product + Security.
+
+A local drop is a file the user had. A pasted URL is whoever
+answered. Session 01 uses the same sandbox for both (isolation
+does not depend on trust). Session 05 Safe mode should
+**default Safe for URL-opened HTML** and Faithful for local
+paths. Recorded now so we do not paint a single global default.
+
+---
+
+## 2. Challenges that did not land (plan holds)
+
+| Challenge | Why we rejected it |
+|---|---|
+| "v2 said consolidate, don't add — HTML is the wrong phase." | Consolidation was about tokens, toolbar collision, and unsigned Win/Linux update. Those shipped or were scoped. HTML is a *job* the current gates refuse. Doing it as a forked kind is smaller than another chrome feature. Caveat: Session 01 stays skeletal so we don't recreate coherence debt. |
+| "Just open HTML in Chrome; SpecDown should stay markdown." | Chrome has no live reload + mixed workspace + SpecDown print. That *is* the product. We are not competing on being a browser. |
+| "Safe-as-default so we never run scripts." | Makes the feature look broken on dashboards/decks — the files we cited as the reason. Isolation (opaque iframe) is the control, not script-stripping. Safe is the escape hatch. |
+| "Convert to markdown for TOC/Find, preview as HTML." | Two sources of truth. Find wouldn't match the page. Rejected again. |
+| "srcdoc is simpler than blob." | srcdoc + `allow-same-origin` + scripts = XSS. srcdoc without same-origin is viable but worse for later `<base>` / assets. Stick to blob; fix CSP (F1). |
+| "Add `allow-same-origin` so parent can read TOC." | Veto stands. Host bridge or hide TOC. |
+| "Skip iOS until TestFlight." | Shared renderer + picker types are cheap. Skipping them is how iPhone becomes a second product. Device smoke stays best-effort. |
+| "Session 01 should include Mermaid-in-HTML so it feels like SpecDown." | Comforting, wrong corpus. Most agent HTML is not a Mermaid document. Enhance stays last. |
+| "Rename `rawMarkdown` now." | Pure churn across the eval harness. Alias later. |
+| "8 MB is too small / too large." | Fine as a first cap; raise with evidence. HTML-only (H5). |
+
+---
+
+## 3. UX honesty contract (Session 01)
+
+What the user may do with an HTML tab on day one:
+
+- Open (drop, browse, URL with `.html`/`.htm` or `text/html`,
+  desktop dialog, OS-open once `fileAssociations` land, iOS picker,
+  workspace **listing**)
+- See the page in the stage (blob iframe)
+- Raw / Split (source | page)
+- File info, recents, session restore, live reload (path-backed)
+- Switch tabs without leaking the last blob under the landing
+
+What they must **not** see as if it worked:
+
+- Print / PDF
+- Find
+- Contents
+- Present, Annotate, Comments
+- Sibling `./chart.js` (no toast-storm; one toast if the rewrite
+  saw relative URLs and we have no `baseHref`)
+
+Landing: change "Drop Markdown File Here" → "Drop a Markdown or
+HTML file." One sample button, Mermaid stays the hero. No new
+pillar.
+
+---
+
+## 4. Resolved contradictions
+
+| Was | Now |
+|---|---|
+| Brainstorm Invariant 2: `allow-scripts allow-forms`. Spec: `allow-scripts` only. | **`allow-scripts` only.** Injected iframe CSP has `form-action 'none'`. Forms that need submit are Session 05+ if ever. |
+| Brainstorm Invariant 6: app CSP unchanged. | **App CSP gains `frame-src` blob.** Script policy unchanged. |
+| Workspace scan "Session 03" vs "Session 01 uses the helper." | **Listing in Session 01.** Links/assets later. |
+| Print "designed in spec, maybe no-op in Session 01." | **Hidden in Session 01.** Host-internal print in Session 02. No same-origin `document.write` of Faithful HTML. |
+| Size cap on all opens. | **HTML only.** |
+
+---
+
+## 5. Open questions — council answers
+
+1. **Blob vs srcdoc vs protocol for v1?** Blob + `frame-src` fix.
+   Protocol remains Session 04. Avoid srcdoc.
+2. **Sniff Content-Type on extensionless URLs?** Yes (H4).
+   Do not sniff bytes of `.md` files.
+3. **`.htm`?** Yes.
+4. **Default Faithful or Safe?** Local Faithful. URL default
+   Safe when the toggle exists (Session 05). Session 01: one
+   sandboxed Faithful path.
+5. **iOS in Session 01?** Shared renderer + `public.html` +
+   picker + capability-aware sheet. No TestFlight dependency.
+
+---
+
+## 6. Is the plan solid?
+
+**Yes, after the amendments.** The product move is the right
+one for 2026 artifacts. The engineering move (fork + opaque
+iframe + capability table) is the only move that does not
+either destroy the file or destroy the security posture.
+
+What was *not* solid was treating Session 01 as "accept the
+extension and put it in an iframe" without:
+
+- changing the **parent** CSP,
+- locking iframe navigation,
+- hiding every chrome control that still walks
+  `#markdown-content`,
+- listing HTML in workspaces,
+- registering the OS file association,
+- specifying iframe teardown,
+- forbidding same-origin print of Faithful HTML.
+
+Those are now in the spec and the Session 01 checklist.
+A later session that wants `allow-same-origin`, parent
+`innerHTML`, or Print-via-`document.write` has to win an
+argument against F1–F3 in this file first.
+
+**Council recommendation:** implement Session 01 from the
+amended spec. Do not open a "just the iframe" spike that
+skips F1 or H6 — that spike would look broken and teach
+the wrong lesson about the fork.

--- a/docs/project-html/2026-08-23-council-html-plan-review.md
+++ b/docs/project-html/2026-08-23-council-html-plan-review.md
@@ -151,9 +151,12 @@ in Finder / Explorer "Open with" for `.html`. The in-app dialog
 can still open them. The OS-open job in the brainstorm ("this
 is the home surface") would be false for a full release cycle.
 
-**Amendment:** Session 01 adds an HTML `fileAssociations` entry
-(`html`, `htm`, `text/html`, role Viewer). Do not put a space
-in any `artifactName` (existing regression).
+**Amendment (first pass):** Session 01 adds an HTML
+`fileAssociations` entry.
+
+**Reversed (product seat):** OS/PWA HTML handler is an identity
+event. Slip `fileAssociations` and `file_handlers` to Session 04.
+In-app dialog filter “HTML” is enough for Session 01.
 
 ### H2 — Workspace listing must move into Session 01
 
@@ -203,9 +206,12 @@ code always `createTab(filename, markdown)` and filename from the
 path (`untitled.md` for `/`). A gist or `raw` URL without `.html`
 would render as markdown garbage.
 
-**Amendment:** Session 01 — `handleUrl` passes
-`response.headers.get('content-type')` into `detectKind(filename,
-contentType)`. Extension still wins.
+**Amendment (first pass):** Session 01 — `handleUrl` passes
+`Content-Type` into `detectKind`.
+
+**Reversed (product seat):** Session 01 is extension-only.
+Content-Type sniff + Faithful is a new trust model. Remote HTML
+waits for Session 05 with Safe-as-default.
 
 ### H5 — 8 MB cap must be HTML-only
 
@@ -338,14 +344,15 @@ pillar.
 
 1. **Blob vs srcdoc vs protocol for v1?** Blob + `frame-src` fix.
    Protocol remains Session 04. Avoid srcdoc.
-2. **Sniff Content-Type on extensionless URLs?** Yes (H4).
-   Do not sniff bytes of `.md` files.
+2. **Sniff Content-Type on extensionless URLs?** **No in
+   Session 01** (product addendum). Extension-only. Sniffing
+   turns the existing URL box into a scripted browser. Session 05
+   ships Safe-default for remote ingress if URL HTML is fetched.
 3. **`.htm`?** Yes.
-4. **Default Faithful or Safe?** Local Faithful. URL default
-   Safe when the toggle exists (Session 05). Session 01: one
-   sandboxed Faithful path.
-5. **iOS in Session 01?** Shared renderer + `public.html` +
-   picker + capability-aware sheet. No TestFlight dependency.
+4. **Default Faithful or Safe?** Local Faithful. Remote HTML is
+   not a Session 01 job. When URL HTML ships, default **Safe**.
+5. **iOS in Session 01?** Shared renderer + picker `UTType.html`.
+   No sample button, no TestFlight dependency.
 
 ---
 
@@ -364,7 +371,6 @@ extension and put it in an iframe" without:
 - hiding every chrome control that still walks
   `#markdown-content`,
 - listing HTML in workspaces,
-- registering the OS file association,
 - specifying iframe teardown,
 - forbidding same-origin print of Faithful HTML.
 
@@ -377,3 +383,40 @@ argument against F1–F3 in this file first.
 amended spec. Do not open a "just the iframe" spike that
 skips F1 or H6 — that spike would look broken and teach
 the wrong lesson about the fork.
+
+---
+
+## 7. Addendum — Product + UX seats (same day)
+
+Independent seats pushed back on the *first* council pass
+where it still launched HTML as a product. Adopted:
+
+**Product (right phase with caveats).** Sessions 01–04 are
+one bet. Kill/pause if after Session 02 the desktop demo is
+not “local HTML + Live chip + print.” Do not change the
+one-liner. Do not register SpecDown as a system/PWA HTML
+handler in Session 01 (`fileAssociations` and
+`file_handlers` slip to Session 04). Session 01 URL path is
+**extension-only** (`.html`/`.htm`); no `Content-Type` sniff.
+Decks, prototypes, and “apps with filters” are not success
+metrics. Session 02 is Print, not Find. Expand the no-list:
+no localhost/`ws:` in document CSP, no cookie jar, no
+default-app claim, nested frames stay stripped (no “revisit”).
+
+**UX (will feel broken unless chrome honesty is the slice).**
+`documentCapabilities` must gate toolbar, palette
+`isAvailable`, iOS sheet, **and** `⌘F`/`⌘P`. `performPrint()`
+returns immediately on HTML — no `window.print()` fallback.
+On HTML render/switch: clear TOC, close search, force
+annotate **off**, hide iframe on Raw. `#document-stage` is
+the flex preview child — do **not** nest `#html-frame` inside
+`.markdown-content` (prose padding imprisons the page). Split
+CSS targets the stage. Lone-file relative-URL toast in
+Session 01. No landing copy change, no second/third sample
+button (sample file is QA-only). Host key-forward for
+⌘K/⌘F/⌘P/`?`/Esc, or document “click the filename to return
+focus.” Relabel Raw → Source when the control is shared.
+
+**Reversed from the first pass:** H1 (OS HTML association)
+and H4 (Content-Type sniff) are **not** Session 01. They
+were the launch. Workspace listing (H2) stays.

--- a/docs/project-html/2026-08-23-council-html-plan-review.md
+++ b/docs/project-html/2026-08-23-council-html-plan-review.md
@@ -292,7 +292,7 @@ paths. Recorded now so we do not paint a single global default.
 | "Just open HTML in Chrome; SpecDown should stay markdown." | Chrome has no live reload + mixed workspace + SpecDown print. That *is* the product. We are not competing on being a browser. |
 | "Safe-as-default so we never run scripts." | Makes the feature look broken on dashboards/decks — the files we cited as the reason. Isolation (opaque iframe) is the control, not script-stripping. Safe is the escape hatch. |
 | "Convert to markdown for TOC/Find, preview as HTML." | Two sources of truth. Find wouldn't match the page. Rejected again. |
-| "srcdoc is simpler than blob." | srcdoc + `allow-same-origin` + scripts = XSS. srcdoc without same-origin is viable but worse for later `<base>` / assets. Stick to blob; fix CSP (F1). |
+| "srcdoc/blob is simpler." | They inherit parent CSP; Faithful dies. Host page instead (security addendum). |
 | "Add `allow-same-origin` so parent can read TOC." | Veto stands. Host bridge or hide TOC. |
 | "Skip iOS until TestFlight." | Shared renderer + picker types are cheap. Skipping them is how iPhone becomes a second product. Device smoke stays best-effort. |
 | "Session 01 should include Mermaid-in-HTML so it feels like SpecDown." | Comforting, wrong corpus. Most agent HTML is not a Mermaid document. Enhance stays last. |
@@ -458,3 +458,43 @@ product/UX tighten:
 
 Workspace listing stays one helper on desktop **and** the web
 walk (H2). Do not leave Open Folder kind-skewed.
+
+---
+
+## 9. Addendum — Security seat (same day)
+
+**Verdict on the first spec: reject the blob/srcdoc preview.**
+The fork (do not `innerHTML` into the app origin) still stands.
+
+CSP3: `blob:`, `srcdoc`, `data:`, and `about:blank` **inherit
+the creating document’s policy**. Parent `script-src` is
+`'self' 'unsafe-eval' file: specdown:` — no `'unsafe-inline'`,
+no `https:`. A meta tag in the frame cannot loosen that.
+Adding `frame-src blob:` would show a frame whose scripts
+(including an inlined host) **never run**. Loosening parent
+`script-src` is the Absorb attack.
+
+Blob URLs are also **same-origin with the app**. Opacity is
+only `sandbox` without `allow-same-origin`. The earlier
+“simplest opaque origin” claim was wrong.
+
+**Adopted architecture:** `#html-frame.src` is a bundled
+`html-preview-host.html` (real URL, own CSP). Parent
+`postMessage`s rewritten HTML; the host writes **inside** the
+sandboxed frame. Parent CSP gains `frame-src 'self' file:
+specdown:` only. Never add `'unsafe-inline'` or `blob:` to
+parent `script-src`.
+
+Also adopted:
+
+- Frame→parent messages are **untrusted**. No
+  `specdown-print-ready.html` into `document.write` /
+  `loadFile` / iOS formatter.
+- iOS: reject `WKScriptMessage` unless
+  `frameInfo.isMainFrame`; cancel iframe navigations.
+- Host script lives on the host page, not inlined into
+  attacker HTML (document scripts can impersonate it).
+- `allow-modals` is a Session 02 print question, not a
+  silent add.
+
+F1 (blank blob frame) is superseded: we do not use blob.

--- a/docs/project-html/2026-08-23-spec-html-v1.md
+++ b/docs/project-html/2026-08-23-spec-html-v1.md
@@ -4,11 +4,19 @@
 **Status:** Specified; **amended after council review**
 **Surfaces:** web, desktop, iOS (shared renderer + thin shell gates)
 **Companion:** [brainstorm](2026-08-23-brainstorm-html-documents.md) ·
-[council](2026-08-23-council-html-plan-review.md)
+[council](2026-08-23-council-html-plan-review.md) ·
+[staging](2026-08-25-spec-html-staging.md)
 
 Council fatals (CSP `frame-src`, print XSS, iframe navigation) are
 invariants in this file. Implement Session 01 from this revision,
 not the first draft.
+
+**Rollout:** Session 01 is **not** a PR into `main`. `main` is a
+release (version bump, DMG, Pages). HTML runtime PRs target the
+`html` integration branch with `VITE_HTML_DOCUMENTS` on. See
+[spec-html-staging](2026-08-25-spec-html-staging.md). Session 00
+(flag + CI, gates unchanged) is the only HTML-project code that
+merges to `main` before the Session 02 go/no-go.
 
 This spec is the implementation contract for the **document-runtime
 fork**. Session tasks check boxes against this file. If a session
@@ -402,6 +410,8 @@ button. Do not replace the Mermaid showcase.
 
 ## 8. Tests (Session 01 minimum)
 
+Flag-**on** (HTML-on build / job):
+
 - `tests/unit/document-kind.test.js` — extensions, URL content-type
   helper, capabilities
 - `tests/unit/html-document.test.js` — rewrite injects CSP + host,
@@ -410,13 +420,19 @@ button. Do not replace the Mermaid showcase.
 - File-loading: HTML file creates `kind: 'html'`; `marked.parse`
   not called (spy); `handleUrl` on an extensionless URL stays
   markdown; 8 MB cap does not reject markdown
-- Production CSP string includes `frame-src 'self'` and does not
+- HTML-on **dist** CSP includes `frame-src 'self'` and does not
   put `blob:` or `'unsafe-inline'` on parent `script-src`
-- Existing markdown tests stay green (kind defaults / markdown path
-  unchanged)
 - `desktop-main.test.js`: `.html` is openable; `.pdf` is not;
   session restore accepts `.html`; `scanWorkspace` lists `.html`;
   `artifactName` space regression remains
+
+Flag-**off** job on the same SHA (staging spec):
+
+- `.html` still rejected at ingress
+- Existing markdown / Mermaid tests stay green
+- `artifactName` space regression remains
+- Source `index.html` CSP still has no `frame-src` until the
+  production flip (HTML-on injects it at build)
 
 ---
 
@@ -438,6 +454,7 @@ button. Do not replace the Mermaid showcase.
 
 | Piece | Where |
 |---|---|
+| Staging flag | `markdown-viewer/src/core/html-flag.js` + `desktop/main.js` env; Session 00 |
 | Kind + capabilities | `markdown-viewer/src/core/document-kind.js` |
 | Rewrite + iframe + bridge | `markdown-viewer/src/features/html-document.js` |
 | Preview host page | `markdown-viewer/html-preview-host.html` (own CSP + host script) |
@@ -445,11 +462,14 @@ button. Do not replace the Mermaid showcase.
 | Dispatch | `main.js` |
 | Tab field | `core/state.js` JSDoc + `features/tabs.js` |
 | Sample | `markdown-viewer/samples/html-showcase.html` |
-| Tests | `tests/unit/document-kind.test.js`, `tests/unit/html-document.test.js`, existing suites |
+| Tests | `tests/unit/html-flag.test.js` (Session 00), `document-kind.test.js`, `html-document.test.js`, existing suites |
 
 ---
 
 ## 11. Acceptance (v1 done)
+
+Dogfood on the HTML-on staging build (`preview:html` /
+`desktop:html`), not on production Pages, until `html` → `main`.
 
 1. Drop / browse / URL of an `.html` file opens a tab that looks
    like the file, not like markdown.

--- a/docs/project-html/2026-08-23-spec-html-v1.md
+++ b/docs/project-html/2026-08-23-spec-html-v1.md
@@ -386,7 +386,7 @@ though HTML print waits for Session 02.
 
 Add `markdown-viewer/samples/html-showcase.html`:
 
-- Self-contained (inline CSS, no external JS required so the blob
+- Self-contained (inline CSS, no external JS required so the
   preview looks complete without Session 04)
 - A real layout (header, sections, a simple CSS-only tab or
   callout) — not `lorem` in Times
@@ -463,8 +463,8 @@ button. Do not replace the Mermaid showcase.
    on HTML tabs. No new iOS sample button.
 7. No new toolbar button. No landing/hero/pillar copy change.
    No PWA or OS HTML file-handler registration.
-8. Parent CSP allows the blob iframe; a dropped HTML file is
-   visible, not a blank stage.
+8. Parent CSP allows the **preview host** to be framed; a dropped
+   HTML file is visible, not a blank stage.
 9. Closing the last HTML tab does not leave a live iframe under
    the landing.
 10. `performPrint()`, Find, and TOC do not run against an HTML

--- a/docs/project-html/2026-08-23-spec-html-v1.md
+++ b/docs/project-html/2026-08-23-spec-html-v1.md
@@ -103,8 +103,11 @@ v1 capabilities:
 
 ### 3.1 Entry
 
-`renderDocument(content, filename, kind)` (name unique for the
-harness — not a bare `render`):
+`renderDocument(content, filename, kind)` or `renderDocument(tab)`
+(name unique for the harness — not a bare `render`). Kind comes
+from the tab; do not re-detect. DI sites that still take
+`renderMarkdown` (`configureTabs`, `configureDesktop`,
+`configureViewMode`) must receive this dispatcher:
 
 - `markdown` → existing `renderMarkdown` body (marked → DOMPurify
   `{ ADD_TAGS: ['#comment'] }` → comments / code-copy / mermaid /
@@ -112,7 +115,7 @@ harness — not a bare `render`):
 - `html` → `renderHtmlDocument` in `features/html-document.js`.
 
 `renderMarkdown` may remain as a wrapper for tests that call it
-directly; new code calls `renderDocument`.
+directly. `refresh-file` uses `isOpenableDocument`.
 
 ### 3.2 HTML stage DOM
 
@@ -303,8 +306,10 @@ documented set `md, markdown, html, htm`.
 | `repo-browser.js` | Session 03: include HTML in the GitHub search |
 | `normalizeMarkdownUrl` | still correct for GitHub blob HTML (`blob` → `raw` works for any path) |
 | `manifest.webmanifest` `file_handlers` | **Session 04** (same reason as `fileAssociations`) |
-| `ios/project.yml` | import `public.html`; add a document type for HTML (picker, not “default app”) |
-| `WebBridge.swift` picker | append `.html` (`UTType.html`) |
+| `ios/project.yml` | add `public.html` to `LSItemContentTypes` only (do not redeclare the UTI); rank Alternate |
+| `WebBridge.swift` picker | append `UTType.html` |
+| iPad `ContentView.swift` | label “Open File”; no new sample |
+| Size cap | 8 MB HTML **at read** (`handleFile` / `openFileByPath` / iOS `openDocument`) |
 | Landing / README / PWA | no lede or sample-button change in Session 01 |
 
 Desktop `file-opened` IPC payload stays `{ path, content, filename }`
@@ -347,7 +352,9 @@ Session 02 algorithm:
 
 `@media print` in SpecDown CSS must still reset any new
 full-height ancestor (`#document-stage { height: auto; overflow:
-visible; }` in the print stylesheet).
+visible; }` in the print stylesheet). **Add that reset in
+Session 01** so markdown Cmd+P fallback does not clip, even
+though HTML print waits for Session 02.
 
 ---
 

--- a/docs/project-html/2026-08-23-spec-html-v1.md
+++ b/docs/project-html/2026-08-23-spec-html-v1.md
@@ -1,0 +1,390 @@
+# Spec: HTML Documents — v1
+
+**Date:** 2026-08-23
+**Status:** Specified; implementation starts at Session 01
+**Surfaces:** web, desktop, iOS (shared renderer + thin shell gates)
+**Companion:** [brainstorm](2026-08-23-brainstorm-html-documents.md)
+
+This spec is the implementation contract for the **document-runtime
+fork**. Session tasks check boxes against this file. If a session
+wants to violate an invariant, it updates this spec first.
+
+---
+
+## 1. Goal
+
+A user can open a `.html` / `.htm` file (or a `text/html` URL) in
+SpecDown and see a **faithful, sandboxed** preview of that document,
+with Raw/Split, tabs, recents, and live reload, without executing
+document scripts in the SpecDown origin and without running the file
+through `marked`.
+
+v1 is Sessions 01–02 in the brainstorm. Sessions 03+ (workspace
+assets, Safe mode, Mermaid enhance, annotations) are sketched here
+as extension points so v1 does not paint them into a corner.
+
+---
+
+## 2. Document kind
+
+### 2.1 Detection
+
+```
+detectKind(filename: string): 'markdown' | 'html' | null
+```
+
+| Extension (lowercase, last `.…`) | Kind |
+|---|---|
+| `.md`, `.markdown` | `markdown` |
+| `.html`, `.htm` | `html` |
+| anything else | `null` (reject) |
+
+Extension wins. A `.md` file that contains `<!DOCTYPE html>` is
+markdown. A `.html` file that contains markdown is HTML.
+
+**URL open without a usable extension:** if `Content-Type`
+starts with `text/html`, kind is `html`; otherwise kind is
+`markdown` (preserves today's "treat the body as markdown" behavior
+for raw GitHub URLs and extensionless paths).
+
+**iOS / desktop OS-open:** kind from the filename the shell already
+passes into `loadFileContent` / `file-opened`.
+
+### 2.2 Tab shape
+
+Add one field. Do not rename `rawMarkdown` in the v1 PR (harness +
+dozens of tests). Treat it as "raw source of whatever this tab is."
+
+```
+Tab {
+  id, filename, filePath, rawMarkdown, viewMode, scrollTop,
+  watching, hasUnseenChanges, sourceMeta,
+  kind: 'markdown' | 'html'   // NEW; default 'markdown' for safety
+}
+```
+
+`createTab(filename, content, …)` calls `detectKind(filename)` and
+stores it. Missing/unknown kind is a programming error — do not
+guess at render time.
+
+`Object.seal(state)` stays; add `kind` only on the tab object, not
+on `AppState`, unless a global "current kind" helper is clearer
+for the toolbar. Prefer `activeTab().kind`.
+
+### 2.3 Capability table
+
+A pure function `documentCapabilities(kind)` returns booleans.
+Every toolbar / palette / iOS-sheet / present-button reveal
+consults it. Do not special-case kind in five UI modules.
+
+v1 capabilities:
+
+| Capability | markdown | html |
+|---|---|---|
+| `preview` | yes | yes (iframe stage) |
+| `raw` | yes | yes |
+| `split` | yes | yes |
+| `liveReload` | yes | yes |
+| `fileInfo` | yes | yes |
+| `toc` | yes | Session 02 |
+| `find` | yes | Session 02 (or hidden) |
+| `print` | yes | Session 02 |
+| `present` | if diagrams | no |
+| `annotate` | yes | no |
+| `authoredComments` | yes | no |
+| `codeCopy` | yes | no |
+| `customCss` | yes (chrome + md) | chrome only |
+| `workspaceLinks` | yes | Session 03 |
+
+---
+
+## 3. Render fork
+
+### 3.1 Entry
+
+`renderDocument(content, filename, kind)` (name unique for the
+harness — not a bare `render`):
+
+- `markdown` → existing `renderMarkdown` body (marked → DOMPurify
+  `{ ADD_TAGS: ['#comment'] }` → comments / code-copy / mermaid /
+  TOC / annotations).
+- `html` → `renderHtmlDocument` in `features/html-document.js`.
+
+`renderMarkdown` may remain as a wrapper for tests that call it
+directly; new code calls `renderDocument`.
+
+### 3.2 HTML stage DOM
+
+The content pane is a stage. Recommended markup (Session 01):
+
+```html
+<div id="document-stage">
+  <div id="markdown-content" class="markdown-body"></div>
+  <iframe id="html-frame"
+          hidden
+          sandbox="allow-scripts"
+          title=""></iframe>
+</div>
+```
+
+Rules:
+
+- Exactly one `#html-frame`.
+- Markdown tabs: hide iframe, show `#markdown-content`, existing
+  CSS applies.
+- HTML tabs: hide `#markdown-content` (or empty it), show iframe
+  filling the stage. **No SpecDown prose max-width on the iframe.**
+- Iframe `title` = filename.
+- **Forbidden attribute combination** on `#html-frame`:
+  `sandbox` containing both `allow-scripts` and `allow-same-origin`.
+  A unit test greps the attribute.
+
+`sandbox` v1 value: `allow-scripts` only.
+
+### 3.3 Rewrite pipeline
+
+`rewriteHtmlDocument(raw: string, opts: { baseHref?: string }): string`
+
+1. `new DOMParser().parseFromString(raw, 'text/html')`.
+2. If the parse is a fragment, DOMParser still produces a document —
+   use that (it wraps html/head/body).
+3. Prepend CSP meta (brainstorm §4.2 Invariant 6) to `head`.
+4. Append host script: `<script src="./html-host.js">` or the
+   Vite-resolved hashed URL. The host must load from the **app**
+   origin via an absolute path on the iframe? **Careful:** a blob
+   document cannot load `'self'` app scripts unless we inline the
+   host or serve it from a blob as well.
+
+   **Session 01 choice (required):** **inline the host script**
+   into the rewritten document as a single `<script>` with our
+   source (built as a string from `features/html-host.js`). The
+   host is trusted code we authored. It does not use
+   `allow-same-origin` to phone home — only `postMessage` to
+   `window.parent`.
+
+5. If `baseHref` is set, ensure a `<base href="…">`.
+6. Remove `iframe`, `object`, `embed`, `frame`, `frameset`.
+7. Remove `meta[http-equiv=refresh]`.
+8. Set `target="_blank"` and `rel="noopener noreferrer"` on
+   `a[href]` that are not `http(s)`-internal-hash-only. Hash-only
+   links stay in-document (the iframe handles them).
+9. Serialize `document.documentElement.outerHTML` with doctype.
+
+### 3.4 Preview source
+
+Session 01: `URL.createObjectURL(new Blob([rewritten], { type: 'text/html' }))`.
+Set `iframe.src` to the blob URL. Revoke the previous blob on
+re-render and on tab close.
+
+`baseHref` in Session 01:
+
+- URL-opened tabs: the fetched URL (after GitHub blob
+  normalization), directory form (`…/path/to/` + file).
+- Desktop/iOS file-backed tabs: omit (no protocol yet). Relative
+  assets 404 inside the blob; acceptable for v1.
+- Web File drop: omit.
+
+### 3.5 Host bridge protocol
+
+Parent → frame (`iframe.contentWindow.postMessage`, target `*`
+because blob origins are opaque; **the frame** checks
+`event.source === window.parent`).
+
+| `type` | Payload | Purpose |
+|---|---|---|
+| `specdown-ping` | `{ id }` | handshake |
+| `specdown-find` | `{ id, query, direction }` | Session 02 |
+| `specdown-clear-find` | `{ id }` | Session 02 |
+| `specdown-scroll-to` | `{ id, headingId }` | Session 02 TOC |
+| `specdown-print` | `{ id }` | Session 02 |
+| `specdown-theme` | `{ theme }` | later; ignore in v1 |
+
+Frame → parent (`window.parent.postMessage`; parent accepts only
+if `event.source === htmlFrame.contentWindow`):
+
+| `type` | Payload |
+|---|---|
+| `specdown-ready` | `{ title, headings: { id, level, text }[] }` |
+| `specdown-find-result` | `{ id, current, total }` |
+| `specdown-print-ready` | `{ id, html }` snapshot |
+| `specdown-open-external` | `{ href }` |
+| `specdown-error` | `{ message }` |
+
+Drop any other `type`. Do not eval payloads.
+
+Host script responsibilities v1: on `load`, send `specdown-ready`
+(document.title, walk `h1–h4` with generated ids if missing).
+Click handler on `a[href^=http]` → preventDefault +
+`specdown-open-external`. Parent opens via existing desktop
+external-link path or `window.open` with noopener on web.
+
+### 3.6 Raw and split
+
+Raw view for HTML is the **author source** (`tab.rawMarkdown`) in
+the existing `<pre class="raw-markdown">` (class name can stay).
+Highlight.js HTML language is already in the bundle.
+
+Split: left (or top) source, right (or bottom) iframe. Reuse the
+split layout chrome; the preview side mounts the stage, not
+`innerHTML` of `#markdown-content`.
+
+### 3.7 What HTML render must not do in v1
+
+- Call `marked.parse`.
+- Assign document HTML to any parent node via `innerHTML`.
+- Run `processMermaidDiagrams` on the iframe.
+- Call `renderAnnotations` / `revealHtmlComments` /
+  `enhanceCodeBlocks` on the iframe.
+- Show Present / Annotate / Comments.
+
+---
+
+## 4. Open-path gates (all must change together)
+
+A single shared list lives in `core/document-kind.js` and is
+imported (or duplicated with a test that they match) in
+`desktop/main.js` — desktop cannot import ESM from the renderer
+today, so **duplicate the extension arrays in main.js** and add a
+regression test that the exported desktop list equals the
+documented set `md, markdown, html, htm`.
+
+| Gate | Change |
+|---|---|
+| `file-loading.js` `VALID_EXTENSIONS` | union; toast: "Please select a Markdown or HTML file (.md, .markdown, .html, .htm)" |
+| `index.html` `#file-input accept` | `.md,.markdown,.html,.htm` |
+| `desktop/main.js` `VALID_EXTENSIONS` + `isValidMarkdownFile` | rename to `isOpenableDocument`; keep `isValidMarkdownFile` as a deprecated alias *or* update every call site in the same PR |
+| Open dialog filters | Markdown; HTML (`html`, `htm`); All files |
+| Dialog title | "Open File" |
+| `scanWorkspace` | `isOpenableDocument` (Session 03 can ship this; Session 01 should still use the helper so Session 03 is a one-line scan change) |
+| `workspace.js` `MARKDOWN_LINK_RE` | Session 03: `/\.(md\|markdown\|html\|htm)$/i` |
+| `repo-browser.js` | Session 03: include HTML in the GitHub search |
+| `normalizeMarkdownUrl` | still correct for GitHub blob HTML (`blob` → `raw` works for any path) |
+| `manifest.webmanifest` `file_handlers` | add `text/html`: [`.html`, `.htm`] |
+| `ios/project.yml` | import `public.html`; add a document type for HTML |
+| `WebBridge.swift` picker | append `.html` (`UTType.html`) |
+| Landing copy | "Markdown or HTML" (see brainstorm §3.2) |
+| PWA / README | mention HTML as an accepted input, not a new product |
+
+Desktop `file-opened` IPC payload stays `{ path, content, filename }`
+(or whatever it is today). Renderer detects kind from filename.
+Do not add a `kind` field to IPC in Session 01 unless it simplifies
+tests.
+
+---
+
+## 5. Print / PDF (Session 02; designed now)
+
+Do not print the SpecDown shell.
+
+HTML print algorithm:
+
+1. Parent sends `specdown-print`.
+2. Host returns `specdown-print-ready` with
+   `document.documentElement.outerHTML` (post-JS, so charts exist
+   when possible).
+3. Parent builds a printable document via the existing
+   `buildPrintableDocument()` path **or** a sibling
+   `buildPrintableHtmlDocument(snapshot)` that wraps the snapshot
+   in the print window/iframe already used for markdown.
+4. Desktop PDF (`export-pdf`) uses the same snapshot.
+5. Fallback if the host never answers (script-broken page): print
+   the rewritten **static** HTML (no JS). Toast: "Printed the
+   static page (scripts didn't finish)."
+
+`@media print` in SpecDown CSS must still reset any new
+full-height ancestor (`#document-stage { height: auto; overflow:
+visible; }` in the print stylesheet).
+
+---
+
+## 6. Security checklist (review every HTML PR)
+
+- [ ] `#html-frame` sandbox does not include `allow-same-origin`
+      together with `allow-scripts`
+- [ ] No parent `innerHTML` / `insertAdjacentHTML` of raw file
+      bytes
+- [ ] Host messages are a closed enum; default drop
+- [ ] `specdown-open-external` only accepts `http:` / `https:`
+- [ ] Blob URLs revoked
+- [ ] Size cap (8 MB) enforced at `handleFile` / `openFileByPath` /
+      `handleUrl`
+- [ ] Nested frames stripped in rewrite
+- [ ] Tests do not use the passthrough DOMPurify mock to "prove"
+      Safe mode (Safe mode is not v1)
+- [ ] New identifiers are harness-safe (no colliding `let render`)
+
+---
+
+## 7. Sample
+
+Add `markdown-viewer/samples/html-showcase.html`:
+
+- Self-contained (inline CSS, no external JS required so the blob
+  preview looks complete without Session 04)
+- A real layout (header, sections, a simple CSS-only tab or
+  callout) — not `lorem` in Times
+- Several `h1`/`h2` so Session 02 TOC has something to show
+- A visible line that it is a SpecDown sample (footer)
+- No network requests (the sample must work offline / in the PWA)
+
+Wire a second landing / iOS sample button. Do not replace the
+Mermaid showcase.
+
+---
+
+## 8. Tests (Session 01 minimum)
+
+- `tests/unit/document-kind.test.js` — extensions, URL content-type
+  helper, capabilities
+- `tests/unit/html-document.test.js` — rewrite injects CSP + host,
+  strips iframe/refresh, does not include `allow-same-origin` in
+  the stage iframe markup
+- File-loading: HTML file creates `kind: 'html'`; `marked.parse`
+  not called (spy)
+- Existing markdown tests stay green (kind defaults / markdown path
+  unchanged)
+- `desktop-main.test.js`: `.html` is openable; `.pdf` is not;
+  `artifactName` space regression remains
+
+---
+
+## 9. Out of scope for v1
+
+- `specdown-doc://` asset protocol
+- Safe / Faithful toggle
+- Mermaid enhance / Present for HTML
+- Annotations on HTML
+- GitHub repo HTML search (Session 03)
+- Sibling asset resolution
+- Converting HTML to markdown
+- Editing
+- New empty-state product / rename
+
+---
+
+## 10. Implementation map
+
+| Piece | Where |
+|---|---|
+| Kind + capabilities | `markdown-viewer/src/core/document-kind.js` |
+| Rewrite + iframe + bridge | `markdown-viewer/src/features/html-document.js` |
+| Host script source | `markdown-viewer/src/features/html-host.js` |
+| Open gates | `file-loading.js`, `index.html`, `desktop/main.js`, `manifest.webmanifest`, `ios/project.yml`, `WebBridge.swift` |
+| Dispatch | `main.js` |
+| Tab field | `core/state.js` JSDoc + `features/tabs.js` |
+| Sample | `markdown-viewer/samples/html-showcase.html` |
+| Tests | `tests/unit/document-kind.test.js`, `tests/unit/html-document.test.js`, existing suites |
+
+---
+
+## 11. Acceptance (v1 done)
+
+1. Drop / browse / URL of an `.html` file opens a tab that looks
+   like the file, not like markdown.
+2. Raw shows the source; Preview shows the page.
+3. A markdown file still renders exactly as today (regression).
+4. Document script cannot read `window.specdown` or parent DOM
+   (manual + sandbox attribute test).
+5. Lint, typecheck, and Jest are clean.
+6. iOS picker can choose an HTML file (types registered).
+7. No new toolbar button.

--- a/docs/project-html/2026-08-23-spec-html-v1.md
+++ b/docs/project-html/2026-08-23-spec-html-v1.md
@@ -1,9 +1,14 @@
 # Spec: HTML Documents — v1
 
 **Date:** 2026-08-23
-**Status:** Specified; implementation starts at Session 01
+**Status:** Specified; **amended after council review**
 **Surfaces:** web, desktop, iOS (shared renderer + thin shell gates)
-**Companion:** [brainstorm](2026-08-23-brainstorm-html-documents.md)
+**Companion:** [brainstorm](2026-08-23-brainstorm-html-documents.md) ·
+[council](2026-08-23-council-html-plan-review.md)
+
+Council fatals (CSP `frame-src`, print XSS, iframe navigation) are
+invariants in this file. Implement Session 01 from this revision,
+not the first draft.
 
 This spec is the implementation contract for the **document-runtime
 fork**. Session tasks check boxes against this file. If a session
@@ -30,22 +35,24 @@ as extension points so v1 does not paint them into a corner.
 ### 2.1 Detection
 
 ```
-detectKind(filename: string): 'markdown' | 'html' | null
+detectKind(filename: string, contentType?: string | null): 'markdown' | 'html' | null
 ```
 
 | Extension (lowercase, last `.…`) | Kind |
 |---|---|
 | `.md`, `.markdown` | `markdown` |
 | `.html`, `.htm` | `html` |
-| anything else | `null` (reject) |
+| anything else | `null` unless `contentType` decides (URLs only) |
 
 Extension wins. A `.md` file that contains `<!DOCTYPE html>` is
-markdown. A `.html` file that contains markdown is HTML.
+markdown. A `.html` file that contains markdown is HTML. Do not
+sniff bytes.
 
-**URL open without a usable extension:** if `Content-Type`
-starts with `text/html`, kind is `html`; otherwise kind is
-`markdown` (preserves today's "treat the body as markdown" behavior
-for raw GitHub URLs and extensionless paths).
+**URL open without a usable extension:** if `contentType` starts
+with `text/html`, kind is `html`; otherwise kind is `markdown`
+(preserves today's "treat the body as markdown" behavior for raw
+GitHub URLs and extensionless paths). `handleUrl` must pass
+`response.headers.get('content-type')`.
 
 **iOS / desktop OS-open:** kind from the filename the shell already
 passes into `loadFileContent` / `file-opened`.
@@ -86,9 +93,9 @@ v1 capabilities:
 | `split` | yes | yes |
 | `liveReload` | yes | yes |
 | `fileInfo` | yes | yes |
-| `toc` | yes | Session 02 |
-| `find` | yes | Session 02 (or hidden) |
-| `print` | yes | Session 02 |
+| `toc` | yes | **hidden until Session 02** |
+| `find` | yes | **hidden until Session 02** |
+| `print` | yes | **hidden until Session 02** (see §5 — do not no-op) |
 | `present` | if diagrams | no |
 | `annotate` | yes | no |
 | `authoredComments` | yes | no |
@@ -123,6 +130,7 @@ The content pane is a stage. Recommended markup (Session 01):
   <iframe id="html-frame"
           hidden
           sandbox="allow-scripts"
+          allow=""
           title=""></iframe>
 </div>
 ```
@@ -135,11 +143,33 @@ Rules:
 - HTML tabs: hide `#markdown-content` (or empty it), show iframe
   filling the stage. **No SpecDown prose max-width on the iframe.**
 - Iframe `title` = filename.
+- `allow=""` (empty Permissions-Policy) — no camera / mic / geo /
+  payment / display-capture prompts from Faithful pages.
 - **Forbidden attribute combination** on `#html-frame`:
   `sandbox` containing both `allow-scripts` and `allow-same-origin`.
   A unit test greps the attribute.
 
-`sandbox` v1 value: `allow-scripts` only.
+`sandbox` v1 value: `allow-scripts` only (not `allow-forms`; the
+injected iframe CSP has `form-action 'none'`).
+
+**Parent CSP (Session 01, required):** `markdown-viewer/index.html`
+must add `frame-src 'self' blob: file: specdown:`. Do not add
+`blob:` to `script-src`. Today's `default-src` has no `blob:`, and
+`frame-src` falls back to it — without this line the preview iframe
+is blocked. A test asserts both facts on the production CSP string.
+
+**Lifecycle:** `htmlTeardownFrame()` revokes the blob, clears
+`iframe.src`, hides the iframe. Call it from `showDropZone`, when
+closing the last HTML tab, and before minting a replacement blob.
+One iframe, many tabs: every activate remounts from
+`tab.rawMarkdown`. `tab.scrollTop` on `#markdown-content` is a
+no-op for HTML preview in Session 01 — do not claim it works.
+
+**Navigation lock:** the preview `src` must remain the blob we
+minted. On `load`, if it is not that blob (and not `about:blank`),
+reset and toast. Desktop: wire `will-frame-navigate` — deny
+in-frame http(s); `openExternal` instead. This is how we do not
+become a browser.
 
 ### 3.3 Rewrite pipeline
 
@@ -162,13 +192,23 @@ Rules:
    `allow-same-origin` to phone home — only `postMessage` to
    `window.parent`.
 
-5. If `baseHref` is set, ensure a `<base href="…">`.
+5. If `baseHref` is set, ensure a `<base href="…">` with no
+   `target`. Strip any existing `<base target>`.
 6. Remove `iframe`, `object`, `embed`, `frame`, `frameset`.
-7. Remove `meta[http-equiv=refresh]`.
+7. Remove `meta[http-equiv=refresh]` and
+   `meta[http-equiv=set-cookie]`.
 8. Set `target="_blank"` and `rel="noopener noreferrer"` on
-   `a[href]` that are not `http(s)`-internal-hash-only. Hash-only
-   links stay in-document (the iframe handles them).
-9. Serialize `document.documentElement.outerHTML` with doctype.
+   `a[href]` that are not in-document hashes. Neutralize
+   `javascript:` and `data:text/html` hrefs (remove or
+   `href="#"`). Hash-only links stay in-document.
+9. Re-emit `<!DOCTYPE html>` + `document.documentElement.outerHTML`.
+   Do not assume DOMParser preserved the doctype.
+
+`html-host.js` must export **only** a string constant
+(`htmlHostInlineSource`) with `htmlHost*` prefixes on any
+bindings. The eval harness inlines relative imports into the
+parent; a host file with side effects or names like `onMessage`
+collides.
 
 ### 3.4 Preview source
 
@@ -251,11 +291,14 @@ documented set `md, markdown, html, htm`.
 | Gate | Change |
 |---|---|
 | `file-loading.js` `VALID_EXTENSIONS` | union; toast: "Please select a Markdown or HTML file (.md, .markdown, .html, .htm)" |
+| `file-loading.js` `handleUrl` | pass `Content-Type` into `detectKind`; 8 MB cap **HTML only** |
 | `index.html` `#file-input accept` | `.md,.markdown,.html,.htm` |
-| `desktop/main.js` `VALID_EXTENSIONS` + `isValidMarkdownFile` | rename to `isOpenableDocument`; keep `isValidMarkdownFile` as a deprecated alias *or* update every call site in the same PR |
+| `index.html` CSP | add `frame-src 'self' blob: file: specdown:` |
+| `desktop/main.js` `VALID_EXTENSIONS` + `isValidMarkdownFile` | rename to `isOpenableDocument` and use it for open, drop, **session restore**, and **workspace scan** |
 | Open dialog filters | Markdown; HTML (`html`, `htm`); All files |
 | Dialog title | "Open File" |
-| `scanWorkspace` | `isOpenableDocument` (Session 03 can ship this; Session 01 should still use the helper so Session 03 is a one-line scan change) |
+| `package.json` `build.fileAssociations` | add HTML (`html`, `htm`, `mimeType: text/html`, role Viewer) |
+| `scanWorkspace` + web folder walk | Session 01: list HTML. Empty copy: "No Markdown or HTML files found." Relative link following stays Session 03 |
 | `workspace.js` `MARKDOWN_LINK_RE` | Session 03: `/\.(md\|markdown\|html\|htm)$/i` |
 | `repo-browser.js` | Session 03: include HTML in the GitHub search |
 | `normalizeMarkdownUrl` | still correct for GitHub blob HTML (`blob` → `raw` works for any path) |
@@ -274,22 +317,34 @@ tests.
 
 ## 5. Print / PDF (Session 02; designed now)
 
-Do not print the SpecDown shell.
+Do not print the SpecDown shell. **Session 01 hides Print** for
+HTML (capability off). Invoking Cmd+P / File > Print / the iOS
+Print row on an HTML tab must **not** call `performPrint()` —
+that clones `#markdown-content` (empty) or falls through to
+`window.print()` on the viewport-fixed shell.
 
-HTML print algorithm:
+**Forbidden (council F2):** taking a Faithful
+`document.documentElement.outerHTML` (scripts included) and
+`document.write`ing it into the same-origin print iframe
+(`printViaHiddenFrame`) or writing it to a temp file the
+desktop PDF window `loadFile`s. That is the Absorb XSS with a
+Print button.
+
+Session 02 algorithm:
 
 1. Parent sends `specdown-print`.
-2. Host returns `specdown-print-ready` with
-   `document.documentElement.outerHTML` (post-JS, so charts exist
-   when possible).
-3. Parent builds a printable document via the existing
-   `buildPrintableDocument()` path **or** a sibling
-   `buildPrintableHtmlDocument(snapshot)` that wraps the snapshot
-   in the print window/iframe already used for markdown.
-4. Desktop PDF (`export-pdf`) uses the same snapshot.
-5. Fallback if the host never answers (script-broken page): print
-   the rewritten **static** HTML (no JS). Toast: "Printed the
+2. **Preferred:** host calls `window.print()` *inside* the opaque
+   preview iframe. Charts exist. Scripts stay in the opaque
+   origin. The dialog attaches to the visible window (macOS
+   sheet rule).
+3. **Fallback** if the host never answers: print a
+   **script-stripped** rewrite (no `<script>`, no event handlers)
+   through the existing printable path. Toast: "Printed the
    static page (scripts didn't finish)."
+4. Desktop PDF uses the same split: prefer a host snapshot that
+   has been script-stripped, or print-to-PDF from a sandboxed
+   offscreen window loaded with the stripped rewrite — never
+   Faithful HTML.
 
 `@media print` in SpecDown CSS must still reset any new
 full-height ancestor (`#document-stage { height: auto; overflow:
@@ -301,17 +356,25 @@ visible; }` in the print stylesheet).
 
 - [ ] `#html-frame` sandbox does not include `allow-same-origin`
       together with `allow-scripts`
+- [ ] `#html-frame` has `allow=""` (or an explicit deny list)
+- [ ] Production CSP has `frame-src` including `blob:` and does
+      **not** add `blob:` to `script-src`
 - [ ] No parent `innerHTML` / `insertAdjacentHTML` of raw file
       bytes
 - [ ] Host messages are a closed enum; default drop
 - [ ] `specdown-open-external` only accepts `http:` / `https:`
-- [ ] Blob URLs revoked
-- [ ] Size cap (8 MB) enforced at `handleFile` / `openFileByPath` /
-      `handleUrl`
-- [ ] Nested frames stripped in rewrite
+- [ ] Blob URLs revoked; `htmlTeardownFrame()` on empty state
+- [ ] Preview `src` reset if the iframe navigates off our blob
+- [ ] Desktop `will-frame-navigate` denies in-frame http(s)
+- [ ] Size cap (8 MB) on **HTML** opens only
+- [ ] Nested frames, `<base target>`, `javascript:` /
+      `data:text/html` hrefs stripped in rewrite
+- [ ] Print/PDF never `document.write`s Faithful HTML into a
+      same-origin frame (Session 01: Print hidden)
 - [ ] Tests do not use the passthrough DOMPurify mock to "prove"
       Safe mode (Safe mode is not v1)
-- [ ] New identifiers are harness-safe (no colliding `let render`)
+- [ ] New identifiers are harness-safe; host module is a string
+      export only (no colliding `let render`)
 
 ---
 
@@ -337,13 +400,17 @@ Mermaid showcase.
 - `tests/unit/document-kind.test.js` — extensions, URL content-type
   helper, capabilities
 - `tests/unit/html-document.test.js` — rewrite injects CSP + host,
-  strips iframe/refresh, does not include `allow-same-origin` in
-  the stage iframe markup
+  strips iframe/refresh/`<base target>`/`javascript:` hrefs, does
+  not include `allow-same-origin` in the stage iframe markup
 - File-loading: HTML file creates `kind: 'html'`; `marked.parse`
-  not called (spy)
+  not called (spy); `handleUrl` uses `Content-Type` when the path
+  has no extension; 8 MB cap does not reject markdown
+- Production CSP string includes `frame-src` + `blob` and does not
+  put `blob:` on `script-src`
 - Existing markdown tests stay green (kind defaults / markdown path
   unchanged)
 - `desktop-main.test.js`: `.html` is openable; `.pdf` is not;
+  session restore accepts `.html`; `scanWorkspace` lists `.html`;
   `artifactName` space regression remains
 
 ---
@@ -386,5 +453,10 @@ Mermaid showcase.
 4. Document script cannot read `window.specdown` or parent DOM
    (manual + sandbox attribute test).
 5. Lint, typecheck, and Jest are clean.
-6. iOS picker can choose an HTML file (types registered).
+6. iOS picker can choose an HTML file (types registered). iOS
+   sheet hides Print / Comments / Annotate / Present on HTML tabs.
 7. No new toolbar button.
+8. Parent CSP allows the blob iframe; a dropped HTML file is
+   visible, not a blank stage.
+9. Closing the last HTML tab does not leave a live iframe under
+   the landing.

--- a/docs/project-html/2026-08-23-spec-html-v1.md
+++ b/docs/project-html/2026-08-23-spec-html-v1.md
@@ -151,27 +151,44 @@ Rules:
   `sandbox` containing both `allow-scripts` and `allow-same-origin`.
   A unit test greps the attribute.
 
-`sandbox` v1 value: `allow-scripts` only (not `allow-forms`; the
-injected iframe CSP has `form-action 'none'`).
+`sandbox` v1 value: `allow-scripts` only (not `allow-forms`;
+`allow-modals` is Session 02 if in-frame print needs it).
 
-**Parent CSP (Session 01, required):** `markdown-viewer/index.html`
-must add `frame-src 'self' blob: file: specdown:`. Do not add
-`blob:` to `script-src`. Today's `default-src` has no `blob:`, and
-`frame-src` falls back to it — without this line the preview iframe
-is blocked. A test asserts both facts on the production CSP string.
+**Do not use `blob:` or `srcdoc` as the preview document
+(council security F2–F3).** Those inherit the **parent** CSP
+(`script-src 'self' 'unsafe-eval' file: specdown:` — no
+`'unsafe-inline'`, no `https:`). A meta CSP in the framed
+document cannot loosen that. Blob URLs are also **same-origin
+with the app**; opacity is only the sandbox flag.
 
-**Lifecycle:** `htmlTeardownFrame()` revokes the blob, clears
-`iframe.src`, hides the iframe. Call it from `showDropZone`, when
-closing the last HTML tab, and before minting a replacement blob.
-One iframe, many tabs: every activate remounts from
-`tab.rawMarkdown`. `tab.scrollTop` on `#markdown-content` is a
-no-op for HTML preview in Session 01 — do not claim it works.
+**Preview host (Session 01 required):** `#html-frame.src` is a
+**real URL** to a bundled page, e.g.
+`markdown-viewer/html-preview-host.html` (Vite copies it; iOS
+`specdown://app/html-preview-host.html`; desktop `file:` next
+to `dist`). That page has **its own** CSP (Faithful:
+`'unsafe-inline' https:`). Parent `postMessage`s the rewritten
+HTML into it; the host `document.write`s **inside the sandboxed
+iframe**. Isolation is `sandbox` without `allow-same-origin`,
+not `blob:`.
 
-**Navigation lock:** the preview `src` must remain the blob we
-minted. On `load`, if it is not that blob (and not `about:blank`),
-reset and toast. Desktop: wire `will-frame-navigate` — deny
-in-frame http(s); `openExternal` instead. This is how we do not
-become a browser.
+**Parent CSP:** add `frame-src 'self' file: specdown:` so the
+host page can be framed. **Do not** add `blob:` to `script-src`.
+**Do not** add `'unsafe-inline'` to parent `script-src`. Static
+grep of `index.html`.
+
+**Lifecycle:** `htmlTeardownFrame()` sets `src` back to the
+host URL or `about:blank`, hides the iframe. Call from
+`showDropZone`, last-HTML-tab close, and before a new load.
+One iframe, many tabs: every activate reloads the host then
+postMessages `tab.rawMarkdown` (rewritten). Do not claim
+scroll restore.
+
+**Navigation lock:** preview `src` must remain the host URL
+(or `about:blank`). On `load`, if it is not, reset and toast.
+Desktop `will-frame-navigate`: deny in-frame http(s) /
+`javascript:` / `data:` / `file:` that is not the app;
+`openExternal` for http(s). iOS: cancel **iframe** navigations
+too, not only main-frame.
 
 ### 3.3 Rewrite pipeline
 
@@ -180,85 +197,63 @@ become a browser.
 1. `new DOMParser().parseFromString(raw, 'text/html')`.
 2. If the parse is a fragment, DOMParser still produces a document —
    use that (it wraps html/head/body).
-3. Prepend CSP meta (brainstorm §4.2 Invariant 6) to `head`.
-4. Append host script: `<script src="./html-host.js">` or the
-   Vite-resolved hashed URL. The host must load from the **app**
-   origin via an absolute path on the iframe? **Careful:** a blob
-   document cannot load `'self'` app scripts unless we inline the
-   host or serve it from a blob as well.
+3. **Strip** author `meta[http-equiv=content-security-policy]`
+   (any case). Do not prepend a CSP meta into attacker HTML —
+   policy lives on the **preview host page**.
+4. **Remove every `<base>`**, then insert ours if `baseHref` is
+   set (no `target`).
+5. Remove `iframe`, `object`, `embed`, `frame`, `frameset`,
+   `portal`, `fencedframe`.
+6. Remove `meta[http-equiv=refresh]` and
+   `meta[http-equiv=set-cookie]` (any ASCII case).
+7. Neutralize `javascript:` `data:` `vbscript:` `file:` `blob:`
+   `specdown:` and protocol-relative `//` hrefs. Hash-only
+   links stay. Do not rely on `_blank` (no `allow-popups`).
+8. Re-emit `<!DOCTYPE html>` + `outerHTML`.
 
-   **Session 01 choice (required):** **inline the host script**
-   into the rewritten document as a single `<script>` with our
-   source (built as a string from `features/html-host.js`). The
-   host is trusted code we authored. It does not use
-   `allow-same-origin` to phone home — only `postMessage` to
-   `window.parent`.
+The preview **host page** (`html-preview-host.html`) owns the
+host script as `'self'` of that URL. Do not inline host source
+into attacker HTML (document scripts can impersonate it).
 
-5. If `baseHref` is set, ensure a `<base href="…">` with no
-   `target`. Strip any existing `<base target>`.
-6. Remove `iframe`, `object`, `embed`, `frame`, `frameset`.
-7. Remove `meta[http-equiv=refresh]` and
-   `meta[http-equiv=set-cookie]`.
-8. Set `target="_blank"` and `rel="noopener noreferrer"` on
-   `a[href]` that are not in-document hashes. Neutralize
-   `javascript:` and `data:text/html` hrefs (remove or
-   `href="#"`). Hash-only links stay in-document.
-9. Re-emit `<!DOCTYPE html>` + `document.documentElement.outerHTML`.
-   Do not assume DOMParser preserved the doctype.
-
-`html-host.js` must export **only** a string constant
-(`htmlHostInlineSource`) with `htmlHost*` prefixes on any
-bindings. The eval harness inlines relative imports into the
-parent; a host file with side effects or names like `onMessage`
-collides.
+**Every frame→parent payload is untrusted** — including
+`specdown-print-ready.html`. Never `innerHTML` /
+`document.write` / `loadFile` / `UIMarkupTextPrintFormatter`
+that string in the **app** origin.
 
 ### 3.4 Preview source
 
-Session 01: `URL.createObjectURL(new Blob([rewritten], { type: 'text/html' }))`.
-Set `iframe.src` to the blob URL. Revoke the previous blob on
-re-render and on tab close.
+Session 01: `iframe.src = html-preview-host.html` (bundled).
+After the host `load`, parent `postMessage`s `{ type:
+'specdown-load', html: rewritten }`. Host writes that HTML
+inside the sandboxed frame.
 
-`baseHref` in Session 01:
+`baseHref` in Session 01: omit (no asset protocol). Relative
+URLs 404; lone-file toast if the rewrite saw them.
 
-- URL-opened tabs: the fetched URL (after GitHub blob
-  normalization), directory form (`…/path/to/` + file).
-- Desktop/iOS file-backed tabs: omit (no protocol yet). Relative
-  assets 404 inside the blob; acceptable for v1.
-- Web File drop: omit.
+Do **not** mint a blob URL of the document.
 
 ### 3.5 Host bridge protocol
 
-Parent → frame (`iframe.contentWindow.postMessage`, target `*`
-because blob origins are opaque; **the frame** checks
+Parent → frame (`postMessage`, target `*`; **the frame** checks
 `event.source === window.parent`).
 
 | `type` | Payload | Purpose |
 |---|---|---|
-| `specdown-ping` | `{ id }` | handshake |
+| `specdown-load` | `{ html }` | Session 01: rewritten source |
 | `specdown-find` | `{ id, query, direction }` | Session 02 |
-| `specdown-clear-find` | `{ id }` | Session 02 |
-| `specdown-scroll-to` | `{ id, headingId }` | Session 02 TOC |
-| `specdown-print` | `{ id }` | Session 02 |
-| `specdown-theme` | `{ theme }` | later; ignore in v1 |
+| `specdown-print` | `{ id }` | Session 02 — host `window.print()`, no HTML return |
 
-Frame → parent (`window.parent.postMessage`; parent accepts only
-if `event.source === htmlFrame.contentWindow`):
+Frame → parent: accept only if `event.source === htmlFrame.contentWindow`.
+Treat **every** payload as attacker input. Drop unknown `type`.
+`specdown-print-ready` with an `html` field is **forbidden** — do
+not implement that message.
 
-| `type` | Payload |
-|---|---|
-| `specdown-ready` | `{ title, headings: { id, level, text }[] }` |
-| `specdown-find-result` | `{ id, current, total }` |
-| `specdown-print-ready` | `{ id, html }` snapshot |
-| `specdown-open-external` | `{ href }` |
-| `specdown-error` | `{ message }` |
+Session 01 host (lives on `html-preview-host.html`, not in the
+document): on `specdown-load`, `document.write` the HTML inside
+this frame. No `specdown-ready` required (TOC is hidden).
 
-Drop any other `type`. Do not eval payloads.
-
-Host script responsibilities v1: on `load`, send `specdown-ready`
-(document.title, walk `h1–h4` with generated ids if missing).
-Click handler on `a[href^=http]` → preventDefault +
-`specdown-open-external`. Parent opens via existing desktop
-external-link path or `window.open` with noopener on web.
+**iOS:** reject `WKScriptMessage` unless `frameInfo.isMainFrame`.
+The preview frame must not reach `webkit.messageHandlers.specdown`.
 
 ### 3.6 Raw and split
 
@@ -295,9 +290,9 @@ documented set `md, markdown, html, htm`.
 | `file-loading.js` `VALID_EXTENSIONS` | union; toast: "Please select a Markdown or HTML file (.md, .markdown, .html, .htm)" |
 | `file-loading.js` `handleUrl` | extension-only (`.html`/`.htm`); **no** Content-Type sniff; 8 MB cap **HTML only** |
 | `index.html` `#file-input accept` | `.md,.markdown,.html,.htm` |
-| `index.html` CSP | add `frame-src 'self' blob: file: specdown:` |
+| `index.html` CSP | add `frame-src 'self' file: specdown:` (preview host, not blob) |
 | `index.html` landing / hero / pillars | **unchanged** in Session 01 (no “Markdown or HTML” launch) |
-| `desktop/main.js` `VALID_EXTENSIONS` + `isValidMarkdownFile` | rename to `isOpenableDocument` and use it for open, drop, **session restore**, and **workspace scan** |
+| `desktop/main.js` `VALID_EXTENSIONS` + `isValidMarkdownFile` | rename to `isOpenableDocument` and use it for open, drop, **session restore**, **refresh-file**, **recents**, and **workspace scan** |
 | Open dialog filters | Markdown; HTML (`html`, `htm`); All files |
 | Dialog title | "Open File" |
 | `package.json` `build.fileAssociations` | **Session 04** — do not claim the OS HTML handler in Session 01 |
@@ -363,14 +358,17 @@ though HTML print waits for Session 02.
 - [ ] `#html-frame` sandbox does not include `allow-same-origin`
       together with `allow-scripts`
 - [ ] `#html-frame` has `allow=""` (or an explicit deny list)
-- [ ] Production CSP has `frame-src` including `blob:` and does
-      **not** add `blob:` to `script-src`
+- [ ] Production CSP has `frame-src` including `'self'` (preview
+      host) and does **not** add `blob:` or `'unsafe-inline'` to
+      parent `script-src`
+- [ ] Preview `src` is the bundled host page, not a blob/srcdoc
+- [ ] iOS bridge rejects non-main-frame `WKScriptMessage`
 - [ ] No parent `innerHTML` / `insertAdjacentHTML` of raw file
       bytes
 - [ ] Host messages are a closed enum; default drop
 - [ ] `specdown-open-external` only accepts `http:` / `https:`
 - [ ] Blob URLs revoked; `htmlTeardownFrame()` on empty state
-- [ ] Preview `src` reset if the iframe navigates off our blob
+- [ ] Preview `src` reset if the iframe navigates off the host URL
 - [ ] Desktop `will-frame-navigate` denies in-frame http(s)
 - [ ] Size cap (8 MB) on **HTML** opens only
 - [ ] Nested frames, `<base target>`, `javascript:` /
@@ -412,8 +410,8 @@ button. Do not replace the Mermaid showcase.
 - File-loading: HTML file creates `kind: 'html'`; `marked.parse`
   not called (spy); `handleUrl` on an extensionless URL stays
   markdown; 8 MB cap does not reject markdown
-- Production CSP string includes `frame-src` + `blob` and does not
-  put `blob:` on `script-src`
+- Production CSP string includes `frame-src 'self'` and does not
+  put `blob:` or `'unsafe-inline'` on parent `script-src`
 - Existing markdown tests stay green (kind defaults / markdown path
   unchanged)
 - `desktop-main.test.js`: `.html` is openable; `.pdf` is not;
@@ -442,7 +440,7 @@ button. Do not replace the Mermaid showcase.
 |---|---|
 | Kind + capabilities | `markdown-viewer/src/core/document-kind.js` |
 | Rewrite + iframe + bridge | `markdown-viewer/src/features/html-document.js` |
-| Host script source | `markdown-viewer/src/features/html-host.js` |
+| Preview host page | `markdown-viewer/html-preview-host.html` (own CSP + host script) |
 | Open gates | `file-loading.js`, `index.html`, `desktop/main.js`, `manifest.webmanifest`, `ios/project.yml`, `WebBridge.swift` |
 | Dispatch | `main.js` |
 | Tab field | `core/state.js` JSDoc + `features/tabs.js` |

--- a/docs/project-html/2026-08-23-spec-html-v1.md
+++ b/docs/project-html/2026-08-23-spec-html-v1.md
@@ -35,24 +35,18 @@ as extension points so v1 does not paint them into a corner.
 ### 2.1 Detection
 
 ```
-detectKind(filename: string, contentType?: string | null): 'markdown' | 'html' | null
+detectKind(filename: string): 'markdown' | 'html' | null
 ```
 
 | Extension (lowercase, last `.…`) | Kind |
 |---|---|
 | `.md`, `.markdown` | `markdown` |
 | `.html`, `.htm` | `html` |
-| anything else | `null` unless `contentType` decides (URLs only) |
+| anything else | `null` (reject) on local open; URL fetch without `.html`/`.htm` stays **markdown** |
 
 Extension wins. A `.md` file that contains `<!DOCTYPE html>` is
 markdown. A `.html` file that contains markdown is HTML. Do not
-sniff bytes.
-
-**URL open without a usable extension:** if `contentType` starts
-with `text/html`, kind is `html`; otherwise kind is `markdown`
-(preserves today's "treat the body as markdown" behavior for raw
-GitHub URLs and extensionless paths). `handleUrl` must pass
-`response.headers.get('content-type')`.
+sniff bytes. Do not sniff `Content-Type` in Session 01.
 
 **iOS / desktop OS-open:** kind from the filename the shell already
 passes into `loadFileContent` / `file-opened`.
@@ -140,8 +134,13 @@ Rules:
 - Exactly one `#html-frame`.
 - Markdown tabs: hide iframe, show `#markdown-content`, existing
   CSS applies.
-- HTML tabs: hide `#markdown-content` (or empty it), show iframe
-  filling the stage. **No SpecDown prose max-width on the iframe.**
+- HTML tabs: hide `#markdown-content` (empty it so Find/TOC/Print
+  cannot see a leftover markdown tab), show iframe filling the
+  stage. **`#html-frame` is a sibling of `#markdown-content`,
+  never a child.** Zero SpecDown padding on the iframe. iOS
+  safe-area lives on `#document-stage`.
+- Raw: hide `#html-frame`; source goes in the existing pre.
+- Split CSS targets `#document-stage`, not `.markdown-content`.
 - Iframe `title` = filename.
 - `allow=""` (empty Permissions-Policy) — no camera / mic / geo /
   payment / display-capture prompts from Faithful pages.
@@ -291,22 +290,22 @@ documented set `md, markdown, html, htm`.
 | Gate | Change |
 |---|---|
 | `file-loading.js` `VALID_EXTENSIONS` | union; toast: "Please select a Markdown or HTML file (.md, .markdown, .html, .htm)" |
-| `file-loading.js` `handleUrl` | pass `Content-Type` into `detectKind`; 8 MB cap **HTML only** |
+| `file-loading.js` `handleUrl` | extension-only (`.html`/`.htm`); **no** Content-Type sniff; 8 MB cap **HTML only** |
 | `index.html` `#file-input accept` | `.md,.markdown,.html,.htm` |
 | `index.html` CSP | add `frame-src 'self' blob: file: specdown:` |
+| `index.html` landing / hero / pillars | **unchanged** in Session 01 (no “Markdown or HTML” launch) |
 | `desktop/main.js` `VALID_EXTENSIONS` + `isValidMarkdownFile` | rename to `isOpenableDocument` and use it for open, drop, **session restore**, and **workspace scan** |
 | Open dialog filters | Markdown; HTML (`html`, `htm`); All files |
 | Dialog title | "Open File" |
-| `package.json` `build.fileAssociations` | add HTML (`html`, `htm`, `mimeType: text/html`, role Viewer) |
+| `package.json` `build.fileAssociations` | **Session 04** — do not claim the OS HTML handler in Session 01 |
 | `scanWorkspace` + web folder walk | Session 01: list HTML. Empty copy: "No Markdown or HTML files found." Relative link following stays Session 03 |
 | `workspace.js` `MARKDOWN_LINK_RE` | Session 03: `/\.(md\|markdown\|html\|htm)$/i` |
 | `repo-browser.js` | Session 03: include HTML in the GitHub search |
 | `normalizeMarkdownUrl` | still correct for GitHub blob HTML (`blob` → `raw` works for any path) |
-| `manifest.webmanifest` `file_handlers` | add `text/html`: [`.html`, `.htm`] |
-| `ios/project.yml` | import `public.html`; add a document type for HTML |
+| `manifest.webmanifest` `file_handlers` | **Session 04** (same reason as `fileAssociations`) |
+| `ios/project.yml` | import `public.html`; add a document type for HTML (picker, not “default app”) |
 | `WebBridge.swift` picker | append `.html` (`UTType.html`) |
-| Landing copy | "Markdown or HTML" (see brainstorm §3.2) |
-| PWA / README | mention HTML as an accepted input, not a new product |
+| Landing / README / PWA | no lede or sample-button change in Session 01 |
 
 Desktop `file-opened` IPC payload stays `{ path, content, filename }`
 (or whatever it is today). Renderer detects kind from filename.
@@ -390,8 +389,9 @@ Add `markdown-viewer/samples/html-showcase.html`:
 - A visible line that it is a SpecDown sample (footer)
 - No network requests (the sample must work offline / in the PWA)
 
-Wire a second landing / iOS sample button. Do not replace the
-Mermaid showcase.
+QA-only; do not wire a landing or iOS sample button in
+Session 01. Allow-list the filename if a later session adds a
+button. Do not replace the Mermaid showcase.
 
 ---
 
@@ -403,8 +403,8 @@ Mermaid showcase.
   strips iframe/refresh/`<base target>`/`javascript:` hrefs, does
   not include `allow-same-origin` in the stage iframe markup
 - File-loading: HTML file creates `kind: 'html'`; `marked.parse`
-  not called (spy); `handleUrl` uses `Content-Type` when the path
-  has no extension; 8 MB cap does not reject markdown
+  not called (spy); `handleUrl` on an extensionless URL stays
+  markdown; 8 MB cap does not reject markdown
 - Production CSP string includes `frame-src` + `blob` and does not
   put `blob:` on `script-src`
 - Existing markdown tests stay green (kind defaults / markdown path
@@ -454,9 +454,14 @@ Mermaid showcase.
    (manual + sandbox attribute test).
 5. Lint, typecheck, and Jest are clean.
 6. iOS picker can choose an HTML file (types registered). iOS
-   sheet hides Print / Comments / Annotate / Present on HTML tabs.
-7. No new toolbar button.
+   sheet hides Print / Comments / Annotate / Present / Contents
+   on HTML tabs. No new iOS sample button.
+7. No new toolbar button. No landing/hero/pillar copy change.
+   No PWA or OS HTML file-handler registration.
 8. Parent CSP allows the blob iframe; a dropped HTML file is
    visible, not a blank stage.
 9. Closing the last HTML tab does not leave a live iframe under
    the landing.
+10. `performPrint()`, Find, and TOC do not run against an HTML
+    tab (no leftover markdown outline, no `window.print()`
+    fallback). `⌘F` / `⌘P` are gated.

--- a/docs/project-html/2026-08-23-tasks-session-01-kind-and-open.md
+++ b/docs/project-html/2026-08-23-tasks-session-01-kind-and-open.md
@@ -1,0 +1,114 @@
+# Session 01 — Document kind, open gates, sandboxed HTML preview
+
+**Date:** 2026-08-23
+**Status:** Ready to implement
+**Spec:** [spec-html-v1](2026-08-23-spec-html-v1.md)
+**Brainstorm:** [brainstorm-html-documents](2026-08-23-brainstorm-html-documents.md)
+
+## Goal
+
+Land the **runtime fork's skeleton** in one PR: SpecDown can open
+`.html` / `.htm` on every ingress, preview the page in a sandboxed
+iframe (document scripts never run in the app origin), and still
+render markdown exactly as today.
+
+Out of this session: TOC/Find/Print-for-HTML, workspace scan,
+asset protocol, Safe mode, Mermaid-in-HTML, annotations, repo
+browser HTML search.
+
+## Preconditions
+
+- Read the spec §2–4 and §6 security checklist before touching
+  the render path.
+- Unique top-level names (`htmlDetectKind`, `htmlRewriteDocument`,
+  `htmlMountFrame`, …) — the eval harness collides on `let`/`const`.
+- Do not assign raw file bytes to parent `innerHTML`.
+- Do not put `allow-same-origin` on the host iframe.
+
+## Tasks
+
+### 1. Kind module
+
+- [ ] Add `markdown-viewer/src/core/document-kind.js` (`// @ts-check`)
+      with `detectKind(filename)`, `OPENABLE_EXTENSIONS`,
+      `documentCapabilities(kind)`.
+- [ ] JSDoc: `/** @typedef {'markdown' | 'html'} DocumentKind */`
+- [ ] Unit tests: extensions (case), unknown → `null`, capabilities
+      hide `present` / `annotate` / `authoredComments` for `html`.
+
+### 2. Tab + dispatch
+
+- [ ] Add `kind` to the `Tab` typedef in `core/state.js`.
+- [ ] `createTab` / tab restore sets `kind` from `detectKind`.
+- [ ] `renderDocument` dispatches; markdown path unchanged.
+- [ ] HTML path does **not** call `marked.parse` (test with a spy).
+
+### 3. Stage + rewrite + host
+
+- [ ] Stage markup: `#document-stage` wrapping `#markdown-content`
+      + `#html-frame` (`sandbox="allow-scripts"`, no same-origin).
+- [ ] `features/html-host.js` — `specdown-ready` + external-link
+      intercept (see spec §3.5).
+- [ ] `features/html-document.js` — rewrite (CSP, inline host,
+      strip nested frames / meta-refresh), blob URL mount, revoke
+      on re-render and tab close, 8 MB cap.
+- [ ] CSS: iframe fills the content pane; no prose max-width; no
+      whole-file format of `styles.css`.
+- [ ] Test: rewritten HTML contains the CSP meta; stage iframe
+      attribute has `allow-scripts` and not `allow-same-origin`.
+
+### 4. Open gates (all surfaces)
+
+- [ ] `file-loading.js` — union extensions + toast copy.
+- [ ] `index.html` — `accept=".md,.markdown,.html,.htm"`.
+- [ ] `desktop/main.js` — `isOpenableDocument`; dialog filters
+      Markdown / HTML / All; title "Open File". Keep the
+      `artifactName` space regression test green.
+- [ ] `manifest.webmanifest` — `file_handlers` for `text/html`.
+- [ ] `ios/project.yml` — HTML document type + `public.html`.
+- [ ] `WebBridge.swift` — picker includes `UTType.html`.
+- [ ] Landing drop-card copy: "Markdown or HTML" (no new hero).
+
+### 5. Raw / split
+
+- [ ] Raw view shows author source for HTML tabs.
+- [ ] Split shows source | iframe (not source | marked output).
+- [ ] Toolbar: hide Present / Annotate / Comments on HTML via
+      `documentCapabilities` (iOS sheet too if those actions are
+      listed — do not add new sheet rows this session).
+
+### 6. Sample
+
+- [ ] `markdown-viewer/samples/html-showcase.html` — self-contained,
+      designed, headings, no network.
+- [ ] Landing + iOS sample button (second button, Mermaid stays
+      primary). Allow-list the filename in `landing.js`.
+
+### 7. Quality gates
+
+- [ ] `npm test` green.
+- [ ] `npm run lint` zero warnings.
+- [ ] `npm run typecheck` clean.
+- [ ] Prettier only on files this session touches.
+
+## Manual smoke (after gates)
+
+1. `npm run preview` (or `dev`): drop the sample HTML — designed
+   page, not markdown. Toggle Raw. Open a `.md` in another tab;
+   switch back.
+2. Drop a `.txt` — still rejected.
+3. In the HTML page console (iframe), `window.parent.specdown` is
+   not readable (opaque / sandbox).
+4. Desktop if a display exists: File > Open a `.html`; Live chip
+   still appears for a path-backed file (reload can wait for a
+   visual check).
+5. Confirm print was **not** wired to `window.print()` on the
+   shell for HTML (Print may no-op or stay markdown-only this
+   session — do not regress markdown print).
+
+## Done when
+
+- HTML opens on web + desktop + iOS picker types.
+- Markdown regression is zero.
+- Security checklist in the spec is all checked for this PR.
+- One commit, one PR.

--- a/docs/project-html/2026-08-23-tasks-session-01-kind-and-open.md
+++ b/docs/project-html/2026-08-23-tasks-session-01-kind-and-open.md
@@ -1,9 +1,10 @@
 # Session 01 — Document kind, open gates, sandboxed HTML preview
 
 **Date:** 2026-08-23
-**Status:** Ready to implement
+**Status:** Ready to implement (**council-amended**)
 **Spec:** [spec-html-v1](2026-08-23-spec-html-v1.md)
 **Brainstorm:** [brainstorm-html-documents](2026-08-23-brainstorm-html-documents.md)
+**Council:** [council-html-plan-review](2026-08-23-council-html-plan-review.md)
 
 ## Goal
 
@@ -12,46 +13,63 @@ Land the **runtime fork's skeleton** in one PR: SpecDown can open
 iframe (document scripts never run in the app origin), and still
 render markdown exactly as today.
 
-Out of this session: TOC/Find/Print-for-HTML, workspace scan,
-asset protocol, Safe mode, Mermaid-in-HTML, annotations, repo
-browser HTML search.
+Out of this session: TOC/Find/Print-for-HTML, workspace *link*
+following, asset protocol, Safe mode, Mermaid-in-HTML, annotations,
+repo browser HTML search. Workspace **listing** *is* in this
+session (council H2).
 
 ## Preconditions
 
-- Read the spec §2–4 and §6 security checklist before touching
+- Read the spec §2–6 and the council F1–F3 fatals before touching
   the render path.
 - Unique top-level names (`htmlDetectKind`, `htmlRewriteDocument`,
-  `htmlMountFrame`, …) — the eval harness collides on `let`/`const`.
+  `htmlMountFrame`, `htmlTeardownFrame`, `htmlHostInlineSource`, …)
+  — the eval harness collides on `let`/`const`.
+- `html-host.js` exports **only** a string. No host side effects
+  in the parent.
 - Do not assign raw file bytes to parent `innerHTML`.
 - Do not put `allow-same-origin` on the host iframe.
+- Do not call `performPrint()` on an HTML tab.
 
 ## Tasks
 
 ### 1. Kind module
 
 - [ ] Add `markdown-viewer/src/core/document-kind.js` (`// @ts-check`)
-      with `detectKind(filename)`, `OPENABLE_EXTENSIONS`,
+      with `detectKind(filename, contentType?)`, `OPENABLE_EXTENSIONS`,
       `documentCapabilities(kind)`.
 - [ ] JSDoc: `/** @typedef {'markdown' | 'html'} DocumentKind */`
-- [ ] Unit tests: extensions (case), unknown → `null`, capabilities
-      hide `present` / `annotate` / `authoredComments` for `html`.
+- [ ] Session 01 HTML capabilities: `preview`, `raw`, `split`,
+      `liveReload`, `fileInfo` only. Print / Find / TOC / Present /
+      Annotate / Comments are **false**.
+- [ ] Unit tests: extensions (case), unknown → `null`, Content-Type
+      fallback, capabilities hide the Session 02+ set.
 
-### 2. Tab + dispatch
+### 2. Tab + dispatch + lifecycle
 
 - [ ] Add `kind` to the `Tab` typedef in `core/state.js`.
 - [ ] `createTab` / tab restore sets `kind` from `detectKind`.
 - [ ] `renderDocument` dispatches; markdown path unchanged.
 - [ ] HTML path does **not** call `marked.parse` (test with a spy).
+- [ ] `htmlTeardownFrame()` from `showDropZone`, last-HTML-tab
+      close, and before remount. One iframe, many tabs: activate
+      remounts from `tab.rawMarkdown`.
 
-### 3. Stage + rewrite + host
+### 3. Stage + rewrite + host + CSP
 
 - [ ] Stage markup: `#document-stage` wrapping `#markdown-content`
-      + `#html-frame` (`sandbox="allow-scripts"`, no same-origin).
-- [ ] `features/html-host.js` — `specdown-ready` + external-link
-      intercept (see spec §3.5).
+      + `#html-frame` (`sandbox="allow-scripts"`, `allow=""`, no
+      same-origin).
+- [ ] `features/html-host.js` — string export only;
+      `specdown-ready` + external-link intercept (spec §3.5).
 - [ ] `features/html-document.js` — rewrite (CSP, inline host,
-      strip nested frames / meta-refresh), blob URL mount, revoke
-      on re-render and tab close, 8 MB cap.
+      strip nested frames / meta-refresh / `<base target>` /
+      `javascript:` and `data:text/html` hrefs), blob URL mount,
+      revoke, 8 MB cap **on HTML only**, navigation lock (reset
+      if `src` leaves our blob).
+- [ ] `index.html` CSP: add `frame-src 'self' blob: file: specdown:`.
+      Do not add `blob:` to `script-src`. Test the production
+      string.
 - [ ] CSS: iframe fills the content pane; no prose max-width; no
       whole-file format of `styles.css`.
 - [ ] Test: rewritten HTML contains the CSP meta; stage iframe
@@ -59,23 +77,34 @@ browser HTML search.
 
 ### 4. Open gates (all surfaces)
 
-- [ ] `file-loading.js` — union extensions + toast copy.
-- [ ] `index.html` — `accept=".md,.markdown,.html,.htm"`.
-- [ ] `desktop/main.js` — `isOpenableDocument`; dialog filters
-      Markdown / HTML / All; title "Open File". Keep the
-      `artifactName` space regression test green.
+- [ ] `file-loading.js` — union extensions + toast copy;
+      `handleUrl` passes `Content-Type` into `detectKind`.
+- [ ] `index.html` — `accept=".md,.markdown,.html,.htm"`; drop-card
+      "Markdown or HTML" (no new hero).
+- [ ] `desktop/main.js` — `isOpenableDocument` for open, drop,
+      **session restore**, **workspace scan**; dialog filters
+      Markdown / HTML / All; title "Open File";
+      `will-frame-navigate` denies in-frame http(s) (`openExternal`).
+      Keep the `artifactName` space regression test green.
+- [ ] `package.json` `build.fileAssociations` — HTML entry
+      (`html`, `htm`, `text/html`).
+- [ ] Web `workspace.js` walk lists HTML; empty copy mentions
+      Markdown or HTML. Relative link following can wait.
 - [ ] `manifest.webmanifest` — `file_handlers` for `text/html`.
 - [ ] `ios/project.yml` — HTML document type + `public.html`.
 - [ ] `WebBridge.swift` — picker includes `UTType.html`.
-- [ ] Landing drop-card copy: "Markdown or HTML" (no new hero).
 
-### 5. Raw / split
+### 5. Raw / split / honest chrome
 
 - [ ] Raw view shows author source for HTML tabs.
 - [ ] Split shows source | iframe (not source | marked output).
-- [ ] Toolbar: hide Present / Annotate / Comments on HTML via
-      `documentCapabilities` (iOS sheet too if those actions are
-      listed — do not add new sheet rows this session).
+      If split is not actually wired this session, set
+      `split: false` in capabilities instead of shipping a lie.
+- [ ] Toolbar, overflow, **palette**, and **iOS sheet** hide
+      Print / Find / Contents / Present / Annotate / Comments on
+      HTML via `documentCapabilities` (`syncIOSChrome` included).
+- [ ] Cmd+P / File > Print / `#print-button` / `#ios-print-button`
+      must not call `performPrint()` on HTML (toast if reached).
 
 ### 6. Sample
 
@@ -94,21 +123,27 @@ browser HTML search.
 ## Manual smoke (after gates)
 
 1. `npm run preview` (or `dev`): drop the sample HTML — designed
-   page, not markdown. Toggle Raw. Open a `.md` in another tab;
-   switch back.
-2. Drop a `.txt` — still rejected.
+   page, not a blank frame (CSP `frame-src` works) and not
+   markdown. Toggle Raw. Open a `.md` in another tab; switch
+   back. Close the last tab — landing, no leftover iframe.
+2. Drop a `.txt` — still rejected. Drop a large `.md` — still
+   opens (cap is HTML-only).
 3. In the HTML page console (iframe), `window.parent.specdown` is
    not readable (opaque / sandbox).
-4. Desktop if a display exists: File > Open a `.html`; Live chip
-   still appears for a path-backed file (reload can wait for a
-   visual check).
-5. Confirm print was **not** wired to `window.print()` on the
-   shell for HTML (Print may no-op or stay markdown-only this
-   session — do not regress markdown print).
+4. Print / Find / Contents / Annotate / Comments / Present are
+   not offered on the HTML tab (desktop toolbar + iOS sheet +
+   palette). Markdown print still works.
+5. Desktop if a display exists: File > Open a `.html`; session
+   restore after relaunch; Open Folder lists HTML; Live chip on
+   a path-backed file. A link inside the HTML that points at
+   `https://…` opens in the system browser, not in the iframe.
+6. Confirm markdown `performPrint()` was not regresssed.
 
 ## Done when
 
-- HTML opens on web + desktop + iOS picker types.
+- HTML opens on web + desktop + iOS picker types and is *visible*
+  (CSP does not blank the stage).
 - Markdown regression is zero.
 - Security checklist in the spec is all checked for this PR.
+- Chrome is honest (no Print-on-empty-content).
 - One commit, one PR.

--- a/docs/project-html/2026-08-23-tasks-session-01-kind-and-open.md
+++ b/docs/project-html/2026-08-23-tasks-session-01-kind-and-open.md
@@ -30,6 +30,9 @@ session (council H2).
 - Do not assign raw file bytes to parent `innerHTML`.
 - Do not put `allow-same-origin` on the host iframe.
 - Do not call `performPrint()` on an HTML tab.
+- Drops use `getPathForFile` only (no `file.path`).
+- `renderDocument` takes the tab (or explicit `kind`). Do not
+  re-detect at render time.
 
 ## Tasks
 
@@ -48,12 +51,18 @@ session (council H2).
 ### 2. Tab + dispatch + lifecycle
 
 - [ ] Add `kind` to the `Tab` typedef in `core/state.js`.
-- [ ] `createTab` / tab restore sets `kind` from `detectKind`.
+- [ ] `createTab` / tab restore / `window.loadFileContent` set
+      `kind` from `detectKind`.
 - [ ] `renderDocument` dispatches; markdown path unchanged.
+      Wire **all** DI sites: `configureTabs`, `configureDesktop`
+      (live reload), `configureViewMode`. Keep the
+      `renderMarkdown` wrapper for existing tests.
 - [ ] HTML path does **not** call `marked.parse` (test with a spy).
-- [ ] `htmlTeardownFrame()` from `showDropZone`, last-HTML-tab
-      close, and before remount. One iframe, many tabs: activate
-      remounts from `tab.rawMarkdown`.
+- [ ] Stage apply on create / switch / close / raw / empty:
+      hide iframe on markdown, raw, and drop-zone; remount blob
+      on HTML activate; revoke on switch-away and close.
+- [ ] Desktop `refresh-file` + session restore + recents use
+      `isOpenableDocument`.
 
 ### 3. Stage + rewrite + host + CSP
 
@@ -66,14 +75,17 @@ session (council H2).
 - [ ] `features/html-document.js` — rewrite (CSP, inline host,
       strip nested frames / meta-refresh / `<base target>` /
       `javascript:` and `data:text/html` hrefs), blob URL mount,
-      revoke, 8 MB cap **on HTML only**, navigation lock (reset
-      if `src` leaves our blob).
+      revoke, navigation lock (reset if `src` leaves our blob).
+- [ ] 8 MB cap **on HTML only, at read** (`handleFile` /
+      `openFileByPath` / iOS `openDocument`) — not at rewrite.
 - [ ] `index.html` CSP: add `frame-src 'self' blob: file: specdown:`.
-      Do not add `blob:` to `script-src`. Test the production
-      string.
+      Do not add `blob:` to `script-src`. **Static grep** of
+      `index.html` (jsdom `loadApp` copies `<body>` only).
 - [ ] CSS: iframe fills the stage (zero SpecDown padding); split
-      targets `#document-stage`, not `.markdown-content`; no
-      whole-file format of `styles.css`.
+      targets `#document-stage`, not `.markdown-content`;
+      `@media print` reset for `#document-stage` (markdown
+      fallback must not clip); no whole-file format of
+      `styles.css`.
 - [ ] Lone-file toast if rewrite sees relative URLs and there is
       no `baseHref` (sample may suppress).
 - [ ] Test: rewritten HTML contains the CSP meta; stage iframe
@@ -94,9 +106,17 @@ session (council H2).
       `manifest.webmanifest` `file_handlers` (Session 04).
 - [ ] Web `workspace.js` walk lists HTML; empty copy mentions
       Markdown or HTML. Relative link following can wait.
-- [ ] `ios/project.yml` — HTML document type + `public.html`.
+- [ ] `ios/project.yml` — add `public.html` to
+      `LSItemContentTypes` only (do **not** redeclare under
+      `UTImportedTypeDeclarations`). Rank Alternate.
 - [ ] `WebBridge.swift` — picker includes `UTType.html`.
       No iOS sample button.
+- [ ] iPad `ContentView.swift` — label “Open File” is enough;
+      do not add a third sidebar sample.
+- [ ] Update inverted tests in the same PR:
+      `desktop-main.test.js` (`.html` now openable),
+      file-loading toast copy. Landing copy tests stay
+      unchanged. Do not test iframe `load` in jsdom.
 
 ### 5. Raw / split / honest chrome
 

--- a/docs/project-html/2026-08-23-tasks-session-01-kind-and-open.md
+++ b/docs/project-html/2026-08-23-tasks-session-01-kind-and-open.md
@@ -36,14 +36,14 @@ session (council H2).
 ### 1. Kind module
 
 - [ ] Add `markdown-viewer/src/core/document-kind.js` (`// @ts-check`)
-      with `detectKind(filename, contentType?)`, `OPENABLE_EXTENSIONS`,
+      with `detectKind(filename)`, `OPENABLE_EXTENSIONS`,
       `documentCapabilities(kind)`.
 - [ ] JSDoc: `/** @typedef {'markdown' | 'html'} DocumentKind */`
 - [ ] Session 01 HTML capabilities: `preview`, `raw`, `split`,
       `liveReload`, `fileInfo` only. Print / Find / TOC / Present /
       Annotate / Comments are **false**.
-- [ ] Unit tests: extensions (case), unknown → `null`, Content-Type
-      fallback, capabilities hide the Session 02+ set.
+- [ ] Unit tests: extensions (case), unknown → `null`, capabilities
+      hide the Session 02+ set. No Content-Type sniff.
 
 ### 2. Tab + dispatch + lifecycle
 
@@ -57,9 +57,10 @@ session (council H2).
 
 ### 3. Stage + rewrite + host + CSP
 
-- [ ] Stage markup: `#document-stage` wrapping `#markdown-content`
-      + `#html-frame` (`sandbox="allow-scripts"`, `allow=""`, no
-      same-origin).
+- [ ] Stage markup: `#document-stage` as the `#content-main`
+      preview flex child; `#markdown-content` and `#html-frame`
+      are **siblings** (`sandbox="allow-scripts"`, `allow=""`, no
+      same-origin). Do not nest the iframe in `.markdown-content`.
 - [ ] `features/html-host.js` — string export only;
       `specdown-ready` + external-link intercept (spec §3.5).
 - [ ] `features/html-document.js` — rewrite (CSP, inline host,
@@ -70,48 +71,55 @@ session (council H2).
 - [ ] `index.html` CSP: add `frame-src 'self' blob: file: specdown:`.
       Do not add `blob:` to `script-src`. Test the production
       string.
-- [ ] CSS: iframe fills the content pane; no prose max-width; no
+- [ ] CSS: iframe fills the stage (zero SpecDown padding); split
+      targets `#document-stage`, not `.markdown-content`; no
       whole-file format of `styles.css`.
+- [ ] Lone-file toast if rewrite sees relative URLs and there is
+      no `baseHref` (sample may suppress).
 - [ ] Test: rewritten HTML contains the CSP meta; stage iframe
       attribute has `allow-scripts` and not `allow-same-origin`.
 
 ### 4. Open gates (all surfaces)
 
 - [ ] `file-loading.js` — union extensions + toast copy;
-      `handleUrl` passes `Content-Type` into `detectKind`.
-- [ ] `index.html` — `accept=".md,.markdown,.html,.htm"`; drop-card
-      "Markdown or HTML" (no new hero).
+      `handleUrl` is **extension-only** (no Content-Type sniff).
+- [ ] `index.html` — `accept=".md,.markdown,.html,.htm"` only.
+      **No** drop-card / hero / pillar copy change.
 - [ ] `desktop/main.js` — `isOpenableDocument` for open, drop,
       **session restore**, **workspace scan**; dialog filters
       Markdown / HTML / All; title "Open File";
       `will-frame-navigate` denies in-frame http(s) (`openExternal`).
       Keep the `artifactName` space regression test green.
-- [ ] `package.json` `build.fileAssociations` — HTML entry
-      (`html`, `htm`, `text/html`).
+- [ ] **Do not** change `package.json` `fileAssociations` or
+      `manifest.webmanifest` `file_handlers` (Session 04).
 - [ ] Web `workspace.js` walk lists HTML; empty copy mentions
       Markdown or HTML. Relative link following can wait.
-- [ ] `manifest.webmanifest` — `file_handlers` for `text/html`.
 - [ ] `ios/project.yml` — HTML document type + `public.html`.
 - [ ] `WebBridge.swift` — picker includes `UTType.html`.
+      No iOS sample button.
 
 ### 5. Raw / split / honest chrome
 
-- [ ] Raw view shows author source for HTML tabs.
-- [ ] Split shows source | iframe (not source | marked output).
-      If split is not actually wired this session, set
-      `split: false` in capabilities instead of shipping a lie.
-- [ ] Toolbar, overflow, **palette**, and **iOS sheet** hide
-      Print / Find / Contents / Present / Annotate / Comments on
-      HTML via `documentCapabilities` (`syncIOSChrome` included).
-- [ ] Cmd+P / File > Print / `#print-button` / `#ios-print-button`
-      must not call `performPrint()` on HTML (toast if reached).
+- [ ] Raw view shows author source; **hide `#html-frame`** in raw.
+- [ ] Split shows source | iframe. CSS must size the **stage**.
+      If not actually wired, set `split: false` instead of a lie.
+- [ ] `documentCapabilities` gates toolbar, overflow, **palette
+      `isAvailable`**, **iOS sheet**, and **`⌘F` / `⌘P`**.
+- [ ] On HTML render / tab switch: empty `#markdown-content`,
+      `tocEntries = []`, close TOC, close search, annotate
+      **off**, `refreshCommentsUI()`.
+- [ ] `performPrint()` returns immediately on HTML (no
+      `window.print()` fallback). Unit test: HTML tab does not
+      clone `#markdown-content` into the print path.
+- [ ] Host key-forward for ⌘K / ⌘F / ⌘P / `?` / Esc, **or**
+      document that chrome shortcuts need focus on the filename.
+- [ ] Skip link still reaches the stage; iframe `title` = filename.
 
 ### 6. Sample
 
 - [ ] `markdown-viewer/samples/html-showcase.html` — self-contained,
-      designed, headings, no network.
-- [ ] Landing + iOS sample button (second button, Mermaid stays
-      primary). Allow-list the filename in `landing.js`.
+      designed, headings, no network. **QA-only** — no landing or
+      iOS button in this session.
 
 ### 7. Quality gates
 

--- a/docs/project-html/2026-08-23-tasks-session-01-kind-and-open.md
+++ b/docs/project-html/2026-08-23-tasks-session-01-kind-and-open.md
@@ -1,17 +1,23 @@
 # Session 01 — Document kind, open gates, sandboxed HTML preview
 
-**Date:** 2026-08-23
-**Status:** Ready to implement (**council-amended**)
-**Spec:** [spec-html-v1](2026-08-23-spec-html-v1.md)
+**Date:** 2026-08-23 (staging rail: 2026-08-25)
+**Status:** Ready to implement (**council-amended**) — **after
+Session 00**. Base branch **`html`**, not `main`.
+**Spec:** [spec-html-v1](2026-08-23-spec-html-v1.md) ·
+[staging](2026-08-25-spec-html-staging.md)
 **Brainstorm:** [brainstorm-html-documents](2026-08-23-brainstorm-html-documents.md)
 **Council:** [council-html-plan-review](2026-08-23-council-html-plan-review.md)
+**Previous:** [Session 00](2026-08-25-tasks-session-00-staging-rail.md)
 
 ## Goal
 
-Land the **runtime fork's skeleton** in one PR: SpecDown can open
-`.html` / `.htm` on every ingress, preview the page in a sandboxed
-iframe (document scripts never run in the app origin), and still
-render markdown exactly as today.
+Land the **runtime fork's skeleton** in one PR **on `html`**:
+SpecDown (HTML-on build) can open `.html` / `.htm` on every
+ingress, preview the page in a sandboxed iframe (document
+scripts never run in the app origin), and still render markdown
+exactly as today. This PR must **not** merge to `main` (that
+would ship a Release). Dogfood with `npm run dev:html` /
+`preview:html` / `desktop:html`.
 
 Out of this session: TOC/Find/Print-for-HTML, workspace *link*
 following, asset protocol, Safe mode, Mermaid-in-HTML, annotations,
@@ -20,6 +26,13 @@ session (council H2).
 
 ## Preconditions
 
+- [Session 00](2026-08-25-tasks-session-00-staging-rail.md) is on
+  `main` and branch `html` exists. This PR’s base is `html`.
+- Build/test HTML-on: `VITE_HTML_DOCUMENTS` / `npm run dev:html`.
+  Keep a flag-**off** CI job green (markdown gates + CSP source
+  unchanged on that job — if this session changes source
+  `index.html` CSP, the transform must still leave flag-off
+  builds without `frame-src`, per the staging spec).
 - Read the spec §2–6 and the council F1–F3 fatals before touching
   the render path.
 - Unique top-level names (`htmlDetectKind`, `htmlRewriteDocument`,
@@ -80,9 +93,15 @@ session (council H2).
       `src` leaves the host URL).
 - [ ] 8 MB cap **on HTML only, at read** (`handleFile` /
       `openFileByPath` / iOS `openDocument`; `stat` first).
-- [ ] `index.html` CSP: add `frame-src 'self' file: specdown:`.
-      Do **not** add `blob:` or `'unsafe-inline'` to parent
-      `script-src`. **Static grep** of `index.html`.
+- [ ] Parent CSP: HTML-on **builds** add
+      `frame-src 'self' file: specdown:` (Vite transform or
+      equivalent). Do **not** add `blob:` or `'unsafe-inline'`
+      to parent `script-src`. Source `index.html` on a flag-off
+      grep still has **no** `frame-src` until the production
+      flip — test both the source file and the HTML-on `dist`
+      CSP. `#document-stage` may exist on this branch (layout
+      is not flag-gated); markdown Print golden path is
+      mandatory.
 - [ ] iOS: reject `WKScriptMessage` unless
       `frameInfo.isMainFrame`. Cancel iframe navigations.
 - [ ] CSS: iframe fills the stage (zero SpecDown padding); split
@@ -147,14 +166,19 @@ session (council H2).
 
 ### 7. Quality gates
 
-- [ ] `npm test` green.
+- [ ] `npm test` green (flag-off **and** HTML-on, once CI
+      matrix exists).
 - [ ] `npm run lint` zero warnings.
 - [ ] `npm run typecheck` clean.
 - [ ] Prettier only on files this session touches.
 
 ## Manual smoke (after gates)
 
-1. `npm run preview` (or `dev`): drop the sample HTML — designed
+Run **`preview:html` / `dev:html` / `desktop:html`**, not the
+flag-off scripts (those must still reject `.html`). Also run the
+staging spec’s **markdown golden path** on the same SHA.
+
+1. `npm run preview:html` (or `dev:html`): drop the sample HTML — designed
    page via the **preview host** (not a blank frame, not
    markdown). Toggle Raw. Open a `.md` in another tab; switch
    back. Close the last tab — landing, no leftover iframe.
@@ -173,9 +197,10 @@ session (council H2).
 
 ## Done when
 
-- HTML opens on web + desktop + iOS picker types and is *visible*
-  (CSP does not blank the stage).
-- Markdown regression is zero.
+- HTML opens on web + desktop + iOS picker types **in the HTML-on
+  build** and is *visible* (CSP does not blank the stage).
+- Flag-off build still rejects `.html`; markdown golden path is
+  green (including Print not clipped).
 - Security checklist in the spec is all checked for this PR.
 - Chrome is honest (no Print-on-empty-content).
-- One commit, one PR.
+- One commit, one PR, into **`html`**. Not `main`.

--- a/docs/project-html/2026-08-23-tasks-session-01-kind-and-open.md
+++ b/docs/project-html/2026-08-23-tasks-session-01-kind-and-open.md
@@ -59,8 +59,8 @@ session (council H2).
       `renderMarkdown` wrapper for existing tests.
 - [ ] HTML path does **not** call `marked.parse` (test with a spy).
 - [ ] Stage apply on create / switch / close / raw / empty:
-      hide iframe on markdown, raw, and drop-zone; remount blob
-      on HTML activate; revoke on switch-away and close.
+      hide iframe on markdown, raw, and drop-zone; reload the
+      **preview host** then `specdown-load` on HTML activate.
 - [ ] Desktop `refresh-file` + session restore + recents use
       `isOpenableDocument`.
 
@@ -70,17 +70,21 @@ session (council H2).
       preview flex child; `#markdown-content` and `#html-frame`
       are **siblings** (`sandbox="allow-scripts"`, `allow=""`, no
       same-origin). Do not nest the iframe in `.markdown-content`.
-- [ ] `features/html-host.js` — string export only;
-      `specdown-ready` + external-link intercept (spec §3.5).
-- [ ] `features/html-document.js` — rewrite (CSP, inline host,
-      strip nested frames / meta-refresh / `<base target>` /
-      `javascript:` and `data:text/html` hrefs), blob URL mount,
-      revoke, navigation lock (reset if `src` leaves our blob).
+- [ ] Bundled `markdown-viewer/html-preview-host.html` — own CSP
+      (Faithful `'unsafe-inline' https:`), host script as that
+      page’s `'self'`. `#html-frame.src` is this URL, **not**
+      a blob or srcdoc.
+- [ ] `features/html-document.js` — rewrite (strip author CSP /
+      `<base>` / nested frames / executable hrefs),
+      `postMessage` `specdown-load`, navigation lock (reset if
+      `src` leaves the host URL).
 - [ ] 8 MB cap **on HTML only, at read** (`handleFile` /
-      `openFileByPath` / iOS `openDocument`) — not at rewrite.
-- [ ] `index.html` CSP: add `frame-src 'self' blob: file: specdown:`.
-      Do not add `blob:` to `script-src`. **Static grep** of
-      `index.html` (jsdom `loadApp` copies `<body>` only).
+      `openFileByPath` / iOS `openDocument`; `stat` first).
+- [ ] `index.html` CSP: add `frame-src 'self' file: specdown:`.
+      Do **not** add `blob:` or `'unsafe-inline'` to parent
+      `script-src`. **Static grep** of `index.html`.
+- [ ] iOS: reject `WKScriptMessage` unless
+      `frameInfo.isMainFrame`. Cancel iframe navigations.
 - [ ] CSS: iframe fills the stage (zero SpecDown padding); split
       targets `#document-stage`, not `.markdown-content`;
       `@media print` reset for `#document-stage` (markdown
@@ -151,8 +155,8 @@ session (council H2).
 ## Manual smoke (after gates)
 
 1. `npm run preview` (or `dev`): drop the sample HTML — designed
-   page, not a blank frame (CSP `frame-src` works) and not
-   markdown. Toggle Raw. Open a `.md` in another tab; switch
+   page via the **preview host** (not a blank frame, not
+   markdown). Toggle Raw. Open a `.md` in another tab; switch
    back. Close the last tab — landing, no leftover iframe.
 2. Drop a `.txt` — still rejected. Drop a large `.md` — still
    opens (cap is HTML-only).

--- a/docs/project-html/2026-08-25-spec-html-staging.md
+++ b/docs/project-html/2026-08-25-spec-html-staging.md
@@ -1,0 +1,307 @@
+# Spec: HTML staging rail
+
+**Date:** 2026-08-25
+**Status:** Specified (process + isolation contract; no product
+code in this file)
+**Companion:** [brainstorm](2026-08-23-brainstorm-html-documents.md) ·
+[spec v1](2026-08-23-spec-html-v1.md) ·
+[council](2026-08-23-council-html-plan-review.md) ·
+[Session 00](2026-08-25-tasks-session-00-staging-rail.md)
+
+HTML work shares `markdown-viewer/` with the shipped markdown
+app. A merge to `main` is not a preview: it is a **release**.
+This spec is how we try HTML without giving that release to
+everyone.
+
+Session 01 does **not** start until Session 00 has landed on
+`main` and the `html` integration branch exists.
+
+---
+
+## 1. Why this exists
+
+Today, anything that reaches `main` does all four:
+
+1. **Version bump** (patch) on `main`
+2. **Desktop** — signed DMG / Win / Linux on the GitHub Release,
+   including `latest*.yml` (auto-update)
+3. **Web** — GitHub Pages at
+   `https://cbremer.github.io/specdown/`
+4. **iOS** — the next source build picks up `markdown-viewer/`
+
+There is no staging URL, no feature flag, and no second Pages
+site. Session 01 as originally scheduled would have been a
+normal PR into `main`. That would ship a new content pane, a
+parent CSP change (`frame-src`), new open gates, and an iframe
+lifecycle into the app every current user already has.
+
+The council already said Session 01 is a skeleton, not a
+launch, and that Sessions 01–04 are one bet to **kill/pause**
+if the Session 02 desktop demo is not “local HTML + Live chip
++ print.” That demo must happen **off production**. This rail
+is that off-ramp.
+
+### What we are protecting
+
+| Surface | Failure if we are sloppy |
+|---|---|
+| Markdown drop / browse / URL / repo | HTML rewrite or `kind` dispatch runs `marked` wrong, or not at all |
+| Mermaid pan/zoom / Present | Stage CSS or `#document-stage` clips or steals events |
+| Print / PDF | New full-height ancestor + `frame-src` + iframe leftover (CLAUDE.md print gotcha) |
+| Parent CSP | Loosening `script-src` to make the preview work is XSS |
+| Desktop auto-update | A bad HTML build on the Release is what every DMG checks next |
+| PWA | A staging folder *under* `/specdown/` is in the production service worker’s scope |
+
+### Non-goals
+
+- A second product, rename, or landing rewrite
+- Playwright in Session 00 (Jest golden-path + manual smoke)
+- TestFlight / a staging DMG on the production update feed
+- Letting `?html=1` on the production origin turn the gates on
+  (that is a drive-by enable of the preview host)
+- Putting HTML staging at
+  `https://cbremer.github.io/specdown/html-staging/` — the PWA
+  service worker is registered at `./sw.js` and claims that
+  whole origin path
+
+---
+
+## 2. Three layers (all required)
+
+Git isolation without a flag still ships layout/CSP the moment
+someone merges early. A flag without git isolation still
+version-bumps six times while the wedge is half-done. A preview
+URL without either still tempts “just land it on Pages.”
+
+Use all three.
+
+### Layer A — Integration branch `html`
+
+- Create `html` from `main` **after** Session 00 merges.
+- Sessions 01–04 (and 05–06 if they happen) are PRs whose
+  **base is `html`**, not `main`.
+- `html` does **not** run version-bump, `desktop.yml`, or
+  production `static.yml`. Those stay `main`-only.
+- Rebase (or merge) `main` into `html` after every version-bump
+  on `main`, so the branch does not rot.
+- One logical change per PR still holds. Rebase-and-merge into
+  `html`. Do not squash a multi-commit session.
+- Feature branch names stay `cursor/…` / `claude/…`. Only the
+  **base** changes.
+
+Kill/pause (council): if Session 02’s staging demo fails, stop
+merging into `html` and do not open `html` → `main`.
+
+### Layer B — Compile-time flag `VITE_HTML_DOCUMENTS`
+
+Default **off**. Production `npm run build` (Pages + release
+desktop + iOS CI on `main`) does not set it.
+
+When **off**, the running app must behave as today’s markdown
+viewer:
+
+- Open gates stay `.md` / `.markdown` (and the current iOS
+  picker set). `.html` is still rejected.
+- No `#html-frame` in the DOM.
+- No `#document-stage` wrapper (do not re-parent markdown “just
+  in case” — that is how print clips).
+- Source `index.html` CSP on `main` stays as it is. `frame-src`
+  is a **build transform** on HTML-on builds only, until the
+  production flip.
+- `detectKind('x.html')` may exist as a pure function, but
+  ingress must not call it for acceptance until the flag is on.
+
+When **on** (staging builds and, later, the flip):
+
+- Session 01+ behavior from the HTML spec applies.
+- Parent CSP may gain `frame-src 'self' file: specdown:` only.
+  Still no `blob:` and no `'unsafe-inline'` on parent
+  `script-src`.
+
+**Vite mode:** `.env.html` contains `VITE_HTML_DOCUMENTS=true`.
+Scripts (Session 00):
+
+| Script | Meaning |
+|---|---|
+| `npm run dev` / `build` / `desktop` | Flag **off** — production-shaped |
+| `npm run dev:html` | `vite --mode html` |
+| `npm run build:html` | HTML-on `dist/` |
+| `npm run preview:html` | Serve that `dist/` (port 4179) |
+| `npm run desktop:html` | HTML-on renderer **and** `VITE_HTML_DOCUMENTS=true electron .` |
+
+Electron **main** is not Vite-bundled. The desktop script must
+export the env var into the main process so `isOpenableDocument`
+and the renderer cannot disagree (HTML UI + OS-open still
+rejecting `.html` is a staging lie).
+
+**Eval harness:** do not rely on a bare `import.meta.env` as the
+only signal — `loadApp.js` evals at global scope. Unique names
+(`htmlDocumentsEnabled`, `htmlDocumentsEnabledFlag`). Prefer a
+Vite `define` boolean literal plus a `process.env` check in
+`desktop/main.js`.
+
+**Layout is not behind the flag.** `#document-stage`, extra CSS, and
+a CSP transform can still break markdown Print/Present the moment
+they exist in the source you merge. The flag only keeps `.html`
+*rejected* on production-shaped builds. That is why Sessions 01–04
+stay on `html` until the golden path has been run **against that
+layout**, not only against `main` as it looks today.
+
+### Layer C — Staging surfaces (where humans actually try it)
+
+Daily loop (required):
+
+1. `npm run dev:html` — web, port 5179
+2. `npm run preview:html` — production-shaped HTML-on bundle
+3. `npm run desktop:html` — only where a display exists; **never**
+   `desktop:build` from this branch onto a `v*` tag
+
+CI (required in Session 00):
+
+- Push/PR to `html`: existing lint / typecheck / `test:ci`
+- **Matrix or second job:** flag off *and* flag on, once HTML
+  modules exist (Session 01). Session 00 only needs the helper
+  unit-tested both ways.
+- Upload `markdown-viewer/dist` from `build:html` as a workflow
+  artifact named `html-staging-web` (reviewers can unzip +
+  `npx serve`).
+
+Public HTTPS (optional, not a Session 00 blocker):
+
+- A **different origin**, e.g. a tiny `specdown-html` repo’s
+  GitHub Pages, or Cloudflare Pages on this repo.
+- Same-origin `/html-staging/` under production Pages is
+  **disallowed** (service worker scope).
+- If a public origin is added, it must noindex, must not
+  register as the PWA for the production start_url, and must
+  never publish `latest*.yml`.
+
+---
+
+## 3. Production vs staging
+
+| | `main` (shipped) | `html` (dogfood) | After go/no-go |
+|---|---|---|---|
+| Version bump / Release / auto-update | yes | **no** | one merge → one bump |
+| Pages `cbremer.github.io/specdown` | flag **off** | not this URL | flag **on** |
+| Open `.html` | reject | accept (flag-on build) | accept |
+| Landing / OG / README lede | unchanged | unchanged | still unchanged until copy is a deliberate PR |
+| `fileAssociations` / PWA HTML handler | unchanged | unchanged (Session 04) | Session 04, still not default-app |
+| Press B | embargoed | embargoed | still embargoed until Live + print on **production** |
+
+---
+
+## 4. Process
+
+### 4.1 Order of work
+
+```
+Session 00  ──PR→  main     rails only (flag, scripts, CI, docs)
+                 then: git branch html main && push
+
+Session 01–04  ──PR→  html   HTML runtime, still not a release
+
+Session 02 staging demo
+        │
+        ├─ fail → pause; do not merge to main
+        └─ pass → PR html → main (flag on in that build)
+                   still no landing launch, no OS HTML handler
+```
+
+Session 00 **may** merge to `main`. It must be behavior-neutral
+for users: same gates, same DOM, same CSP source, same Pages.
+
+### 4.2 Markdown golden path (every HTML PR)
+
+Automated (Jest; flag-off job must stay green):
+
+- Existing markdown / Mermaid / tabs / workspace / desktop
+  `artifactName` tests
+- Flag **off:** `.html` still rejected at ingress (file-loading +
+  `desktop/main.js`); `accept` attribute unchanged; no
+  `#html-frame`; source CSP string unchanged (static grep of
+  `markdown-viewer/index.html`, not `loadApp`)
+- Flag **on** (from Session 01): HTML tests from spec §8, **and**
+  the flag-off job still run on the same SHA
+
+Manual, on `preview:html` or `desktop:html`, before merging into
+`html`:
+
+1. Drop `diagram-showcase.md` (or equivalent) — Mermaid zoom,
+   Present, export
+2. Markdown Print/PDF — not clipped to the viewport
+3. Drop a `.txt` — still rejected
+4. Close last tab — landing, no leftover iframe
+5. Then the HTML checklist for that session
+
+Do not treat “HTML sample looks good” as the only smoke.
+
+### 4.3 Go / no-go (`html` → `main`)
+
+All of:
+
+- Session 02 desktop staging demo: local `.html` + Live chip +
+  print from inside the isolated frame
+- Flag-off CI green (markdown product still identical in that
+  job)
+- Flag-on CI green
+- Parent `script-src` still has no `'unsafe-inline'` and no
+  `blob:` on production-shaped HTML-on CSP
+- No `fileAssociations` / `file_handlers` HTML claim in that
+  merge
+- Rollback plan below is written in the merge PR body
+
+The merge is **one** PR into `main` (rebase if `html` is linear).
+That is the first HTML *release*. It is still not Press B and
+not a landing change.
+
+### 4.4 Rollback (after a production flip)
+
+Fast: set the production workflows to build **flag off**
+(`static.yml` / `desktop.yml` / iOS web copy) and ship that
+hotfix. Do not attach a flag-on artifact to the Release in
+between.
+
+Slower: revert the `html` → `main` merge. Prefer the flag off
+hotfix if the markdown path is fine and only HTML is on fire.
+
+Do **not** roll back by publishing a staging Electron build
+onto the existing tag. `artifactName` and `latest*.yml` stay
+production-only.
+
+### 4.5 What not to do
+
+- Merge Session 01 to `main` “behind a comment” or a
+  `localStorage` kill switch with the flag compiled on
+- `workflow_dispatch` `desktop.yml` against `html` and upload
+  to the current Release
+- Loosen parent CSP on `main` to “get ready”
+- Add `#document-stage` on the flag-off path
+- Use `--no-verify` or skip the flag-off test job
+
+---
+
+## 5. iOS
+
+No auto-update channel. Blast radius is source builds and CI.
+Still:
+
+- Session 01 iOS picker / UTI changes live on `html`, not
+  `main`
+- Session 00 may add `html` to `ios.yml` `push.branches` so the
+  simulator build runs there
+- Do not redeclare `public.html` under
+  `UTImportedTypeDeclarations` (council)
+
+---
+
+## 6. Acceptance (this spec is in force when)
+
+- Session 00 checklist is done on `main`
+- `html` exists and is protected from version-bump by simply
+  not being `main`
+- README / Session 01 / HTML spec say: **base `html`, flag on
+  for dogfood, production stays off until go/no-go**
+- A reviewer can exercise HTML without installing a Release
+  DMG (`dev:html` / `preview:html` / `desktop:html` / CI
+  artifact)

--- a/docs/project-html/2026-08-25-tasks-session-00-staging-rail.md
+++ b/docs/project-html/2026-08-25-tasks-session-00-staging-rail.md
@@ -1,0 +1,133 @@
+# Session 00 — Staging rail (before any HTML runtime)
+
+**Date:** 2026-08-25
+**Status:** Ready to implement — **first code PR**, targets **`main`**
+**Spec:** [spec-html-staging](2026-08-25-spec-html-staging.md)
+**HTML runtime spec:** [spec-html-v1](2026-08-23-spec-html-v1.md)
+  (do not implement that file in this session)
+
+## Goal
+
+Give HTML work a place to live that is **not a SpecDown
+release**: compile-time flag (default off), scripts to dogfood
+an HTML-on build, CI that keeps the markdown product honest,
+artifact for reviewers. **No** `.html` open gates, **no** iframe,
+**no** `frame-src`, **no** landing copy, **no** `html` feature
+modules.
+
+After this PR is on `main`, create the `html` integration
+branch from that tip and push it. Sessions 01+ are PRs into
+`html`.
+
+## Preconditions
+
+- Read the [staging spec](2026-08-25-spec-html-staging.md) in
+  full.
+- Unique identifiers (`htmlDocumentsEnabled`,
+  `htmlDocumentsEnabledFlag`, …) — eval harness collisions.
+- Do not add `#document-stage` or `#html-frame`.
+- Do not change `VALID_EXTENSIONS`, `accept=`, desktop filters,
+  iOS UTIs, or parent CSP in this session.
+- Do not set `VITE_HTML_DOCUMENTS` in `static.yml` or
+  `desktop.yml`.
+
+## Tasks
+
+### 1. Flag helper (renderer + desktop main)
+
+- [ ] `markdown-viewer/src/core/html-flag.js` (`// @ts-check`):
+      `htmlDocumentsEnabled()` is true only when the Vite HTML
+      mode (or `define`) compiled it on. Default false.
+      Eval-harness safe (boolean literal / `process.env`, not
+      a lone `import.meta.env` that throws under `loadApp`).
+- [ ] `desktop/main.js` reads `process.env.VITE_HTML_DOCUMENTS
+      === 'true'` (same name). Session 01 will AND this with
+      `isOpenableDocument`; this session only exposes the
+      helper or inlines the check behind a named function
+      `htmlDocumentsEnabledMain` so tests can stub it.
+- [ ] `.env.html` with `VITE_HTML_DOCUMENTS=true`.
+- [ ] Vite `define` or equivalent so HTML-on and HTML-off
+      builds cannot drift from a forgotten env var in one
+      process only. Document in a short comment on the helper.
+
+### 2. npm scripts
+
+- [ ] `dev:html` → `vite --mode html`
+- [ ] `build:html` → `vite build --mode html && node scripts/copy-static.js`
+- [ ] `preview:html` → `build:html` then `vite preview --mode html`
+      (keep port 4179)
+- [ ] `desktop:html` → `build:html` then
+      `VITE_HTML_DOCUMENTS=true electron .`
+      (renderer and main both on)
+- [ ] Default `dev` / `build` / `desktop` remain flag **off**
+
+### 3. Tests (flag off is the product)
+
+- [ ] `tests/unit/html-flag.test.js` — off by default; on when
+      the test stubs the compiled flag.
+- [ ] Flag **off** golden path (must stay on `main` CI):
+      file-loading still rejects `.html` / `.htm`;
+      `desktop-main.test.js` still rejects `.html`;
+      static grep: `index.html` `accept` has no `html`;
+      static grep: CSP has no `frame-src`;
+      document body fixture / `index.html` has no
+      `html-frame` / `document-stage`.
+- [ ] Do not invert the `.html` rejection tests in this PR.
+
+### 4. CI
+
+- [ ] `.github/workflows/ci.yml` — also run on push to `html`.
+- [ ] New workflow `.github/workflows/html-staging.yml`:
+      on push/PR to `html` (and `workflow_dispatch`);
+      `npm ci`; lint; typecheck; `test:ci` (flag off);
+      `npm run build:html`; upload artifact
+      `html-staging-web` from `markdown-viewer/dist`.
+      **Do not** call `desktop.yml`, version-bump, or
+      production Pages.
+- [ ] Optional: add `html` to `ios.yml` `push.branches` so
+      simulator CI runs on the integration branch.
+- [ ] Confirm `static.yml` / `version-bump.yml` /
+      `desktop.yml` still only ship from `main` / tags /
+      dispatch on `main`.
+
+### 5. Docs in the same PR
+
+- [ ] AGENTS.md or `package.json` description is **not**
+      required. A 10-line note at the top of
+      [project-html README](README.md) “how to dogfood” is
+      enough if the scripts exist.
+- [ ] Do not rewrite landing or Press B.
+
+## Manual smoke
+
+1. `npm run build` then `npm run preview` — drop a `.md`,
+   Mermaid still works; drop `.html` still rejected; landing
+   unchanged.
+2. `npm run build:html` — `htmlDocumentsEnabled()` is true in
+   the bundle (grep `dist` or a tiny console check). Still no
+   open-gate change, so dropping `.html` is still rejected
+   until Session 01. That is correct.
+3. `npm run desktop` (if a display): unchanged markdown app.
+4. Do **not** run `desktop:build` / notarize from this PR.
+
+## After merge to `main`
+
+```bash
+git fetch origin
+git checkout main
+git pull origin main
+git checkout -b html
+git push -u origin html
+```
+
+Protect `html` only as a normal branch (no version-bump). Do
+not open Session 01 against `main`.
+
+## Done when
+
+- Production-shaped build is byte-behavior identical for
+  users (gates, CSP source, DOM).
+- HTML-on *build* exists as a script + CI artifact pipeline,
+  ready for Session 01 to hang gates on.
+- `html` branch is pushed.
+- One commit, one PR, into **`main`**.

--- a/docs/project-html/README.md
+++ b/docs/project-html/README.md
@@ -1,0 +1,40 @@
+# Project: HTML Documents
+
+A first-class **HTML document kind** for SpecDown — a *forked* viewing
+runtime next to markdown, not HTML forced through `marked`.
+
+AI coding tools emit standalone `.html` as often as `.md` now: reports,
+dashboards, slide decks, architecture explainers, prototypes. SpecDown
+already wins at *reading* markdown specs. This project makes the same
+reader honest about the other artifact agents actually write.
+
+**Architectural rule:** fork the document runtime at the render boundary.
+Do not convert HTML to markdown. Do not inject untrusted HTML into the
+app origin. Markdown stays the compiler pipeline; HTML is already compiled.
+
+## Timeline
+
+| Date       | Doc                                                                                          | Summary                                                                                                                                                                 |
+| ---------- | -------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-08-23 | [brainstorm-html-documents](2026-08-23-brainstorm-html-documents.md)                         | Three-lens plan (PM / UX / distinguished engineer): why now, what we refuse to become, the runtime fork, security model, feature set, phased roadmap                    |
+| 2026-08-23 | [spec-html-v1](2026-08-23-spec-html-v1.md)                                                   | Technical specification for the document-kind model, sandboxed iframe host, open-path gates, feature compatibility, and the Phase 0–1 implementation surface            |
+| 2026-08-23 | [tasks-session-01-kind-and-open](2026-08-23-tasks-session-01-kind-and-open.md)                | First implementation session: `kind` on tabs, accept `.html`/`.htm` at every open gate, sandboxed faithful preview, raw source, sample, tests                           |
+
+## Current Status
+
+**Planning complete; implementation not started.** Session 01 is scoped
+and ready to pick up from
+[tasks-session-01-kind-and-open](2026-08-23-tasks-session-01-kind-and-open.md).
+
+The north-star one-liner this project is aiming at:
+
+> SpecDown is the reader for AI-generated specs — markdown *and* HTML —
+> without becoming a browser and without weakening the markdown
+> renderer's security posture.
+
+## Naming Conventions
+
+Files follow the repo-wide pattern `YYYY-MM-DD-<type>-<detail>.md` with
+types `brainstorm`, `spec`, and `tasks` (see [docs/README.md](../README.md)).
+The next implementation session should add
+`2026-XX-XX-tasks-session-02-<slice>.md` and update the timeline above.

--- a/docs/project-html/README.md
+++ b/docs/project-html/README.md
@@ -20,6 +20,7 @@ app origin. Markdown stays the compiler pipeline; HTML is already compiled.
 | 2026-08-23 | [spec-html-v1](2026-08-23-spec-html-v1.md)                                                   | Technical specification for the document-kind model, sandboxed iframe host, open-path gates, feature compatibility, and the Phase 0–1 implementation surface            |
 | 2026-08-23 | [tasks-session-01-kind-and-open](2026-08-23-tasks-session-01-kind-and-open.md)                | First implementation session: `kind` on tabs, accept `.html`/`.htm` at every open gate, sandboxed faithful preview, raw source, sample, tests                           |
 | 2026-08-23 | [council-html-plan-review](2026-08-23-council-html-plan-review.md)                           | Four-seat council. Fork holds; blob/srcdoc preview **rejected** (CSP inheritance). Host page + untrusted postMessage. Session 01 is a skeleton, not a launch. |
+| 2026-08-23 | [brainstorm-names-and-press](2026-08-23-brainstorm-names-and-press.md)                     | Naming/tagline council: keep SpecDown; HTML-era lede; press release A (today) and embargoed B (after Live + print) |
 
 ## Current Status
 

--- a/docs/project-html/README.md
+++ b/docs/project-html/README.md
@@ -19,7 +19,7 @@ app origin. Markdown stays the compiler pipeline; HTML is already compiled.
 | 2026-08-23 | [brainstorm-html-documents](2026-08-23-brainstorm-html-documents.md)                         | Three-lens plan (PM / UX / distinguished engineer): why now, what we refuse to become, the runtime fork, security model, feature set, phased roadmap                    |
 | 2026-08-23 | [spec-html-v1](2026-08-23-spec-html-v1.md)                                                   | Technical specification for the document-kind model, sandboxed iframe host, open-path gates, feature compatibility, and the Phase 0–1 implementation surface            |
 | 2026-08-23 | [tasks-session-01-kind-and-open](2026-08-23-tasks-session-01-kind-and-open.md)                | First implementation session: `kind` on tabs, accept `.html`/`.htm` at every open gate, sandboxed faithful preview, raw source, sample, tests                           |
-| 2026-08-23 | [council-html-plan-review](2026-08-23-council-html-plan-review.md)                           | Adversarial council. Thesis holds; Session 01 amended (CSP, honest chrome, no launch), then platform gates (live-reload DI, print CSS, 8 MB at read, iOS UTI) |
+| 2026-08-23 | [council-html-plan-review](2026-08-23-council-html-plan-review.md)                           | Four-seat council. Fork holds; blob/srcdoc preview **rejected** (CSP inheritance). Host page + untrusted postMessage. Session 01 is a skeleton, not a launch. |
 
 ## Current Status
 

--- a/docs/project-html/README.md
+++ b/docs/project-html/README.md
@@ -18,19 +18,31 @@ app origin. Markdown stays the compiler pipeline; HTML is already compiled.
 | ---------- | -------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 2026-08-23 | [brainstorm-html-documents](2026-08-23-brainstorm-html-documents.md)                         | Three-lens plan (PM / UX / distinguished engineer): why now, what we refuse to become, the runtime fork, security model, feature set, phased roadmap                    |
 | 2026-08-23 | [spec-html-v1](2026-08-23-spec-html-v1.md)                                                   | Technical specification for the document-kind model, sandboxed iframe host, open-path gates, feature compatibility, and the Phase 0–1 implementation surface            |
-| 2026-08-23 | [tasks-session-01-kind-and-open](2026-08-23-tasks-session-01-kind-and-open.md)                | First implementation session: `kind` on tabs, accept `.html`/`.htm` at every open gate, sandboxed faithful preview, raw source, sample, tests                           |
+| 2026-08-23 | [tasks-session-01-kind-and-open](2026-08-23-tasks-session-01-kind-and-open.md)                | First HTML *runtime* session: `kind`, open gates, sandboxed preview. **Base branch `html`, not `main`.** |
 | 2026-08-23 | [council-html-plan-review](2026-08-23-council-html-plan-review.md)                           | Four-seat council. Fork holds; blob/srcdoc preview **rejected** (CSP inheritance). Host page + untrusted postMessage. Session 01 is a skeleton, not a launch. |
 | 2026-08-23 | [brainstorm-names-and-press](2026-08-23-brainstorm-names-and-press.md)                     | Naming/tagline council: keep SpecDown; HTML-era lede; press A / embargoed B. **Names under research:** Specular, Lantern. **Lines to keep:** *Present the diagram…* / *Specs you can stand in front of.* **Subtitles ok:** *Diagrams you can present* / *The spec reader.* |
+| 2026-08-25 | [spec-html-staging](2026-08-25-spec-html-staging.md)                                         | Staging rail: `html` integration branch, compile-time flag, no merge to `main` until Session 02 go/no-go. Production merge = release. |
+| 2026-08-25 | [tasks-session-00-staging-rail](2026-08-25-tasks-session-00-staging-rail.md)                | **First code PR (into `main`):** flag default off, `*:html` scripts, CI artifact. No HTML gates. |
 
 ## Current Status
 
-**Planning complete and council-amended; implementation not started.**
-The fork thesis survived review. Session 01 is ready only from the
-**amended** spec + checklist — the first draft would have shipped a
-blank iframe (parent CSP), a lying Print button, and markdown-only
-folders. Start at
-[tasks-session-01-kind-and-open](2026-08-23-tasks-session-01-kind-and-open.md)
-after reading the [council](2026-08-23-council-html-plan-review.md).
+**Planning complete (council-amended + staging rail). HTML runtime
+not started.** Merge-to-`main` is a GitHub Release + Pages deploy —
+Session 01 must not go there first.
+
+**Next code:** [Session 00](2026-08-25-tasks-session-00-staging-rail.md)
+onto `main`, then create branch `html`. Then
+[Session 01](2026-08-23-tasks-session-01-kind-and-open.md) onto `html`
+from the [amended spec](2026-08-23-spec-html-v1.md) and
+[council](2026-08-23-council-html-plan-review.md).
+
+### How to dogfood (after Session 00)
+
+Production-shaped (what users get): `npm run dev` / `build` / `desktop`.
+HTML-on staging: `npm run dev:html` / `preview:html` / `desktop:html`.
+Do not publish a staging desktop build to the production Release or
+`latest*.yml`. Do not put a staging app under `/specdown/html-staging/`
+(PWA service worker scope).
 
 The north-star one-liner this project is aiming at:
 
@@ -42,5 +54,6 @@ The north-star one-liner this project is aiming at:
 
 Files follow the repo-wide pattern `YYYY-MM-DD-<type>-<detail>.md` with
 types `brainstorm`, `spec`, and `tasks` (see [docs/README.md](../README.md)).
-The next implementation session should add
-`2026-XX-XX-tasks-session-02-<slice>.md` and update the timeline above.
+Session 00 is the first code PR (into `main`). Session 02+ should add
+`2026-XX-XX-tasks-session-0N-<slice>.md` (PRs into `html`) and
+update the timeline above.

--- a/docs/project-html/README.md
+++ b/docs/project-html/README.md
@@ -19,12 +19,17 @@ app origin. Markdown stays the compiler pipeline; HTML is already compiled.
 | 2026-08-23 | [brainstorm-html-documents](2026-08-23-brainstorm-html-documents.md)                         | Three-lens plan (PM / UX / distinguished engineer): why now, what we refuse to become, the runtime fork, security model, feature set, phased roadmap                    |
 | 2026-08-23 | [spec-html-v1](2026-08-23-spec-html-v1.md)                                                   | Technical specification for the document-kind model, sandboxed iframe host, open-path gates, feature compatibility, and the Phase 0–1 implementation surface            |
 | 2026-08-23 | [tasks-session-01-kind-and-open](2026-08-23-tasks-session-01-kind-and-open.md)                | First implementation session: `kind` on tabs, accept `.html`/`.htm` at every open gate, sandboxed faithful preview, raw source, sample, tests                           |
+| 2026-08-23 | [council-html-plan-review](2026-08-23-council-html-plan-review.md)                           | Adversarial council (security / product / UX / platform). Thesis holds; Session 01 amended (CSP `frame-src`, print XSS, navigation lock, honest chrome, workspace listing) |
 
 ## Current Status
 
-**Planning complete; implementation not started.** Session 01 is scoped
-and ready to pick up from
-[tasks-session-01-kind-and-open](2026-08-23-tasks-session-01-kind-and-open.md).
+**Planning complete and council-amended; implementation not started.**
+The fork thesis survived review. Session 01 is ready only from the
+**amended** spec + checklist — the first draft would have shipped a
+blank iframe (parent CSP), a lying Print button, and markdown-only
+folders. Start at
+[tasks-session-01-kind-and-open](2026-08-23-tasks-session-01-kind-and-open.md)
+after reading the [council](2026-08-23-council-html-plan-review.md).
 
 The north-star one-liner this project is aiming at:
 

--- a/docs/project-html/README.md
+++ b/docs/project-html/README.md
@@ -20,7 +20,7 @@ app origin. Markdown stays the compiler pipeline; HTML is already compiled.
 | 2026-08-23 | [spec-html-v1](2026-08-23-spec-html-v1.md)                                                   | Technical specification for the document-kind model, sandboxed iframe host, open-path gates, feature compatibility, and the Phase 0–1 implementation surface            |
 | 2026-08-23 | [tasks-session-01-kind-and-open](2026-08-23-tasks-session-01-kind-and-open.md)                | First implementation session: `kind` on tabs, accept `.html`/`.htm` at every open gate, sandboxed faithful preview, raw source, sample, tests                           |
 | 2026-08-23 | [council-html-plan-review](2026-08-23-council-html-plan-review.md)                           | Four-seat council. Fork holds; blob/srcdoc preview **rejected** (CSP inheritance). Host page + untrusted postMessage. Session 01 is a skeleton, not a launch. |
-| 2026-08-23 | [brainstorm-names-and-press](2026-08-23-brainstorm-names-and-press.md)                     | Naming/tagline council: keep SpecDown; HTML-era lede; press release A (today) and embargoed B (after Live + print) |
+| 2026-08-23 | [brainstorm-names-and-press](2026-08-23-brainstorm-names-and-press.md)                     | Naming/tagline council: keep SpecDown; HTML-era lede; press A / embargoed B. **Names under research:** Specular, Lantern. **Lines to keep:** *Present the diagram…* / *Specs you can stand in front of.* **Subtitles ok:** *Diagrams you can present* / *The spec reader.* |
 
 ## Current Status
 

--- a/docs/project-html/README.md
+++ b/docs/project-html/README.md
@@ -19,7 +19,7 @@ app origin. Markdown stays the compiler pipeline; HTML is already compiled.
 | 2026-08-23 | [brainstorm-html-documents](2026-08-23-brainstorm-html-documents.md)                         | Three-lens plan (PM / UX / distinguished engineer): why now, what we refuse to become, the runtime fork, security model, feature set, phased roadmap                    |
 | 2026-08-23 | [spec-html-v1](2026-08-23-spec-html-v1.md)                                                   | Technical specification for the document-kind model, sandboxed iframe host, open-path gates, feature compatibility, and the Phase 0–1 implementation surface            |
 | 2026-08-23 | [tasks-session-01-kind-and-open](2026-08-23-tasks-session-01-kind-and-open.md)                | First implementation session: `kind` on tabs, accept `.html`/`.htm` at every open gate, sandboxed faithful preview, raw source, sample, tests                           |
-| 2026-08-23 | [council-html-plan-review](2026-08-23-council-html-plan-review.md)                           | Adversarial council (security / product / UX / platform). Thesis holds; Session 01 amended (CSP `frame-src`, print XSS, navigation lock, honest chrome, workspace listing) |
+| 2026-08-23 | [council-html-plan-review](2026-08-23-council-html-plan-review.md)                           | Adversarial council. Thesis holds; Session 01 amended, then tightened again (no OS/PWA HTML handler, no landing launch, extension-only URLs, chrome honesty) |
 
 ## Current Status
 

--- a/docs/project-html/README.md
+++ b/docs/project-html/README.md
@@ -19,7 +19,7 @@ app origin. Markdown stays the compiler pipeline; HTML is already compiled.
 | 2026-08-23 | [brainstorm-html-documents](2026-08-23-brainstorm-html-documents.md)                         | Three-lens plan (PM / UX / distinguished engineer): why now, what we refuse to become, the runtime fork, security model, feature set, phased roadmap                    |
 | 2026-08-23 | [spec-html-v1](2026-08-23-spec-html-v1.md)                                                   | Technical specification for the document-kind model, sandboxed iframe host, open-path gates, feature compatibility, and the Phase 0–1 implementation surface            |
 | 2026-08-23 | [tasks-session-01-kind-and-open](2026-08-23-tasks-session-01-kind-and-open.md)                | First implementation session: `kind` on tabs, accept `.html`/`.htm` at every open gate, sandboxed faithful preview, raw source, sample, tests                           |
-| 2026-08-23 | [council-html-plan-review](2026-08-23-council-html-plan-review.md)                           | Adversarial council. Thesis holds; Session 01 amended, then tightened again (no OS/PWA HTML handler, no landing launch, extension-only URLs, chrome honesty) |
+| 2026-08-23 | [council-html-plan-review](2026-08-23-council-html-plan-review.md)                           | Adversarial council. Thesis holds; Session 01 amended (CSP, honest chrome, no launch), then platform gates (live-reload DI, print CSS, 8 MB at read, iOS UTI) |
 
 ## Current Status
 

--- a/docs/project-sharing/2026-08-20-spec-feature-copy.md
+++ b/docs/project-sharing/2026-08-20-spec-feature-copy.md
@@ -16,6 +16,14 @@ how-I-built-it outlines.
 first-class — zoom, pan, present, and export — so architecture docs stop being
 tiny static images.
 
+**Also interesting (not swapping the one-liner):** *Present the diagram, not a
+screenshot* is already the landing title — keep it. *Specs you can stand in
+front of* is a format-agnostic second breath (Present as a room). Wordmark
+subtitles that are ok: *SpecDown — Diagrams you can present* and
+*SpecDown — The spec reader*. HTML-era lede, when the wedge ships: *The reader
+for specs — markdown, diagrams, and the HTML your agent just wrote.* Full kit:
+[names and press](../project-html/2026-08-23-brainstorm-names-and-press.md).
+
 **Contrast:** Typora and Obsidian edit. GitHub preview is static. SpecDown is
 the reading and presenting layer.
 

--- a/docs/project-sharing/README.md
+++ b/docs/project-sharing/README.md
@@ -16,6 +16,7 @@ drop-zone.
 | 2026-08-20 | [tasks-session-01-sharing-kit](2026-08-20-tasks-session-01-sharing-kit.md)           | Implement showcase + copy kit + OG card + tests                                                                          |
 | 2026-08-22 | [tasks-session-02-starfield-toggle](2026-08-22-tasks-session-02-starfield-toggle.md) | Named Theme catalog (Default, Starfield) on every surface; scalable for future looks                                     |
 | 2026-08-22 | [tasks-session-03-aurora-blueprint](2026-08-22-tasks-session-03-aurora-blueprint.md) | Two more empty-state Themes: Aurora (curtains) and Blueprint (spec grid)                                                 |
+| 2026-08-23 | [HTML names and press](../project-html/2026-08-23-brainstorm-names-and-press.md)     | Naming council, taglines, press A (today) and embargoed B (HTML)                                                         |
 
 ## Current status
 
@@ -25,6 +26,9 @@ on by default for the web homepage; Default on desktop/iOS until opted in).
 Add a future look by appending to `visualThemeCatalog` plus a CSS block. The
 web app is unchanged as a **viewer** — drop, browse, URL, GitHub repo, folder
 (Chromium), and session restore still open documents the same way.
+
+Names and press drafts for the HTML era live with that project:
+[`../project-html/2026-08-23-brainstorm-names-and-press.md`](../project-html/2026-08-23-brainstorm-names-and-press.md).
 
 ## Naming conventions
 

--- a/docs/project-sharing/README.md
+++ b/docs/project-sharing/README.md
@@ -16,7 +16,7 @@ drop-zone.
 | 2026-08-20 | [tasks-session-01-sharing-kit](2026-08-20-tasks-session-01-sharing-kit.md)           | Implement showcase + copy kit + OG card + tests                                                                          |
 | 2026-08-22 | [tasks-session-02-starfield-toggle](2026-08-22-tasks-session-02-starfield-toggle.md) | Named Theme catalog (Default, Starfield) on every surface; scalable for future looks                                     |
 | 2026-08-22 | [tasks-session-03-aurora-blueprint](2026-08-22-tasks-session-03-aurora-blueprint.md) | Two more empty-state Themes: Aurora (curtains) and Blueprint (spec grid)                                                 |
-| 2026-08-23 | [HTML names and press](../project-html/2026-08-23-brainstorm-names-and-press.md)     | Naming council, taglines, press A (today) and embargoed B (HTML)                                                         |
+| 2026-08-23 | [HTML names and press](../project-html/2026-08-23-brainstorm-names-and-press.md)     | Naming council, taglines, press A / embargoed B. Keepers: Specular, Lantern; *Present the diagram…* / *Specs you can stand in front of.*; subtitles *Diagrams you can present* / *The spec reader*. |
 
 ## Current status
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Planning-only PR. No product code.

HTML as a **forked document kind**, council-amended (security host page, no Session 01 launch).

## Staging (new)

Merge-to-`main` is a **release** (version bump, DMG / `latest*.yml`, GitHub Pages). HTML runtime must not go there first.

- **Session 00** (first code, into `main`): compile-time flag default **off**, `dev:html` / `preview:html` / `desktop:html`, CI artifact. No open gates.
- **Sessions 01–04**: PRs into integration branch **`html`**, not `main`.
- **Go/no-go:** Session 02 desktop staging demo (local HTML + Live + print). Only then `html` → `main`.
- Flag keeps `.html` rejected on production-shaped builds; it does **not** isolate `#document-stage` layout — that is why git isolation exists.
- Do not put staging under `/specdown/html-staging/` (PWA service worker scope). Do not publish a staging DMG to the production update feed.

Contract: `docs/project-html/2026-08-25-spec-html-staging.md`. First code checklist: Session 00.

## Names

**Ship as SpecDown.** Under research (not adopted): Specular, Lantern.

## Taglines (kit only; landing unchanged)

- Present the diagram, not a screenshot
- Specs you can stand in front of
- SpecDown — Diagrams you can present
- SpecDown — The spec reader
- HTML-era (after Live + print on production): *The reader for specs — markdown, diagrams, and the HTML your agent just wrote.*

## Press

- **A** — existing product; can go out today.
- **B** — embargoed until local open + Live + print on **production**.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02d7c-1a7f-735a-b546-7d0eb53713d1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02d7c-1a7f-735a-b546-7d0eb53713d1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

